### PR TITLE
build: should fail build if unlinked dependencies are used

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,6 +17,9 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
+      - name: Check Dependencies
+        run: node scripts/detect.unlinked.dep.js
+
       - name: Install
         run: yarn
 

--- a/packages/cog/package.json
+++ b/packages/cog/package.json
@@ -16,6 +16,7 @@
     "test": "ospec build/**/*.test.js"
   },
   "dependencies": {
+    "@basemaps/geo": "1.2.0",
     "@basemaps/lambda-shared": "^1.2.0",
     "@cogeotiff/core": "^1.0.3",
     "@cogeotiff/source-aws": "^1.0.3",

--- a/packages/lambda-api-tracker/package.json
+++ b/packages/lambda-api-tracker/package.json
@@ -6,6 +6,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@basemaps/geo": "1.2.0",
     "@basemaps/lambda-shared": "^1.2.0"
   },
   "scripts": {

--- a/packages/lambda-shared/package.json
+++ b/packages/lambda-shared/package.json
@@ -11,6 +11,8 @@
     "test": "ospec 'build/**/*.test.js'"
   },
   "dependencies": {
+    "@basemaps/geo": "1.2.0",
+    "@basemaps/metrics": "1.2.0",
     "@basemaps/tiler": "^1.2.0",
     "aws-sdk": "^2.508.0",
     "base-x": "^3.0.7",

--- a/packages/lambda-xyz/package.json
+++ b/packages/lambda-xyz/package.json
@@ -6,8 +6,10 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@basemaps/geo": "1.2.0",
     "@basemaps/lambda-shared": "^1.2.0",
     "@basemaps/tiler": "^1.2.0",
+    "@basemaps/tiler-sharp": "1.2.0",
     "@cogeotiff/core": "^1.0.3",
     "@cogeotiff/source-aws": "^1.0.3",
     "path-to-regexp": "^6.1.0",

--- a/packages/tiler-sharp/package.json
+++ b/packages/tiler-sharp/package.json
@@ -10,6 +10,8 @@
     "test": "ospec build/**/*.test.js"
   },
   "dependencies": {
+    "@basemaps/geo": "1.2.0",
+    "@basemaps/metrics": "1.2.0",
     "@basemaps/tiler": "^1.2.0",
     "sharp": "^0.25.2"
   },

--- a/packages/tiler/package.json
+++ b/packages/tiler/package.json
@@ -8,6 +8,7 @@
   "types": "./build/index.d.ts",
   "scripts": {},
   "dependencies": {
+    "@basemaps/geo": "1.2.0",
     "@basemaps/metrics": "^1.2.0",
     "@cogeotiff/core": "^1.0.3"
   },

--- a/scripts/detect.unlinked.dep.js
+++ b/scripts/detect.unlinked.dep.js
@@ -32,6 +32,7 @@ function getAllImports(path) {
 async function main() {
     const packages = await fs.readdir('./packages');
 
+    let hasFailures = false;
     for (const pkg of packages) {
         const pkgPath = `./packages/${pkg}`;
         const pkgJson = JSON.parse(await fs.readFile(`${pkgPath}/package.json`));
@@ -47,8 +48,12 @@ async function main() {
         for (const importedPackage of allImports) {
             if (!localDeps.has(importedPackage)) {
                 console.error(`${pkg}: Missing import "${importedPackage}"`);
+                hasFailures = true;
             }
         }
+    }
+    if (hasFailures) {
+        process.exit(1);
     }
 }
 


### PR DESCRIPTION
Verify that there are no unlinked deps inside the monorepo.