### PR TITLE
fix: wait for the tiffs to load before trying to serve them

### DIFF
--- a/packages/lambda-xyz/src/index.ts
+++ b/packages/lambda-xyz/src/index.ts
@@ -47,7 +47,7 @@ async function initTiffs(qk: string, zoom: number, logger: LogType): Promise<Cog
     let failed = false;
     // Remove any tiffs that failed to load
     const promises = tiffs.map(c => {
-        LoadingQueue(async () => {
+        return LoadingQueue(async () => {
             try {
                 await c.init();
             } catch (error) {


### PR DESCRIPTION
Tiffs need to be initialized before trying to access them.