### PR TITLE
fix(wmts): change image format order for ArcGIS Pro

### DIFF
--- a/packages/lambda-xyz/src/__test__/wmts.capability.test.ts
+++ b/packages/lambda-xyz/src/__test__/wmts.capability.test.ts
@@ -16,13 +16,15 @@ o.spec('wmts', () => {
         }
 
         o(listTag(raw, 'TileMatrixSetLink')).deepEquals([
-            '<TileMatrixSetLink>\n' + '  <TileMatrixSet>aerial</TileMatrixSet>\n' + '</TileMatrixSetLink>',
+            '<TileMatrixSetLink>\n' +
+                '  <TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>\n' +
+                '</TileMatrixSetLink>',
         ]);
 
         o(listTag(raw, 'Format')).deepEquals([
             '<Format>image/png</Format>',
-            '<Format>image/jpeg</Format>',
             '<Format>image/webp</Format>',
+            '<Format>image/jpeg</Format>',
         ]);
 
         o(listTag(raw, 'ows:WGS84BoundingBox')).deepEquals([
@@ -43,7 +45,9 @@ o.spec('wmts', () => {
         const tileMatrixSet = Array.from(raw.tags('TileMatrixSet'));
         o(tileMatrixSet.length).equals(2);
 
-        o(listTag(tileMatrixSet[1], 'ows:Identifier')[0]).equals('<ows:Identifier>aerial</ows:Identifier>');
+        o(listTag(tileMatrixSet[1], 'ows:Identifier')[0]).equals(
+            '<ows:Identifier>GoogleMapsCompatible</ows:Identifier>',
+        );
         o(listTag(tileMatrixSet[1], 'ows:SupportedCRS')).deepEquals([
             '<ows:SupportedCRS>urn:ogc:def:crs:EPSG::3857</ows:SupportedCRS>',
         ]);
@@ -100,7 +104,9 @@ o.spec('wmts', () => {
         );
 
         o(listTag(raw, 'TileMatrixSetLink')).deepEquals([
-            '<TileMatrixSetLink>\n' + '  <TileMatrixSet>aerial</TileMatrixSet>\n' + '</TileMatrixSetLink>',
+            '<TileMatrixSetLink>\n' +
+                '  <TileMatrixSet>GoogleMapsCompatible</TileMatrixSet>\n' +
+                '</TileMatrixSetLink>',
         ]);
 
         const tileMatrices = Array.from(raw.tags('TileMatrix'));
@@ -136,7 +142,7 @@ o.spec('wmts', () => {
         o(xml).equals('<?xml version="1.0"?>\n' + raw.toString());
 
         o(createHash('sha256').update(Buffer.from(xml)).digest('base64')).equals(
-            '7KnOltdFMTqLAxdohlvpGz6EDhp4TCsHfkpKcii3FxQ=',
+            'TVC+AvvAGcQBIsTa2lgbD3CrAn2jruPyuqVglM46D+o=',
         );
     });
 

--- a/packages/lambda-xyz/src/__test__/xyz.test.ts
+++ b/packages/lambda-xyz/src/__test__/xyz.test.ts
@@ -133,7 +133,7 @@ o.spec('LambdaXyz', () => {
         });
 
         o('should 304 if a xml is not modified', async () => {
-            const key = '7j85JRqMNzbxW7jhKStV/BUj5Cmd2g4CddCDDc6szX8=';
+            const key = '+YQQBzXrZis6og9dRrC55qPE9rYjjywpwUq+KYuTuFw=';
             const request = req('/v1/tiles/aerial/WMTSCapabilities.xml', 'get', {
                 'if-none-match': key,
             });
@@ -156,7 +156,7 @@ o.spec('LambdaXyz', () => {
             o(res.status).equals(200);
             o(res.header('content-type')).equals('text/xml');
             o(res.header('cache-control')).equals('max-age=0');
-            o(res.header('eTaG')).equals('Rh06Txcp7+na/8CspwrgzfQ3qIOT+UOS9EQNROX/iiE=');
+            o(res.header('eTaG')).equals('sAHdnZjjoU0lWK2oD5YPC1C6rJ/z5FDW69GiyHtN7QY=');
 
             const body = Buffer.from(res.getBody() ?? '', 'base64').toString();
             o(body.slice(0, 100)).equals(

--- a/packages/tiler/src/raster.ts
+++ b/packages/tiler/src/raster.ts
@@ -39,6 +39,8 @@ export enum ImageFormat {
     WEBP = 'webp',
 }
 
+export const ImageFormatOrder = [ImageFormat.PNG, ImageFormat.WEBP, ImageFormat.JPEG];
+
 /** Guess the image format based on the file extension */
 export function getImageFormat(ext: string): ImageFormat | null {
     const search = ext.toLowerCase();


### PR DESCRIPTION
### FIxes

1. Change image format order for ArcGIS Pro
2. Rename TileMatrixSet to GoogleMapsCompatible

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
