### PR TITLE
fix: update landing page and cli/serve to include aerial/3857

### DIFF
--- a/packages/lambda-xyz/src/cli/serve.ts
+++ b/packages/lambda-xyz/src/cli/serve.ts
@@ -50,7 +50,7 @@ async function main(): Promise<void> {
             const data = await lambda.handleRequest(
                 {
                     httpMethod: 'get',
-                    path: `/v1/tiles/${z}/${x}/${y}.png`,
+                    path: `/v1/tiles/aerial/3857/${z}/${x}/${y}.png`,
                 } as any,
                 ctx,
                 logger,

--- a/packages/landing/static/index.html
+++ b/packages/landing/static/index.html
@@ -35,7 +35,7 @@
     <script type="text/javascript">
         const basemapLayer = new ol.layer.Tile({
             source: new ol.source.XYZ({
-                url: '/v1/tiles/{z}/{x}/{y}.png?api=SZguJbyxMjMZqZ0A7SoTAyF3Y6g8Otdd'
+                url: '/v1/tiles/aerial/3857/{z}/{x}/{y}.png?api=SZguJbyxMjMZqZ0A7SoTAyF3Y6g8Otdd'
             })
         })
 


### PR DESCRIPTION
### Fixes:

1. landing page tiles url
2. `cli/serve.ts` to forward correct url


#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
