### PR TITLE
fix: new bathy imagery which improves the render quality

### DIFF
--- a/packages/lambda-xyz/src/tiff.ts
+++ b/packages/lambda-xyz/src/tiff.ts
@@ -83,7 +83,7 @@ export const TiffUtil = {
         }
 
         Tiffs = [
-            new MosaicCog(bucketName, '2019/world/bathy-gebco/2019-12-17/', ['0', '1', '2', '3']),
+            new MosaicCog(bucketName, '2019/world/bathy-gebco/01DYE4EGR92TNMV16AHXSR45JH/', ['0', '1', '2', '3']),
             new MosaicCog(bucketName, '2019/new-zealand/new_zealand_sentinel_2018-19_10m/2019-12-04/', ['31'], 0, 32),
             new MosaicCog(
                 bucketName,


### PR DESCRIPTION
Fixes a off by one error in the generation of bathy, this should remove the empty line on the anti meridian