### PR TITLE
build: ensure deploy script can be run

### DIFF
--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -9,7 +9,7 @@
   "types": "./build/index.d.ts",
   "scripts": {
     "test": "ospec 'build/**/*.test.js'",
-    "deploy:deploy": "./deploy.js"
+    "deploy:deploy": "node deploy.js"
   },
   "dependencies": {
     "@basemaps/infra": "^1.2.0"


### PR DESCRIPTION
node scripts can not be directly exectued

either need to `chmod +x ` and `#!/usr/bin/env node`
or to just run the node cli