### PR TITLE
Bug/overzoom failure

### DIFF
--- a/packages/lambda-xyz/src/imagery/gebco.ts
+++ b/packages/lambda-xyz/src/imagery/gebco.ts
@@ -9,6 +9,7 @@ MosaicCog.create({
     priority: 10,
     year: 2019,
     resolution: 100 * 1000,
+    maxZoom: 15,
 
     quadKeys: ['0', '1', '2', '3'],
 });

--- a/packages/lambda-xyz/src/index.ts
+++ b/packages/lambda-xyz/src/index.ts
@@ -99,6 +99,7 @@ export async function handleRequest(
     if (layers == null) {
         return emptyPng(session, cacheKey);
     }
+
     session.set('layers', layers.length);
 
     // If the user has supplied a IfNoneMatch Header and it contains the full sha256 sum for our etag this tile has not been modified.
@@ -112,6 +113,7 @@ export async function handleRequest(
     session.timer.start('tile:compose');
     const res = await tileMaker.compose(layers);
     session.timer.end('tile:compose');
+    session.set('layersUsed', res.layers);
 
     if (res == null) {
         return emptyPng(session, cacheKey);

--- a/packages/tiler-sharp/src/__test__/tile.creation.test.ts
+++ b/packages/tiler-sharp/src/__test__/tile.creation.test.ts
@@ -1,3 +1,5 @@
+import 'source-map-support/register';
+
 import { CogTiff } from '@cogeotiff/core';
 import { CogSourceFile } from '@cogeotiff/source-file';
 import { readFileSync, writeFileSync } from 'fs';
@@ -76,9 +78,9 @@ o.spec('TileCreation', () => {
             const tiler = new Tiler(tileSize);
 
             const tileMaker = new TileMakerSharp(tileSize);
-
             // Make the background black to easily spot flaws
-            tileMaker.background.alpha = 1;
+            tileMaker.background = { r: 0, g: 0, b: 0, alpha: 1 };
+
             const layers = await tiler.tile([tiff], centerTile, centerTile, zoom);
             o(layers).notEquals(null);
             if (layers == null) throw new Error('Tile is null');

--- a/packages/tiler-sharp/src/index.ts
+++ b/packages/tiler-sharp/src/index.ts
@@ -19,31 +19,51 @@ export interface Composition {
     crop?: BoundingBox;
 }
 
+function notEmpty<T>(value: T | null | undefined): value is T {
+    return value != null;
+}
 export type SharpOverlay = { input: string | Buffer } & Sharp.OverlayOptions;
 
 const SharpScaleOptions = { fit: Sharp.fit.cover };
 
 export class TileMakerSharp implements TileMaker {
+    static readonly MaxImageSize = 256 * 2 ** 15;
     private tileSize: number;
-    /** The background of all tiles that are created */
-    public background = { r: 0, g: 0, b: 0, alpha: 0 };
+    /** The background of all tiles that are created, slightly light blue*/
+    public background = { r: 0xdc, g: 0xe9, b: 0xed, alpha: 1 };
 
     public constructor(tileSize: number) {
         this.tileSize = tileSize;
     }
 
-    public async compose(composition: Composition[]): Promise<{ buffer: Buffer; metrics: Metrics }> {
+    protected isTooLarge(composition: Composition): boolean {
+        if (composition.resize) {
+            if (composition.resize.width >= TileMakerSharp.MaxImageSize) {
+                return true;
+            }
+            if (composition.resize.height >= TileMakerSharp.MaxImageSize) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public async compose(composition: Composition[]): Promise<{ buffer: Buffer; metrics: Metrics; layers: number }> {
         const sharp = this.createImage();
         const metrics = new Metrics();
         // TODO to prevent too many of these running, it should ideally be inside of a two step promise queue
         // 1. Load all image bytes
         // 2. Create image overlays
         metrics.start('compose:overlay');
-        const todo: Promise<SharpOverlay>[] = [];
+        const todo: Promise<SharpOverlay | null>[] = [];
         for (const comp of composition) {
+            if (this.isTooLarge(comp)) {
+                continue;
+            }
             todo.push(this.composeTile(comp));
         }
-        const overlays = await Promise.all(todo);
+        const overlays = await Promise.all(todo).then(items => items.filter(notEmpty));
         metrics.end('compose:overlay');
 
         metrics.start('compose:compress');
@@ -54,12 +74,23 @@ export class TileMakerSharp implements TileMaker {
 
         metrics.end('compose:compress');
 
-        return { buffer, metrics };
+        return { buffer, metrics, layers: overlays.length };
     }
 
-    private async composeTile(composition: Composition): Promise<SharpOverlay> {
+    private async composeTile(composition: Composition): Promise<SharpOverlay | null> {
         const bytes = await composition.getBuffer();
         const sharp = Sharp(Buffer.from(bytes));
+
+        // The stats function takes too long to run, its faster to just compose all the tiles anyway.
+        // const stats = await sharp.stats();
+        // const [red, green, blue] = stats.channels;
+        // // If there is no color this tile is not really worth doing anything with
+        // if (red.max == 0 && green.max == 0 && blue.max == 0) {
+        //     // TODO this could be made to be much more smart in terms of excluding images from the rendering
+        //     // If there is no area which has alpha then we may not need to compose all the tiles
+        //     // so we could cut the rendering pipeline down
+        //     return null;
+        // }
 
         if (composition.extract) {
             sharp.extract({ top: 0, left: 0, width: composition.extract.width, height: composition.extract.height });


### PR DESCRIPTION
When overzooming the gebco bathmetry libvips would complain about the number of pixels used.

This limits the maximum amount we can overzoom which should stop libvips from throwing errors