### PR TITLE
fix: lambda functions need a "handler" to be exported to run

### DIFF
--- a/packages/lambda-xyz/src/__test__/index.test.ts
+++ b/packages/lambda-xyz/src/__test__/index.test.ts
@@ -15,6 +15,12 @@ o.spec('LambdaXyz index', () => {
         };
     }
 
+    o('should export handler', () => {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const foo = require('../index');
+        o(typeof foo.handler).equals('function');
+    });
+
     o.spec('version', () => {
         const origVersion: any = process.env[Env.Version];
         const origHash: any = process.env[Env.Hash];

--- a/packages/lambda-xyz/src/index.ts
+++ b/packages/lambda-xyz/src/index.ts
@@ -1,4 +1,12 @@
-import { LambdaHttpResponseAlb, LambdaSession, LogType, ReqInfo, Router } from '@basemaps/lambda-shared';
+import {
+    LambdaHttpResponseAlb,
+    LambdaSession,
+    LogType,
+    ReqInfo,
+    Router,
+    LambdaType,
+    LambdaFunction,
+} from '@basemaps/lambda-shared';
 import { ALBEvent } from 'aws-lambda';
 import health from './health';
 import ping from './ping';
@@ -50,3 +58,5 @@ export async function handleRequest(
 
     return (await app.handle(info)) as LambdaHttpResponseAlb;
 }
+
+export const handler = LambdaFunction.wrap(LambdaType.Alb, handleRequest);


### PR DESCRIPTION
Lambda functions use `index.js > handler()` as the invocation point.

The function must be exported.