### PR TITLE
fix: log errors into err so pino will serialize them

### DIFF
--- a/packages/shared/src/lambda.ts
+++ b/packages/shared/src/lambda.ts
@@ -53,7 +53,7 @@ export class LambdaFunction {
                 }
             } catch (error) {
                 session.set('status', 500);
-                session.set('error', error);
+                session.set('err', error);
                 err = error;
             }
 


### PR DESCRIPTION
### Change Description:

Pino only serializes errors if they are labeled "err"

### Notes for Testing:

#### Source Code Documentation Tasks:
- [x] README updated (where applicable)
- [x] CHANGELOG (Unreleased section) updated
- [x] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [x] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [x] Added tests that fail without this change
- [x] All tests are passing in development environment
- [x] Reviewers assigned
- [x] Linked to main issue for ZenHub board
