### PR TITLE
build: aws cdk cannot ask for deploy approval as there is no tty

### DIFF
--- a/packages/_infra/package.json
+++ b/packages/_infra/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "deploy:synth": "cdk synth",
     "deploy:diff": "cdk diff || true",
-    "deploy:deploy": "cdk deploy '*' -y"
+    "deploy:deploy": "cdk deploy '*' -y --require-approval never"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
aws cdk cannot ask for deploy approval as there is no tty

### Notes for Testing:

Master branch should be able to deploy

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
