### PR TITLE
fix: 0 is not the root tile "" is

### DIFF
--- a/packages/shared/src/__test__/quad.key.test.ts
+++ b/packages/shared/src/__test__/quad.key.test.ts
@@ -2,12 +2,21 @@ import { QuadKey } from '../quad.key';
 
 describe('QuadKey', () => {
     it('should intersect big to small', () => {
+        expect(QuadKey.intersects('', '30003303')).toEqual(true);
+
         expect(QuadKey.intersects('3', '30')).toEqual(true);
         expect(QuadKey.intersects('3', '301')).toEqual(true);
         expect(QuadKey.intersects('3', '333')).toEqual(true);
         expect(QuadKey.intersects('33', '30')).toEqual(false);
         expect(QuadKey.intersects('33', '301')).toEqual(false);
         expect(QuadKey.intersects('33', '333')).toEqual(true);
+    });
+
+    it('should not intersect other cells', () => {
+        expect(QuadKey.intersects('0', '30003303')).toEqual(false);
+        expect(QuadKey.intersects('1', '30003303')).toEqual(false);
+        expect(QuadKey.intersects('2', '30003303')).toEqual(false);
+        expect(QuadKey.intersects('31', '30003303')).toEqual(false);
     });
 
     it('should intersect small to big', () => {

--- a/packages/shared/src/quad.key.ts
+++ b/packages/shared/src/quad.key.ts
@@ -6,10 +6,6 @@ export const QuadKey = {
      * @returns whether qkA intersects qkB
      */
     intersects(qkA: string, qkB: string): boolean {
-        // Everything intersects with the root tile
-        if (qkA == '0' || qkB == '0') {
-            return true;
-        }
         const shortestLength = Math.min(qkA.length, qkB.length);
         return qkA.substr(0, shortestLength) == qkB.substr(0, shortestLength);
     },


### PR DESCRIPTION

### Change Description:

Quadkey intersection was using the wrong root tile.
Root tile intersections of "" works without extra logic.


#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
