### PR TITLE
feat(tile): serve png, webp and jpeg

### DIFF
--- a/packages/lambda-shared/src/__test__/api.path.test.ts
+++ b/packages/lambda-shared/src/__test__/api.path.test.ts
@@ -2,6 +2,7 @@ import { EPSG } from '@basemaps/geo';
 import * as o from 'ospec';
 import { tileFromPath, TileSetType, TileType } from '../api.path';
 import { LambdaContext } from '../lambda.context';
+import { ImageFormat } from '@basemaps/tiler';
 import { LogConfig } from '../log';
 
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
@@ -35,19 +36,31 @@ o.spec('api.path', () => {
             o(ans).equals(null);
         });
 
-        o('should extract variables', () => {
+        o('should extract variables png', () => {
             const ctx = makeContext('/v1/tiles/aerial/global-mercator/1/2/3.png');
 
-            const ans = tileFromPath(ctx.action.rest);
-
-            o(ans).deepEquals({
+            o(tileFromPath(ctx.action.rest)).deepEquals({
                 type: TileType.Image,
                 tileSet: TileSetType.aerial,
                 projection: EPSG.Google,
                 x: 2,
                 y: 3,
                 z: 1,
-                ext: 'png',
+                ext: ImageFormat.PNG,
+            });
+        });
+
+        o('should extract variables webp', () => {
+            const ctx = makeContext('/v1/tiles/aerial/3857/4/5/6.webp');
+
+            o(tileFromPath(ctx.action.rest)).deepEquals({
+                type: TileType.Image,
+                tileSet: TileSetType.aerial,
+                projection: EPSG.Google,
+                x: 5,
+                y: 6,
+                z: 4,
+                ext: ImageFormat.WEBP,
             });
         });
 

--- a/packages/lambda-shared/src/api.path.ts
+++ b/packages/lambda-shared/src/api.path.ts
@@ -1,4 +1,6 @@
 import { Projection, EPSG } from '@basemaps/geo';
+import { getImageFormat, ImageFormat } from '@basemaps/tiler';
+
 export interface ActionData {
     version: string;
     action: string;
@@ -24,7 +26,7 @@ export interface TileDataXyz {
     x: number;
     y: number;
     z: number;
-    ext: string;
+    ext: ImageFormat;
 }
 
 export interface TileDataWmts {
@@ -42,12 +44,13 @@ function tileXyzFromPath(path: string[], tileSet: TileSetType): TileData | null 
     if (projection == null) return null;
     const z = parseInt(path[2], 10);
     const x = parseInt(path[3], 10);
-    const [ystr, ext] = path[4].split('.', 2);
+    const [ystr, extStr] = path[4].split('.', 2);
     const y = parseInt(ystr, 10);
 
     if (isNaN(x) || isNaN(y) || isNaN(z)) return null;
-    // TODO
-    // if (getImageFormat(ext) == null) return null;
+
+    const ext = getImageFormat(extStr);
+    if (ext == null) return null;
 
     return { type: TileType.Image, tileSet, projection, x, y, z, ext };
 }

--- a/packages/lambda-xyz/src/__test__/xyz.test.ts
+++ b/packages/lambda-xyz/src/__test__/xyz.test.ts
@@ -56,7 +56,7 @@ o.spec('LambdaXyz', () => {
         o(typeof base.handler).equals('function');
     });
 
-    o('should generate a tile 0,0,0', async () => {
+    o('should generate a tile 0,0,0 for png', async () => {
         const request = req('/v1/tiles/aerial/global-mercator/0/0/0.png');
         const res = await handleRequest(request);
         o(res.status).equals(200);
@@ -73,6 +73,28 @@ o.spec('LambdaXyz', () => {
 
         // Validate the session information has been set correctly
         o(request.logContext['path']).equals('/v1/tiles/aerial/global-mercator/0/0/0.png');
+        o(request.logContext['method']).equals('get');
+        o(request.logContext['xyz']).deepEquals({ x: 0, y: 0, z: 0 });
+        o(request.logContext['location']).deepEquals({ lat: 0, lon: 0 });
+    });
+
+    o('should generate a tile 0,0,0 for webp', async () => {
+        const request = req('/v1/tiles/aerial/3857/0/0/0.webp');
+        const res = await handleRequest(request);
+        o(res.status).equals(200);
+        o(res.header('content-type')).equals('image/webp');
+        o(res.header('eTaG')).equals('kOkbgX07nGYNVt4RO5HxkKxfL2/uM4UJpf1IJl9ySTk=');
+        o(res.getBody()).equals(rasterMockBuffer.toString('base64'));
+
+        o(tileMock.calls.length).equals(1);
+        const [tiffs, x, y, z] = tileMock.args;
+        o(tiffs).deepEquals([]);
+        o(x).equals(0);
+        o(y).equals(0);
+        o(z).equals(0);
+
+        // Validate the session information has been set correctly
+        o(request.logContext['path']).equals('/v1/tiles/aerial/3857/0/0/0.webp');
         o(request.logContext['method']).equals('get');
         o(request.logContext['xyz']).deepEquals({ x: 0, y: 0, z: 0 });
         o(request.logContext['location']).deepEquals({ lat: 0, lon: 0 });

--- a/packages/lambda-xyz/src/routes/tile.ts
+++ b/packages/lambda-xyz/src/routes/tile.ts
@@ -9,7 +9,6 @@ import {
     TileDataWmts,
     TileDataXyz,
 } from '@basemaps/lambda-shared';
-import { ImageFormat } from '@basemaps/tiler';
 import { CogTiff } from '@cogeotiff/core';
 import { createHash } from 'crypto';
 import pLimit from 'p-limit';
@@ -62,7 +61,7 @@ export async function Tile(req: LambdaContext, xyzData: TileDataXyz): Promise<La
     const tiler = Tilers.tile256;
     const tileMaker = Tilers.compose256;
 
-    const { x, y, z } = xyzData;
+    const { x, y, z, ext } = xyzData;
 
     const latLon = tiler.projection.getLatLonCenterFromTile(x, y, z);
     const qk = tiler.projection.getQuadKeyFromTile(x, y, z);
@@ -98,7 +97,7 @@ export async function Tile(req: LambdaContext, xyzData: TileDataXyz): Promise<La
     }
 
     req.timer.start('tile:compose');
-    const res = await tileMaker.compose({ layers, format: ImageFormat.PNG });
+    const res = await tileMaker.compose({ layers, format: ext });
     req.timer.end('tile:compose');
     req.set('layersUsed', res.layers);
     req.set('allLayersUsed', res.layers == layers.length);
@@ -109,7 +108,7 @@ export async function Tile(req: LambdaContext, xyzData: TileDataXyz): Promise<La
     req.set('bytes', res.buffer.byteLength);
     const response = new LambdaHttpResponse(200, 'ok');
     response.header(HttpHeader.ETag, cacheKey);
-    response.buffer(res.buffer, 'image/png');
+    response.buffer(res.buffer, 'image/' + ext);
     return response;
 }
 


### PR DESCRIPTION
### Change Description:

Allow requests for jpeg and webp image formats in addition to PNG

### Notes for Testing:

Check that server responds with image of requested type

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
