### PR TITLE
build: since we are looking up a vpc deploy:synth needs access keys

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -28,6 +28,10 @@ jobs:
 
       - name: Deploy - Create Template
         run: npx lerna run deploy:synth --stream
+        env:
+          CDK_DEFAULT_ACCOUNT: ${{secrets.CDK_DEFAULT_ACCOUNT}}
+          AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
+          AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
 
       - name: Deploy - Show Diff
         run: npx lerna run deploy:diff --stream


### PR DESCRIPTION
Master deployment pipeline is broken, because it is missing access keys to do a `deploy:synth`


### Notes for Testing:
Master build pipeline should now work

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
