### PR TITLE
refactor: improve the logging of imagery set names while processing COGs

### DIFF
--- a/packages/cog/src/cli/actions/action.cog.ts
+++ b/packages/cog/src/cli/actions/action.cog.ts
@@ -70,7 +70,7 @@ export class ActionCogCreate extends CommandLineAction {
 
         const isCommit = this.commit?.value ?? false;
 
-        const logger = LogConfig.get().child({ id: processId, correlationId: job.id });
+        const logger = LogConfig.get().child({ id: processId, correlationId: job.id, imageryName: job.name });
         LogConfig.set(logger);
 
         const quadKey = this.getQuadKey(job, logger);
@@ -96,6 +96,8 @@ export class ActionCogCreate extends CommandLineAction {
             logger.info({ target: targetPath }, 'StoreTiff');
             if (isCommit) {
                 await outputFs.write(targetPath, createReadStream(tmpTiff), logger);
+            } else {
+                logger.warn('DryRun:Done');
             }
         } finally {
             // Cleanup!

--- a/packages/cog/src/cog.ts
+++ b/packages/cog/src/cog.ts
@@ -9,6 +9,9 @@ export interface CogJob {
     /** Unique processing Id */
     id: string;
 
+    /** Imagery set name */
+    name: string;
+
     source: {
         /** List of input files */
         files: string[];


### PR DESCRIPTION
Add the base folder name as the name of the imagery set, this is used in names and job definitions.