### PR TITLE
fix: headers need to be lower cased

### DIFF
--- a/packages/shared/src/lambda.response.alb.ts
+++ b/packages/shared/src/lambda.response.alb.ts
@@ -59,6 +59,6 @@ export class LambdaHttpResponseAlb extends LambdaHttpResponse {
         if (req.headers == null) {
             return null;
         }
-        return req.headers[header];
+        return req.headers[header.toLowerCase()];
     }
 }

--- a/packages/shared/src/lambda.response.cf.ts
+++ b/packages/shared/src/lambda.response.cf.ts
@@ -48,7 +48,7 @@ export class LambdaHttpResponseCloudFront extends LambdaHttpResponse {
             return null;
         }
 
-        const value = headers[key];
+        const value = headers[key.toLowerCase()];
         if (value == null || value.length == 0) {
             return null;
         }


### PR DESCRIPTION
### Change Description:

All headers are passed into these functions as lower case, need to lowercase them before using them.

### Notes for Testing:

...

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
