### PR TITLE
docs: switch to MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,29 +1,21 @@
-BSD 3-Clause License
+Basemaps MIT Licence
 
-Crown copyright (c) 2017, Land Information New Zealand
-All rights reserved.
+Crown copyright (c) 2020, Land Information New Zealand on behalf of the New Zealand Government.
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-
-* Neither the name of the copyright holder nor the names of its
-  contributors may be used to endorse or promote products derived from
-  this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": "git@github.com:linz/basemaps.git",
   "author": "",
-  "license": "BSD 3-Clause",
+  "license": "MIT",
   "scripts": {
     "lint": "eslint 'packages/*/src/**/*.ts' --quiet --fix",
     "test": "lerna run test --stream",

--- a/packages/_infra/package.json
+++ b/packages/_infra/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": "git@github.com:linz/basemaps.git",
   "author": "",
-  "license": "BSD 3-Clause",
+  "license": "MIT",
   "scripts": {
     "deploy:synth": "cdk synth",
     "deploy:diff": "cdk diff || true",

--- a/packages/cog/package.json
+++ b/packages/cog/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": "git@github.com:linz/basemaps.git",
   "author": "",
-  "license": "BSD 3-Clause",
+  "license": "MIT",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "bin": {

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "repository": "git@github.com:linz/basemaps.git",
   "author": "",
-  "license": "BSD 3-Clause",
+  "license": "MIT",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "scripts": {

--- a/packages/lambda-api-tracker/package.json
+++ b/packages/lambda-api-tracker/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": "git@github.com:linz/basemaps.git",
   "author": "",
-  "license": "BSD 3-Clause",
+  "license": "MIT",
   "dependencies": {
     "@basemaps/lambda-shared": "^1.1.0"
   },

--- a/packages/lambda-shared/package.json
+++ b/packages/lambda-shared/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": "git@github.com:linz/basemaps.git",
   "author": "",
-  "license": "BSD 3-Clause",
+  "license": "MIT",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "scripts": {

--- a/packages/lambda-xyz/package.json
+++ b/packages/lambda-xyz/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": "git@github.com:linz/basemaps.git",
   "author": "",
-  "license": "BSD 3-Clause",
+  "license": "MIT",
   "dependencies": {
     "@basemaps/lambda-shared": "^1.1.0",
     "@basemaps/tiler": "^1.1.0",

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "repository": "git@github.com:linz/basemaps.git",
   "author": "",
-  "license": "BSD 3-Clause",
+  "license": "MIT",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "scripts": {

--- a/packages/metrics/package.json
+++ b/packages/metrics/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "repository": "git@github.com:linz/basemaps.git",
   "author": "",
-  "license": "BSD 3-Clause",
+  "license": "MIT",
   "main": "./build/metrics.js",
   "types": "./build/metrics.d.ts",
   "scripts": {

--- a/packages/tiler-sharp/package.json
+++ b/packages/tiler-sharp/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "repository": "git@github.com:linz/basemaps.git",
   "author": "",
-  "license": "BSD 3-Clause",
+  "license": "MIT",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "scripts": {

--- a/packages/tiler/package.json
+++ b/packages/tiler/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.0",
   "repository": "git@github.com:linz/basemaps.git",
   "author": "",
-  "license": "BSD 3-Clause",
+  "license": "MIT",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
   "scripts": {},


### PR DESCRIPTION
LINZ has suggested using MIT as the default licensing for new projects.