### PR TITLE
fix(wmts): respond with 304 if not modified

### DIFF
--- a/packages/lambda-xyz/src/__test__/xyz.test.ts
+++ b/packages/lambda-xyz/src/__test__/xyz.test.ts
@@ -125,6 +125,20 @@ o.spec('LambdaXyz', () => {
         o.after(() => {
             process.env[Env.PublicUrlBase] = origPublicUrlBase;
         });
+
+        o('should 304 if a xml is not modified', async () => {
+            const key = 'AUjdJhRzn4qFv9um0D0/k+8IRxdI4jgzO+QUg/aaMxw=';
+            const request = req('/v1/tiles/aerial/WMTSCapabilities.xml', 'get', {
+                'if-none-match': key,
+            });
+
+            const res = await handleRequest(request);
+            o(res.status).equals(304);
+            o(rasterMock.calls.length).equals(0);
+
+            o(request.logContext['cache']).deepEquals({ key, match: key, hit: true });
+        });
+
         o('should serve WMTSCapabilities for tile_set', async () => {
             process.env[Env.PublicUrlBase] = 'https://tiles.test';
 


### PR DESCRIPTION
### Fixes

Check etag against file contents and respond with 304 if not modified

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
