### PR TITLE
refactor: when runnning in debug mode increase the verbosity of logging

### DIFF
--- a/packages/_infra/src/serve/lambda.xyz.ts
+++ b/packages/_infra/src/serve/lambda.xyz.ts
@@ -29,6 +29,7 @@ export class LambdaXyz extends cdk.Construct {
             handler: 'index.handler',
             code: lambda.Code.asset(CODE_PATH),
             environment: {
+                [Env.NodeEnv]: Env.get(Env.NodeEnv, 'dev'),
                 [Env.CogBucket]: cogBucket.bucketName,
                 [Env.Hash]: version.hash,
                 [Env.Version]: version.version,

--- a/packages/lambda-shared/src/const.ts
+++ b/packages/lambda-shared/src/const.ts
@@ -11,8 +11,12 @@ export const Const = {
 };
 
 export const Env = {
+    /** Environment in use "dev" | "production" */
+    NodeEnv: 'NODE_ENV',
+
     /** Current version number for basemaps */
     Version: 'BASEMAPS_VERSION',
+
     /** Current git commit hash */
     Hash: 'BASEMAPS_HASH',
 
@@ -56,5 +60,9 @@ export const Env = {
             return defaultNumber;
         }
         return output;
+    },
+
+    isProduction(): boolean {
+        return Env.get(Env.NodeEnv, 'dev') != 'dev';
     },
 };

--- a/packages/lambda-xyz/src/index.ts
+++ b/packages/lambda-xyz/src/index.ts
@@ -109,11 +109,17 @@ export async function handleRequest(
         return new LambdaHttpResponseAlb(304, 'Not modified');
     }
 
-    logger.info({ layers: layers.length }, 'Composing');
+    if (!Env.isProduction()) {
+        for (const layer of layers) {
+            logger.debug({ layerId: layer.id, layerSource: layer.source }, 'Compose');
+        }
+    }
+
     session.timer.start('tile:compose');
     const res = await tileMaker.compose(layers);
     session.timer.end('tile:compose');
     session.set('layersUsed', res.layers);
+    session.set('allLayersUsed', res.layers == layers.length);
 
     if (res == null) {
         return emptyPng(session, cacheKey);

--- a/packages/tiler/src/raster.ts
+++ b/packages/tiler/src/raster.ts
@@ -8,6 +8,13 @@ export interface TileMaker {
 export interface Composition {
     /** Tiff Id */
     id: string;
+    /** Source tile used */
+    source: {
+        x: number;
+        y: number;
+        /** Internal tiff image used */
+        imageId: number;
+    };
     /** Image buffer */
     getBuffer: () => Promise<Buffer>;
     /** Point to draw the image at on the output bounds */

--- a/packages/tiler/src/tiler.ts
+++ b/packages/tiler/src/tiler.ts
@@ -110,6 +110,7 @@ export class Tiler {
         const drawAtRegion = target.subtract(raster.tile);
         const composition: Composition = {
             id: img.tif.source.name,
+            source: { x, y, imageId: img.id },
             getBuffer: async (): Promise<Buffer> => Buffer.from((await img.getTile(x, y)).bytes),
             y: Math.max(0, Math.round(drawAtRegion.y)),
             x: Math.max(0, Math.round(drawAtRegion.x)),


### PR DESCRIPTION
Logging out the exact image and tiles used for the composition allows easier debugging of image issues