### PR TITLE
feat: serve 1x1 pixel png instead of 404

### DIFF
--- a/packages/lambda-xyz/src/index.ts
+++ b/packages/lambda-xyz/src/index.ts
@@ -11,6 +11,7 @@ import { createHash } from 'crypto';
 import { route } from './router';
 import { TiffUtil } from './tiff';
 import { Tilers } from './tiler';
+import { EmptyPng } from './png';
 
 // To force a full cache invalidation change this number
 const RenderId = 1;
@@ -72,14 +73,14 @@ export async function handleRequest(
     );
     session.timer.end('tile:compose');
 
+    const response = new LambdaHttpResponseAlb(200, 'ok');
+    response.header(HttpHeader.ETag, cacheKey);
     if (buf == null) {
-        // TODO serve empty PNG?
-        return new LambdaHttpResponseAlb(404, 'Tile not found');
+        response.buffer(EmptyPng, 'image/png');
+        return response;
     }
 
-    const response = new LambdaHttpResponseAlb(200, 'ok');
     response.buffer(buf, 'image/png');
-    response.header(HttpHeader.ETag, cacheKey);
     return response;
 }
 

--- a/packages/lambda-xyz/src/png.ts
+++ b/packages/lambda-xyz/src/png.ts
@@ -1,0 +1,4 @@
+export const EmptyPng = Buffer.from(
+    `iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR4nGNgAAIAAAUAAXpeqz8=`,
+    'base64',
+);


### PR DESCRIPTION
### Change Description:

Serve up a 1x1 pixel png, instead of 404.

This allows better caching of the png.

### Notes for Testing:

...

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
