### PR TITLE
feat(wmts): set cache-control max-age=0 for WMTSCapabilities.xml

### DIFF
--- a/packages/lambda-shared/src/header.ts
+++ b/packages/lambda-shared/src/header.ts
@@ -3,6 +3,7 @@ export const HttpHeader = {
     CorrelationId: 'X-LINZ-Correlation-Id',
     RequestId: 'X-LINZ-Request-Id',
     ApiKey: 'X-LINZ-Api-Key',
+    CacheControl: 'Cache-Control',
     ContentType: 'Content-Type',
     ETag: 'ETag',
     IfNoneMatch: 'If-None-Match',

--- a/packages/lambda-xyz/src/__test__/xyz.test.ts
+++ b/packages/lambda-xyz/src/__test__/xyz.test.ts
@@ -134,6 +134,7 @@ o.spec('LambdaXyz', () => {
             const res = await handleRequest(request);
             o(res.status).equals(200);
             o(res.header('content-type')).equals('text/xml');
+            o(res.header('cache-control')).equals('max-age=0');
             o(res.header('eTaG')).equals('4hPFjntF8bG9stOVb3kMxU0+MXhrdXfiDbsSjoOeu2A=');
 
             const body = Buffer.from(res.getBody() ?? '', 'base64').toString();

--- a/packages/lambda-xyz/src/routes/tile.ts
+++ b/packages/lambda-xyz/src/routes/tile.ts
@@ -128,6 +128,7 @@ export async function Wmts(req: LambdaContext, wmtsData: TileDataWmts): Promise<
         .digest('base64');
 
     response.header(HttpHeader.ETag, cacheKey);
+    response.header(HttpHeader.CacheControl, 'max-age=0');
     response.buffer(data, 'text/xml');
     return response;
 }


### PR DESCRIPTION
### Change Description:

Set `WMTSCapabilities.xml` response header `cache-control: max-age=0` for api-tracker and tile requests 
...

### Notes for Testing:

Using a different api key should result in different `ResouceURL` elements.

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
