### PR TITLE
Feat/wmts improvements

### DIFF
--- a/packages/geo/src/projection.ts
+++ b/packages/geo/src/projection.ts
@@ -114,6 +114,11 @@ export class Projection {
         return `EPSG:${epsg}`;
     }
 
+    /** convert a EPSG code into a URN */
+    public static toUrn(epsg: EPSG): string {
+        return `urn:ogc:def:crs:EPSG:6.18:3:${epsg}`;
+    }
+
     /** parse a string returning the `EPSG` code **/
     public static parseEpsgString(text: string): EPSG | null {
         return EPSGTextMap[text.replace(/[\W_]/g, '').toLowerCase()] || null;

--- a/packages/lambda-xyz/src/__test__/wmts.capability.test.ts
+++ b/packages/lambda-xyz/src/__test__/wmts.capability.test.ts
@@ -26,7 +26,7 @@ o.spec('wmts', () => {
         ]);
 
         o(listTag(raw, 'ows:WGS84BoundingBox')).deepEquals([
-            '<ows:WGS84BoundingBox>\n' +
+            '<ows:WGS84BoundingBox crs="urn:ogc:def:crs:OGC:2:84">\n' +
                 '  <ows:LowerCorner>-180 -85.0511287798066</ows:LowerCorner>\n' +
                 '  <ows:UpperCorner>180 85.0511287798066</ows:UpperCorner>\n' +
                 '</ows:WGS84BoundingBox>',
@@ -44,7 +44,13 @@ o.spec('wmts', () => {
         o(tileMatrixSet.length).equals(2);
 
         o(listTag(tileMatrixSet[1], 'ows:Identifier')[0]).equals('<ows:Identifier>aerial</ows:Identifier>');
-        o(listTag(tileMatrixSet[1], 'ows:SupportedCRS')).deepEquals(['<ows:SupportedCRS>EPSG:3857</ows:SupportedCRS>']);
+        o(listTag(tileMatrixSet[1], 'ows:SupportedCRS')).deepEquals([
+            '<ows:SupportedCRS>urn:ogc:def:crs:EPSG:6.18:3:3857</ows:SupportedCRS>',
+        ]);
+
+        o(listTag(tileMatrixSet[1], 'WellKnownScaleSet')).deepEquals([
+            '<WellKnownScaleSet>urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible</WellKnownScaleSet>',
+        ]);
 
         const tileMatrices = Array.from(raw.tags('TileMatrix'));
 
@@ -130,7 +136,7 @@ o.spec('wmts', () => {
         o(xml).equals('<?xml version="1.0"?>\n' + raw.toString());
 
         o(createHash('sha256').update(Buffer.from(xml)).digest('base64')).equals(
-            '6/LJ2nPrCPTiMt4dteMk46hq/80JbFZEH4GMrHG3eaU=',
+            'c6nAkVgp2YR1JKfamidVGZh4mY8LOhWmjOqf9u/T/kk=',
         );
     });
 

--- a/packages/lambda-xyz/src/__test__/wmts.capability.test.ts
+++ b/packages/lambda-xyz/src/__test__/wmts.capability.test.ts
@@ -48,7 +48,7 @@ o.spec('wmts', () => {
 
         const tileMatrices = Array.from(raw.tags('TileMatrix'));
 
-        o(tileMatrices.length).equals(20);
+        o(tileMatrices.length).equals(25);
 
         o(tileMatrices[0].toString()).equals(
             '<TileMatrix>\n' +
@@ -99,7 +99,7 @@ o.spec('wmts', () => {
 
         const tileMatrices = Array.from(raw.tags('TileMatrix'));
 
-        o(tileMatrices.length).equals(20);
+        o(tileMatrices.length).equals(25);
 
         o(tileMatrices[0].toString()).equals(
             '<TileMatrix>\n' +
@@ -130,7 +130,7 @@ o.spec('wmts', () => {
         o(xml).equals('<?xml version="1.0"?>\n' + raw.toString());
 
         o(createHash('sha256').update(Buffer.from(xml)).digest('base64')).equals(
-            'sdDWwHqM7SzcV9dL1dQ0Kp8QqulUSdk/n1vQ/a3UgN4=',
+            '6/LJ2nPrCPTiMt4dteMk46hq/80JbFZEH4GMrHG3eaU=',
         );
     });
 

--- a/packages/lambda-xyz/src/__test__/xyz.test.ts
+++ b/packages/lambda-xyz/src/__test__/xyz.test.ts
@@ -127,12 +127,13 @@ o.spec('LambdaXyz', () => {
         });
 
         o('should 304 if a xml is not modified', async () => {
-            const key = 'BVnuCvMWJ1PBIIa/D2s3swuKNR/TY3xHkgzM7MMWjho=';
+            const key = 'uv2XFvwiRkvhkPbj+QazOpYj7X0TjB5IBIIJPNGkLr8=';
             const request = req('/v1/tiles/aerial/WMTSCapabilities.xml', 'get', {
                 'if-none-match': key,
             });
 
             const res = await handleRequest(request);
+            if (res.status == 200) o(res.header('eTaG')).equals(key); // this line is useful for discovering the new etag
             o(res.status).equals(304);
             o(rasterMock.calls.length).equals(0);
 
@@ -149,7 +150,7 @@ o.spec('LambdaXyz', () => {
             o(res.status).equals(200);
             o(res.header('content-type')).equals('text/xml');
             o(res.header('cache-control')).equals('max-age=0');
-            o(res.header('eTaG')).equals('g2Z5qHK7nkoMcmA0VQ/c/O5FEgcYEvpAxtQWyN+dmt4=');
+            o(res.header('eTaG')).equals('EM2yWCUl7sdJudnCwYslzX8SGyW6fpwQUnAqNEJAST4=');
 
             const body = Buffer.from(res.getBody() ?? '', 'base64').toString();
             o(body.slice(0, 100)).equals(

--- a/packages/lambda-xyz/src/__test__/xyz.test.ts
+++ b/packages/lambda-xyz/src/__test__/xyz.test.ts
@@ -127,7 +127,7 @@ o.spec('LambdaXyz', () => {
         });
 
         o('should 304 if a xml is not modified', async () => {
-            const key = 'AUjdJhRzn4qFv9um0D0/k+8IRxdI4jgzO+QUg/aaMxw=';
+            const key = 'BVnuCvMWJ1PBIIa/D2s3swuKNR/TY3xHkgzM7MMWjho=';
             const request = req('/v1/tiles/aerial/WMTSCapabilities.xml', 'get', {
                 'if-none-match': key,
             });
@@ -149,7 +149,7 @@ o.spec('LambdaXyz', () => {
             o(res.status).equals(200);
             o(res.header('content-type')).equals('text/xml');
             o(res.header('cache-control')).equals('max-age=0');
-            o(res.header('eTaG')).equals('4hPFjntF8bG9stOVb3kMxU0+MXhrdXfiDbsSjoOeu2A=');
+            o(res.header('eTaG')).equals('g2Z5qHK7nkoMcmA0VQ/c/O5FEgcYEvpAxtQWyN+dmt4=');
 
             const body = Buffer.from(res.getBody() ?? '', 'base64').toString();
             o(body.slice(0, 100)).equals(

--- a/packages/lambda-xyz/src/wmts.capability.ts
+++ b/packages/lambda-xyz/src/wmts.capability.ts
@@ -4,6 +4,8 @@ import { ImageFormat } from '@basemaps/tiler';
 
 const { lat, lon } = Projection.Wgs84Bound;
 
+const MaxZoomLevel = 25;
+
 const CapabilitiesAttrs = {
     xmlns: 'http://www.opengis.net/wmts/1.0',
     'xmlns:ows': 'http://www.opengis.net/ows/1.1',
@@ -86,7 +88,7 @@ const MatrixSets = new Map<TileSetType, EPSGToGenerator>();
             const matrices = [];
             let scale = 559082264.029,
                 size = 1;
-            for (let i = 0; i < 20; ++i, scale *= 0.5) {
+            for (let i = 0; i < MaxZoomLevel; ++i, scale *= 0.5) {
                 const dim = String(size);
                 size *= 2;
                 matrices.push(

--- a/packages/lambda-xyz/src/wmts.capability.ts
+++ b/packages/lambda-xyz/src/wmts.capability.ts
@@ -1,4 +1,4 @@
-import { V, VNode, TileSetType } from '@basemaps/lambda-shared';
+import { V, VNode, TileSetType, VNodeElement } from '@basemaps/lambda-shared';
 import { EPSG, Projection } from '@basemaps/geo';
 import { ImageFormat } from '@basemaps/tiler';
 
@@ -23,8 +23,32 @@ for (const k in ImageFormat) formats.push(V('Format', 'image/' + ImageFormat[k a
 const LayerPreamble: Record<TileSetType, VNode[]> = {
     [TileSetType.aerial]: [
         V('ows:Title', 'NZ Aerial Imagery Basemap'),
-        V('ows:Abstract', ''),
-        V('ows:WGS84BoundingBox', [V('ows:LowerCorner', -lon + ' -' + lat), V('ows:UpperCorner', lon + ' ' + lat)]),
+        V(
+            'ows:Abstract',
+            `The NZ Aerial Imagery basemap provides a seamless nationwide imagery layer with the newest and
+highest resolution data, and covers 95% of New Zealand.
+
+The date of capture is prioritised over resolution. This means newer imagery layers are prioritised
+above higher resolution imagery in the same location.
+
+This basemap has been designed to be integrated into GIS, web and mobile applications via our WMTS
+and XYZ tile services. View the Services tab to access these services.
+
+This layer is made up of individual aerial imagery (orthophotography) layers available on the [LINZ
+Data Service](https://data.linz.govt.nz/data/category/aerial-photos/) and will be updated as new
+imagery is captured.
+
+Please refer to the individual layers for specific accuracy, pixel resolution, and licensing
+attribution requirements. More information about the individual layers can be found using the [NZ
+Imagery Surveys layer.](https://data.linz.govt.nz/layer/95677-nz-imagery-surveys/)
+
+A list of attribution requirements for each layer are also available at [Attributing Aerial Imagery
+data](http://www.linz.govt.nz/data/licensing-and-using-data/attributing-aerial-imagery-data).`,
+        ),
+        V('ows:WGS84BoundingBox', { crs: 'urn:ogc:def:crs:OGC:2:84' }, [
+            V('ows:LowerCorner', -lon + ' -' + lat),
+            V('ows:UpperCorner', lon + ' ' + lat),
+        ]),
         V('ows:Identifier', 'aerial'),
         V('Style', [V('ows:Identifier', 'default')]),
         ...formats,
@@ -68,6 +92,10 @@ the Creative Commons 3.0
     ]),
 ];
 
+function wellKnownScaleSet(projection: EPSG): VNodeElement[] {
+    return projection === EPSG.Google ? [V('WellKnownScaleSet', 'urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible')] : [];
+}
+
 const CommonGlobalMercator = [
     V('TopLeftCorner', -Projection.OriginShift + ' ' + Projection.OriginShift),
     V('TileWidth', '256'),
@@ -103,7 +131,8 @@ const MatrixSets = new Map<TileSetType, EPSGToGenerator>();
             }
             return V('TileMatrixSet', [
                 V('ows:Identifier', tileSet),
-                V('ows:SupportedCRS', Projection.toEpsgString(projection)),
+                V('ows:SupportedCRS', Projection.toUrn(projection)),
+                ...wellKnownScaleSet(projection),
                 ...matrices,
             ]);
         },


### PR DESCRIPTION
### Change Description:

1. Add the layer abstract, this should include information about the imagery set or at least a URL to more detailed information
2. The TileMatrixSet would be better labeled as GoogleMapsCompatible to be consistent with other services, including the LDS. “aerial” is not a good label.
3. Add <WellKnownScaleSet>urn:ogc:def:wkss:OGC:1.0:GoogleMapsCompatible</WellKnownScaleSet> to the tilematrixset definition. Will this add better interoperability with some clients. 
4. You might need to consider adding “crs=“urn:ogc:def:crs:OGC:2:84” to the layer ows:WGS84BoundingBox element to explicitly define the WGS84 coordinate axis order. I remember  ArcMap 10.3/4 needed it and ArcGIS (as least when I last tested). It might be fixed now, but worth another look. I don’t see an harm in adding the attribute in any case for further axis order compatability. 
5. Increase zoom levels to 25


### Notes for Testing:

...

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
