### PR TITLE
build: allow jumping to source in different packages

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,6 +5,7 @@
         "module": "commonjs",
         "lib": [],
         "declaration": true,
+        "declarationMap": true,
         "strict": true,
         "noImplicitAny": true,
         "strictNullChecks": true,


### PR DESCRIPTION
### Change Description:

Fixes a bug where you could not ctrl + click class names and end up a the class source in vscode.

