### PR TITLE
feat: adding basic benchmark to track tile render performance

### DIFF
--- a/packages/shared/src/metrics.ts
+++ b/packages/shared/src/metrics.ts
@@ -5,11 +5,15 @@ export class Metrics {
     /**
      * Start time of all timers
      */
-    private timers: Record<string, number> = {};
+    private timers: Record<string, bigint> = {};
     /**
      * List of time recordings
      */
-    private time: Record<string, number> = {};
+    private time: Record<string, bigint> = {};
+
+    private getTime(): bigint {
+        return process.hrtime.bigint();
+    }
 
     /**
      * Start a timer at the current time
@@ -19,23 +23,23 @@ export class Metrics {
         if (this.timers[timeName] != null) {
             throw new Error(`Duplicate startTime for "${timeName}"`);
         }
-        this.timers[timeName] = Date.now();
+        this.timers[timeName] = this.getTime();
     }
 
     /**
      * End the timer, returning the duration in milliseconds
      * @param timeName timer to end
      */
-    public end(timeName: string): number {
+    public end(timeName: string): bigint {
         if (this.timers[timeName] == null) {
             throw new Error(`Missing startTime information for "${timeName}"`);
         }
-        const duration = Date.now() - this.timers[timeName];
+        const duration = this.getTime() - this.timers[timeName];
         this.time[timeName] = duration;
         return duration;
     }
 
-    public get metrics(): Record<string, number> | undefined {
+    public get metrics(): Record<string, bigint> | undefined {
         const endTimes = Object.keys(this.time);
         // No metrics were started
         if (endTimes.length === 0) {

--- a/packages/tiler/src/__test__/tile.benchmark.test.ts
+++ b/packages/tiler/src/__test__/tile.benchmark.test.ts
@@ -1,0 +1,89 @@
+import { LambdaSession, Logger } from '@basemaps/shared';
+import { CogTiff } from '@cogeotiff/core';
+import { CogSourceFile } from '@cogeotiff/source-file';
+import { writeFileSync } from 'fs';
+import * as path from 'path';
+import { Tiler } from '../tiler';
+
+describe('TileCreationBenchmark', () => {
+    const NanoSecondToMillisecond = 1e6;
+    const RenderCount = 5;
+    const TimeoutSeconds = 30 * 1000;
+    const Zoom = 19;
+
+    const Center = 2 ** Zoom;
+    const CenterTile = Center / 2;
+
+    const TiffPath = path.join(__dirname, '../../data/rgba8_tiled.wm.tiff');
+
+    async function renderTile(tileSize: number): Promise<void> {
+        const { timer } = LambdaSession.get();
+        const tiler = new Tiler(tileSize);
+
+        timer.start('tiff:init');
+        const tiff = new CogTiff(new CogSourceFile(TiffPath));
+        await tiff.init();
+        timer.end('tiff:init');
+
+        timer.start('tiler:tile');
+        const layers = await tiler.tile([tiff], CenterTile, CenterTile, Zoom, Logger);
+        timer.end('tiler:tile');
+
+        if (layers == null) throw new Error('Tile is null');
+        await tiler.raster.compose(
+            layers,
+            Logger,
+        );
+    }
+    const results: Record<string, Record<string, bigint[]>> = {};
+
+    [256, 512].forEach(tileSize => {
+        it(`should render ${RenderCount}x${tileSize} tiles`, async () => {
+            jest.setTimeout(TimeoutSeconds);
+
+            const metrics: Record<string, bigint[]> = {};
+
+            for (let i = 0; i < RenderCount; i++) {
+                const { timer } = LambdaSession.reset();
+
+                timer.start('total');
+                await renderTile(tileSize);
+                timer.end('total');
+
+                const m = timer.metrics;
+                if (m == null) {
+                    throw new Error('Missing metric');
+                }
+                for (const key of Object.keys(m)) {
+                    const arr = (metrics[key] = metrics[key] || []);
+                    arr.push(m[key]);
+                }
+            }
+
+            results[`${tileSize}x${tileSize}`] = metrics;
+        });
+    });
+
+    /** Compute the average for the result */
+    function computeStats(records: Record<string, bigint[]>): Record<string, number> {
+        const output: Record<string, number> = {};
+        for (const key of Object.keys(records)) {
+            const values = records[key];
+            let total = 0;
+            for (const val of values) {
+                total += Number(val) / NanoSecondToMillisecond;
+            }
+
+            output[key] = parseFloat((total / values.length).toFixed(3));
+        }
+        return output;
+    }
+
+    // TODO logging this out is not ideal, we should look into publishing the results of the benchmarks somewhere
+    afterAll(() => {
+        for (const key of Object.keys(results)) {
+            console.log(key, results[key], computeStats(results[key]));
+        }
+        writeFileSync('./benchmarks.json', JSON.stringify(results, null, 2));
+    });
+});


### PR DESCRIPTION
### Change Description:

Start tracking basic timings for how long it takes to open, parse and render a tile


#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
