### PR TITLE
chore: rename dev url to dev.basemaps.linz.govt.nz

### DIFF
--- a/packages/_infra/src/config.ts
+++ b/packages/_infra/src/config.ts
@@ -19,8 +19,8 @@ export const BaseMapsDevConfig: BaseMapsConfig = {
     CogBucket: 'basemaps-cog-test',
     Route53Zone: 'nonprod.basemaps.awsint.linz.govt.nz',
     AlbPublicDns: 'dev.int.tiles.basemaps.linz.govt.nz',
-    CloudFrontDns: ['dev.tiles.basemaps.linz.govt.nz', 'dev.basemaps.linz.govt.nz'],
-    PublicUrlBase: 'https://dev.tiles.basemaps.linz.govt.nz',
+    CloudFrontDns: ['tiles.dev.basemaps.linz.govt.nz', 'dev.basemaps.linz.govt.nz'],
+    PublicUrlBase: 'https://tiles.dev.basemaps.linz.govt.nz',
 };
 
 export const BaseMapsProdConfig: BaseMapsConfig = {


### PR DESCRIPTION
Use the newly created `tiles.dev.basemaps.linz.govt.nz`
