### PR TITLE
fix: bigint logging does not work

### DIFF
--- a/packages/lambda-api-tracker/src/index.ts
+++ b/packages/lambda-api-tracker/src/index.ts
@@ -1,6 +1,5 @@
 import {
     Const,
-    Projection,
     getXyzFromPath,
     HttpHeader,
     LambdaFunction,
@@ -9,7 +8,8 @@ import {
     LambdaHttpResponseCloudFrontRequest,
     LambdaSession,
     LambdaType,
-    Logger,
+    Projection,
+    LogType,
 } from '@basemaps/shared';
 import { CloudFrontRequestEvent, Context } from 'aws-lambda';
 import { queryStringExtractor } from './query';
@@ -22,7 +22,7 @@ const projection = new Projection(256);
 export async function handleRequest(
     event: CloudFrontRequestEvent,
     context: Context,
-    logger: typeof Logger,
+    logger: LogType,
 ): Promise<LambdaHttpResponse> {
     const session = LambdaSession.get();
     const [record] = event.Records;

--- a/packages/lambda-api-tracker/src/validate.ts
+++ b/packages/lambda-api-tracker/src/validate.ts
@@ -1,11 +1,11 @@
-import { Aws, Logger, Const, LambdaHttpResponseCloudFront, HttpHeader, LambdaSession } from '@basemaps/shared';
+import { Aws, LogType, Const, LambdaHttpResponseCloudFront, HttpHeader, LambdaSession } from '@basemaps/shared';
 
 export const ValidateRequest = {
     /**
      * Validate that a API Key is valid
      * @param apiKey API key to validate
      */
-    async validate(apiKey: string, log: typeof Logger): Promise<LambdaHttpResponseCloudFront | void> {
+    async validate(apiKey: string, log: LogType): Promise<LambdaHttpResponseCloudFront | void> {
         const timer = LambdaSession.get().timer;
         // TODO increment the api counter
         timer.start('validate:db');

--- a/packages/lambda-xyz/src/index.ts
+++ b/packages/lambda-xyz/src/index.ts
@@ -1,5 +1,11 @@
-import { HttpHeader, LambdaFunction, LambdaHttpResponseAlb, LambdaSession, LambdaType, Logger } from '@basemaps/shared';
-import { Log } from '@cogeotiff/core';
+import {
+    HttpHeader,
+    LambdaFunction,
+    LambdaHttpResponseAlb,
+    LambdaSession,
+    LambdaType,
+    LogType,
+} from '@basemaps/shared';
 import { ALBEvent, Context } from 'aws-lambda';
 import { createHash } from 'crypto';
 import { route } from './router';
@@ -19,11 +25,11 @@ function getHeader(evt: ALBEvent, header: string): string | null {
 export async function handleRequest(
     event: ALBEvent,
     context: Context,
-    logger: typeof Logger,
+    logger: LogType,
 ): Promise<LambdaHttpResponseAlb> {
     const session = LambdaSession.get();
     const tiler = Tilers.tile256;
-    Log.set(logger);
+
     const httpMethod = event.httpMethod.toLowerCase();
 
     session.set('method', httpMethod);

--- a/packages/shared/src/__test__/lambda.test.ts
+++ b/packages/shared/src/__test__/lambda.test.ts
@@ -4,6 +4,8 @@ import { LambdaType } from '../lambda.response.http';
 import { ALBResult, CloudFrontResultResponse } from 'aws-lambda';
 import { HttpHeader } from '../header';
 import { LambdaHttpResponseAlb } from '../lambda.response.alb';
+import { LambdaSession } from '../session';
+import { LogSpy } from './log.spy';
 
 describe('LambdaFunction', () => {
     const DoneError = new Error('Done');
@@ -57,11 +59,23 @@ describe('LambdaFunction', () => {
 
     it('should callback on success', async () => {
         const albOk = new LambdaHttpResponseAlb(200, 'ok');
-        const testFunc = LambdaFunction.wrap(LambdaType.Alb, async () => albOk);
+
+        const testFunc = LambdaFunction.wrap(LambdaType.Alb, async () => {
+            const { timer } = LambdaSession.get();
+            timer.start('xxx');
+            timer.end('xxx');
+            return albOk;
+        });
 
         const cbSpy = jest.fn();
         await testFunc(null as any, null as any, cbSpy);
         expect(cbSpy).toBeCalledTimes(1);
         expect(cbSpy).toBeCalledWith(null, albOk.toResponse());
+
+        expect(LogSpy.mock.calls.length).toBeGreaterThan(1);
+        const lastCall = LogSpy.mock.calls[LogSpy.mock.calls.length - 1];
+        const json = JSON.parse(lastCall[0]);
+        expect(json.duration).toBeGreaterThan(0);
+        expect(json.metrics.xxx).toBeGreaterThan(0);
     });
 });

--- a/packages/shared/src/__test__/log.spy.ts
+++ b/packages/shared/src/__test__/log.spy.ts
@@ -1,0 +1,7 @@
+import { LogConfig } from '../log';
+
+export const LogSpy = jest.spyOn(LogConfig.getOutputStream(), 'write').mockImplementation();
+
+beforeEach(() => {
+    LogSpy.mockClear();
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -7,7 +7,7 @@ export { LambdaFunction } from './lambda';
 export { LambdaHttpResponseAlb } from './lambda.response.alb';
 export { LambdaHttpResponseCloudFront, LambdaHttpResponseCloudFrontRequest } from './lambda.response.cf';
 export { LambdaHttpResponse, LambdaType } from './lambda.response.http';
-export { Logger } from './log';
+export { LogConfig, LogType } from './log';
 export { getXyzFromPath, PathData } from './path';
 export { Projection } from './projection';
 export { LambdaSession } from './session';

--- a/packages/shared/src/log.ts
+++ b/packages/shared/src/log.ts
@@ -1,5 +1,41 @@
 import * as pino from 'pino';
+import { Writable } from 'stream';
 
-// Disable logging while jest is doing it's testing thing
-const isEnabled = process.env['JEST_WORKER_ID'] == null;
-export const Logger = pino({ level: 'debug', enabled: isEnabled });
+let currentLog: pino.Logger;
+
+/**
+ * Expose log type so functions that do not have direct access to pino have access to the log type
+ */
+export type LogType = pino.Logger;
+
+/**
+ * Encapsulate the logger so that it can be swapped out
+ */
+export const LogConfig = {
+    /**
+     * Getting access to the current log stream is hard,
+     *
+     * Pino uses Symbols for all its internal functions,
+     * getting access to them without knowing the logger is a pino logger is difficult
+     *
+     * **Used for testing**
+     * To allow overwriting of the .write() to get access to the output logs
+     */
+    getOutputStream(): Writable {
+        // There are no types for pino.symbols
+        const streamSym = (pino as any).symbols.streamSym;
+        // there is no type for pino['Symbol(stream)']
+        return LogConfig.get()[streamSym] as any;
+    },
+
+    /** Get the currently configured logger */
+    get: (): pino.Logger => {
+        if (currentLog == null) {
+            currentLog = pino({ level: 'debug' });
+        }
+        return currentLog;
+    },
+    set: (log: pino.Logger): void => {
+        currentLog = log;
+    },
+};

--- a/packages/shared/src/metrics.ts
+++ b/packages/shared/src/metrics.ts
@@ -30,23 +30,30 @@ export class Metrics {
      * End the timer, returning the duration in milliseconds
      * @param timeName timer to end
      */
-    public end(timeName: string): bigint {
+    public end(timeName: string): number {
         if (this.timers[timeName] == null) {
             throw new Error(`Missing startTime information for "${timeName}"`);
         }
         const duration = this.getTime() - this.timers[timeName];
         this.time[timeName] = duration;
-        return duration;
+        return Number(duration);
     }
 
-    public get metrics(): Record<string, bigint> | undefined {
+    /**
+     * Convert all the times to Number so that they can be used
+     */
+    public get metrics(): Record<string, number> | undefined {
         const endTimes = Object.keys(this.time);
         // No metrics were started
         if (endTimes.length === 0) {
             return undefined;
         }
+        const output: Record<string, number> = {};
+        for (const key of endTimes) {
+            output[key] = Number(this.time[key]);
+        }
 
-        return this.time;
+        return output;
     }
 
     /** Get a list of timers that never finished */

--- a/packages/tiler/src/__test__/tile.creation.test.ts
+++ b/packages/tiler/src/__test__/tile.creation.test.ts
@@ -1,4 +1,4 @@
-import { LambdaSession, Logger } from '@basemaps/shared';
+import { LambdaSession, LogConfig } from '@basemaps/shared';
 import { CogSourceFile } from '@cogeotiff/source-file';
 import { readFileSync, writeFileSync } from 'fs';
 import * as path from 'path';
@@ -27,12 +27,13 @@ describe('TileCreation', () => {
     beforeEach(async () => {
         await tiff.init();
         LambdaSession.reset();
+        jest.spyOn(LogConfig.getOutputStream(), 'write').mockImplementation();
     });
 
     it('should generate a tile', async () => {
         // Make a really large tile so this image will be visible at zoom zero
         const tiler = new Tiler(2 ** 20);
-        const layers = await tiler.tile([tiff], 0, 0, 0, Logger);
+        const layers = await tiler.tile([tiff], 0, 0, 0, LogConfig.get());
 
         expect(layers).not.toEqual(null);
         if (layers == null) throw new Error('Tile is null');
@@ -61,13 +62,13 @@ describe('TileCreation', () => {
 
             // Make the background black to easily spot flaws
             tiler.raster.background.alpha = 1;
-            const layers = await tiler.tile([tiff], centerTile, centerTile, zoom, Logger);
+            const layers = await tiler.tile([tiff], centerTile, centerTile, zoom, LogConfig.get());
             expect(layers).not.toEqual(null);
             if (layers == null) throw new Error('Tile is null');
 
             const png = await tiler.raster.compose(
                 layers,
-                Logger,
+                LogConfig.get(),
             );
             const newImage = PNG.sync.read(png);
             if (WRITE_IMAGES) {

--- a/packages/tiler/src/raster.ts
+++ b/packages/tiler/src/raster.ts
@@ -1,4 +1,4 @@
-import { Logger, LambdaSession, BoundingBox, Size } from '@basemaps/shared';
+import { LogType, LambdaSession, BoundingBox, Size } from '@basemaps/shared';
 import * as Sharp from 'sharp';
 
 export interface Composition {
@@ -30,7 +30,7 @@ export class Raster {
         this.tileSize = tileSize;
     }
 
-    public async compose(composition: Composition[], logger: typeof Logger): Promise<Buffer> {
+    public async compose(composition: Composition[], logger: LogType): Promise<Buffer> {
         const sharp = this.createImage();
 
         const timer = LambdaSession.get().timer;

--- a/packages/tiler/src/tiler.ts
+++ b/packages/tiler/src/tiler.ts
@@ -1,4 +1,4 @@
-import { LambdaSession, Logger } from '@basemaps/shared';
+import { LambdaSession, LogType } from '@basemaps/shared';
 import { Bounds } from '@basemaps/shared/build/bounds';
 import { Projection } from '@basemaps/shared/build/projection';
 import { CogTiff, CogTiffImage } from '@cogeotiff/core';
@@ -42,7 +42,7 @@ export class Tiler {
         x: number,
         y: number,
         zoom: number,
-        logger: typeof Logger,
+        logger: LogType,
     ): Promise<Composition[] | null> {
         let layers: Composition[] = [];
         const timer = LambdaSession.get().timer;
@@ -153,7 +153,7 @@ export class Tiler {
         return composition;
     }
 
-    protected getTiles(tiff: CogTiff, x: number, y: number, z: number, logger: typeof Logger): Composition[] | null {
+    protected getTiles(tiff: CogTiff, x: number, y: number, z: number, logger: LogType): Composition[] | null {
         const rasterBounds = this.getRasterTiffIntersection(tiff, x, y, z);
         if (rasterBounds == null) {
             return null;


### PR DESCRIPTION
`JSON.stringify(1n)` throws a exception

Restructure logging so that the stream can be overriden rather than disabled.
This allows the logger to continue working so it can be tested

### Change Description:

Modifies the logger so that during tests we no longer disable it.



#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
