### PR TITLE
Build/aws cdk 1.32.2

### DIFF
--- a/packages/_infra/package.json
+++ b/packages/_infra/package.json
@@ -14,20 +14,20 @@
     "git-rev-sync": "^2.0.0"
   },
   "devDependencies": {
-    "@aws-cdk/aws-batch": "^1.32.0",
-    "@aws-cdk/aws-certificatemanager": "^1.32.0",
-    "@aws-cdk/aws-cloudfront": "^1.32.0",
-    "@aws-cdk/aws-dynamodb": "^1.32.0",
-    "@aws-cdk/aws-ecr": "^1.32.0",
-    "@aws-cdk/aws-ecr-assets": "^1.32.0",
-    "@aws-cdk/aws-elasticloadbalancingv2": "^1.32.0",
-    "@aws-cdk/aws-elasticloadbalancingv2-targets": "^1.32.0",
-    "@aws-cdk/aws-s3": "^1.32.0",
-    "@aws-cdk/core": "^1.32.0",
+    "@aws-cdk/aws-batch": "^1.32.2",
+    "@aws-cdk/aws-certificatemanager": "^1.32.2",
+    "@aws-cdk/aws-cloudfront": "^1.32.2",
+    "@aws-cdk/aws-dynamodb": "^1.32.2",
+    "@aws-cdk/aws-ecr": "^1.32.2",
+    "@aws-cdk/aws-ecr-assets": "^1.32.2",
+    "@aws-cdk/aws-elasticloadbalancingv2": "^1.32.2",
+    "@aws-cdk/aws-elasticloadbalancingv2-targets": "^1.32.2",
+    "@aws-cdk/aws-s3": "^1.32.2",
+    "@aws-cdk/core": "^1.32.2",
     "@basemaps/lambda-api-tracker": "^1.2.0",
     "@basemaps/lambda-shared": "^1.2.0",
     "@basemaps/lambda-xyz": "^1.2.0",
     "@types/git-rev-sync": "^1.12.0",
-    "aws-cdk": "^1.32.0"
+    "aws-cdk": "^1.32.2"
   }
 }

--- a/packages/cog/src/cli/basemaps/action.imagery.import.ts
+++ b/packages/cog/src/cli/basemaps/action.imagery.import.ts
@@ -76,7 +76,7 @@ export class ImageryImportAction extends CommandLineAction {
 
         logger.info({ imagery: job.name }, 'Importing');
 
-        const imgRecord = await createImageryRecordFromJob(job);
+        const imgRecord = createImageryRecordFromJob(job);
 
         if (imgRecord.year == -1) logger.warn({ imagery: job.name }, 'Failed to parse year');
         if (imgRecord.resolution == -1) logger.warn({ imagery: job.name }, 'Failed to parse resolution');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,547 +2,547 @@
 # yarn lockfile v1
 
 
-"@aws-cdk/assets@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/assets/-/assets-1.32.0.tgz#a575c19abfa0e1f0859996b23bc1dcb3908a1a31"
-  integrity sha512-ooINlKG9PvmsiKNWX1JLAxFQG2AnGfaQp7WYW73gLhG2XYcQd42aV6TN4adsxHAqgsPXbxdsrnDx6f4IqoIyfQ==
+"@aws-cdk/assets@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/assets/-/assets-1.32.2.tgz#fa0d9c41a87fc5b894161abc599706bac232074a"
+  integrity sha512-GOAGU2yHpXfBkzDRGZbVKoT717Huvhczmqj0KCkM83Sh4mCf43cdIMennMU1kGsvZAOS7QC1O/Xps+1KHqerkg==
   dependencies:
-    "@aws-cdk/core" "1.32.0"
-    "@aws-cdk/cx-api" "1.32.0"
+    "@aws-cdk/core" "1.32.2"
+    "@aws-cdk/cx-api" "1.32.2"
     constructs "^2.0.0"
     minimatch "^3.0.4"
 
-"@aws-cdk/aws-apigateway@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigateway/-/aws-apigateway-1.32.0.tgz#5485fc5c46a2bfdcfaccc79a920c133b031d8b17"
-  integrity sha512-qoUq64MIwFBHWTJ4o0VjIKoQ0hJDGI7HrBVj1WNWm61/t45kT+/SBIZLsG6X/qESgAqZAEukdBOpqtG83ft1Uw==
+"@aws-cdk/aws-apigateway@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-apigateway/-/aws-apigateway-1.32.2.tgz#aecb99c64ba3ec677f5eb1a4993034a5d9249a7a"
+  integrity sha512-edtDTvdvleMHtN9jpot+rwHDKfmH+tCIGFGLmbECyfcXVxPkvKOzW08V3lwl5PcrxS5BaAqPSNYn7+tONOoYew==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.32.0"
-    "@aws-cdk/aws-ec2" "1.32.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-lambda" "1.32.0"
-    "@aws-cdk/aws-logs" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-certificatemanager" "1.32.2"
+    "@aws-cdk/aws-ec2" "1.32.2"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-lambda" "1.32.2"
+    "@aws-cdk/aws-logs" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-applicationautoscaling@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.32.0.tgz#256741e2fa417f478ef71215a4153136745c315b"
-  integrity sha512-KsOC+XxfjXzVYTYV1ZAby2U3vKvlSXp22mheHGRezR3yDfgqlRbjXHSpUxjELPlbfWxJUMG7Erlm0jSyFbIqjQ==
+"@aws-cdk/aws-applicationautoscaling@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-applicationautoscaling/-/aws-applicationautoscaling-1.32.2.tgz#aad8f7c6df95cd40352708621e2577f3530561dc"
+  integrity sha512-Ce8cD3UhijMIXjoduQGRODnMtj5BPq6l7h5j9/NDCv8aqy821vndxLA5FVNMgJjw7Lc5igO7kkvQQ0/4EHBqVQ==
   dependencies:
-    "@aws-cdk/aws-autoscaling-common" "1.32.0"
-    "@aws-cdk/aws-cloudwatch" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-autoscaling-common" "1.32.2"
+    "@aws-cdk/aws-cloudwatch" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-autoscaling-common@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.32.0.tgz#6aca693724a55139baf48ab62fa9a4a6f449cc16"
-  integrity sha512-tHwhHK9Baua9qX0s4/Hbltj/kptycOwN7gynw2MnoCJpDM4Of4kU9ljs8u4fpKLe5lrYWHg7gfVpsnyTa/b3uw==
+"@aws-cdk/aws-autoscaling-common@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-common/-/aws-autoscaling-common-1.32.2.tgz#e15cb4e835eb0c70d2236afdb222a012188402b0"
+  integrity sha512-ltSc5smF2YO1m6to8IAoTeXHpWw0bLZikuHV5w8PB0La4cCG8MdvgAIm95SJRjZYD7IQPXs6OmzOuWHIeEaJiQ==
   dependencies:
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-autoscaling-hooktargets@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-1.32.0.tgz#ab0915c5b3f83a03d0f366da68603c7d8c1558e1"
-  integrity sha512-33K2w0PMWL2cgSuJTUVlk/woIpZjO5xUNXlq4g2q2/Fp7iv5EOnM8T3MbQe3QLom3HYnDUKH3iUIOXxtCd7oRQ==
+"@aws-cdk/aws-autoscaling-hooktargets@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling-hooktargets/-/aws-autoscaling-hooktargets-1.32.2.tgz#a59186483358c7866e496d4db0c7b5c9f180de9a"
+  integrity sha512-+SLlebaYpm1Gi++AGRiUlLqHnBi7jPYc4qava+UzjSINlz8LZKq6O4G8SVmNxvcJWGOUhS1jRYSVqV/y4XJSHg==
   dependencies:
-    "@aws-cdk/aws-autoscaling" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-lambda" "1.32.0"
-    "@aws-cdk/aws-sns" "1.32.0"
-    "@aws-cdk/aws-sns-subscriptions" "1.32.0"
-    "@aws-cdk/aws-sqs" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-autoscaling" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-lambda" "1.32.2"
+    "@aws-cdk/aws-sns" "1.32.2"
+    "@aws-cdk/aws-sns-subscriptions" "1.32.2"
+    "@aws-cdk/aws-sqs" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-autoscaling@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.32.0.tgz#d00ff2c61973cf785283f271ad0c4fc3111f4394"
-  integrity sha512-cRIWxwB8vOd2xxtNOZdFoTKdDSWUF2mW09xgEIrDmbhsfOUniZQWdj9PsLWbYFkNMCbpH+1QLCYQGzSg0A4uWQ==
+"@aws-cdk/aws-autoscaling@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-autoscaling/-/aws-autoscaling-1.32.2.tgz#30ee07a732a08a5aeb5dd94d01b4b42d4591614a"
+  integrity sha512-7g1g2yx3//l2tHz45QKLbbPFz3x/in1yVUPihWBXj8OMoy/jwHnagbKJFFcE2mu/gLtJEVRKZ3BskxdeXXSj7A==
   dependencies:
-    "@aws-cdk/aws-autoscaling-common" "1.32.0"
-    "@aws-cdk/aws-cloudwatch" "1.32.0"
-    "@aws-cdk/aws-ec2" "1.32.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.32.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-sns" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-autoscaling-common" "1.32.2"
+    "@aws-cdk/aws-cloudwatch" "1.32.2"
+    "@aws-cdk/aws-ec2" "1.32.2"
+    "@aws-cdk/aws-elasticloadbalancing" "1.32.2"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-sns" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-batch@1.32.0", "@aws-cdk/aws-batch@^1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-batch/-/aws-batch-1.32.0.tgz#c1db29497d913dea21afe6c2cc0e0bebdcf48466"
-  integrity sha512-tMaw/DcTQ+ZJBdAF9UqvzdSuakcWHHDe9yPdmoxQzpae8LpgW3ztHPSA/qNZT4lfNCIe8kFeecblTr/8DN5ZNQ==
+"@aws-cdk/aws-batch@1.32.2", "@aws-cdk/aws-batch@^1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-batch/-/aws-batch-1.32.2.tgz#8d98ec23d053ce8b19bae33f110d2b14f2d255bf"
+  integrity sha512-tfliM4EWlXRds0AnyC45+77jpyBCiW8SASTcYmaQvEixCmiCiaadPfk7XnyF6yqs4Nv2Lyq5g3d23BSNUh9fvA==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.32.0"
-    "@aws-cdk/aws-ecr" "1.32.0"
-    "@aws-cdk/aws-ecs" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-ec2" "1.32.2"
+    "@aws-cdk/aws-ecr" "1.32.2"
+    "@aws-cdk/aws-ecs" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-certificatemanager@1.32.0", "@aws-cdk/aws-certificatemanager@^1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.32.0.tgz#0638ed254f03cea04e6b762b860f383c05d9bb64"
-  integrity sha512-wLn2yeiEtwVhZIXL/OKoFseZeDVMJ1GeG+tkWYyvhljTvQgl3+xdCJUclYDhizFIC/VziZpM2CoSk1xrBsWVGA==
+"@aws-cdk/aws-certificatemanager@1.32.2", "@aws-cdk/aws-certificatemanager@^1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-certificatemanager/-/aws-certificatemanager-1.32.2.tgz#117bb81415d93e84a2ccc4f7c68d07921168d589"
+  integrity sha512-vGa6zqr6+8/zzlVAsz5biY1NxLznCivYZnVj09BCtaqmXPgWkNcIGxnyEZnNLoLPSdDD6JwdQZU6tHARg+Wo1w==
   dependencies:
-    "@aws-cdk/aws-cloudformation" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-lambda" "1.32.0"
-    "@aws-cdk/aws-route53" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-cloudformation" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-lambda" "1.32.2"
+    "@aws-cdk/aws-route53" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-cloudformation@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.32.0.tgz#7c8b10fd8427776865b0ace5cddb7d3b747933f1"
-  integrity sha512-NuJ7IckX0/4WvyxmLdviLWlS/jiBOXDj8RxKW/wuUOYHc+ARAekspWkYZYeXPhrqNPzwSWa/xONI3dHZORfI2A==
+"@aws-cdk/aws-cloudformation@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudformation/-/aws-cloudformation-1.32.2.tgz#79c4dbacea4c5db59c524027f1ee5143a3149419"
+  integrity sha512-3f6c16/0meFdD1LNIvLcQd/I1qnzogVSRa+aqAHDG8gi9pwVS/Y/IDquifa4ox+3wMjKRIDBd6C9+xUhvaUAgw==
   dependencies:
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-lambda" "1.32.0"
-    "@aws-cdk/aws-s3" "1.32.0"
-    "@aws-cdk/aws-sns" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
-    "@aws-cdk/cx-api" "1.32.0"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-lambda" "1.32.2"
+    "@aws-cdk/aws-s3" "1.32.2"
+    "@aws-cdk/aws-sns" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
+    "@aws-cdk/cx-api" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-cloudfront@1.32.0", "@aws-cdk/aws-cloudfront@^1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.32.0.tgz#95ac2554e7486b38011fb2732ecfe19e1a49498a"
-  integrity sha512-xt7CNtZz5ekDmAb8/U2C38KxtU/oE09ci/WjQlWqo9AUuz/s2SZUZvuT2xuA4KHOEwmzEk7eEwc8yU0pCY00RA==
+"@aws-cdk/aws-cloudfront@1.32.2", "@aws-cdk/aws-cloudfront@^1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudfront/-/aws-cloudfront-1.32.2.tgz#40fdf8c24cc369e43179d0837d9bf9ef8f438fe3"
+  integrity sha512-zebzZMW6KmASUPDtluNGHKlnCLw+zxD1AKlQUrYUnCyGOqEv9RfgEnBWadpqO3nYj0wxZQtglRvbYLlZEYXafg==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-kms" "1.32.0"
-    "@aws-cdk/aws-lambda" "1.32.0"
-    "@aws-cdk/aws-s3" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-certificatemanager" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-kms" "1.32.2"
+    "@aws-cdk/aws-lambda" "1.32.2"
+    "@aws-cdk/aws-s3" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-cloudwatch@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.32.0.tgz#daac3a8cf92151a617e9e57b8f5b744774cebfac"
-  integrity sha512-JGxES/zE84BM61xvgjERWB7kwk6pLSM02TA8RfDMWpvzujbncHwzoEXVkQPlFyDqaR/2/i4mdJx10jGVnhvvmw==
+"@aws-cdk/aws-cloudwatch@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-cloudwatch/-/aws-cloudwatch-1.32.2.tgz#906d7a61de99d2dfb501b172fda33b5537b7a094"
+  integrity sha512-QbrkIKqs6hn5SnFFdVzZTx09Esr3Kd7md/Nrkq96vfp8UVW0d+6sTUZdeXppF+qvu8WOGradZWOKUd6RwPfyyg==
   dependencies:
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-dynamodb@^1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-dynamodb/-/aws-dynamodb-1.32.0.tgz#a7de061557f045805e4f5b8e5c534cb6d62f6ae2"
-  integrity sha512-vsfykJLNIXLojlPaFeAOjYla7PvtsKx1yfjlvu72X9SczwCsiLnSFsftKxV7s05Plj33HamQPIM2kbhoYznczw==
+"@aws-cdk/aws-dynamodb@^1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-dynamodb/-/aws-dynamodb-1.32.2.tgz#364da2b41c0f116cfd9542f1eaf84a59bf240b2d"
+  integrity sha512-xDCKHTf5lCp9YTjnez3YhaAtTliEeFzWXVMNHIa6JtptCBn016IAtu1ruSTSiei8x1r58DYTNS/EAujxwYHuVQ==
   dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.32.0"
-    "@aws-cdk/aws-cloudformation" "1.32.0"
-    "@aws-cdk/aws-cloudwatch" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-lambda" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
-    "@aws-cdk/custom-resources" "1.32.0"
+    "@aws-cdk/aws-applicationautoscaling" "1.32.2"
+    "@aws-cdk/aws-cloudformation" "1.32.2"
+    "@aws-cdk/aws-cloudwatch" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-lambda" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
+    "@aws-cdk/custom-resources" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-ec2@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ec2/-/aws-ec2-1.32.0.tgz#4a1f5f66ffbdfcf03150773d4cfd7ad07b9a8afd"
-  integrity sha512-AhiEqPYFukqT376PiNak7nUrBwyzdGPIdSmjeDQQbtQHvp2HInFK+3j0/kZxhKJvGW9KWMktxNjU3ntiVNU+CA==
+"@aws-cdk/aws-ec2@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ec2/-/aws-ec2-1.32.2.tgz#ac7031a797ad4bd4a72c9967d0b353415d5aebac"
+  integrity sha512-hYEWRYsXH+6QBx6OZH3wvUTKYeu9qnVdOsi1v4JHyfhGLeAvQIhSGTq9G2HtEyRs68svlJivAbDoYexaI3mFHg==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-logs" "1.32.0"
-    "@aws-cdk/aws-s3" "1.32.0"
-    "@aws-cdk/aws-ssm" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
-    "@aws-cdk/cx-api" "1.32.0"
+    "@aws-cdk/aws-cloudwatch" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-logs" "1.32.2"
+    "@aws-cdk/aws-s3" "1.32.2"
+    "@aws-cdk/aws-ssm" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
+    "@aws-cdk/cx-api" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-ecr-assets@1.32.0", "@aws-cdk/aws-ecr-assets@^1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.32.0.tgz#e7557025fc45254774a0a64155592181cc744cb8"
-  integrity sha512-ca7adPx0VA2WOOKttkHR5zj7aKD/uWuWBG5nfonpe1LZBIftWZ+yuGyQrlYy2LtbXMGc5zTkuMTCpzVRJgrMsQ==
+"@aws-cdk/aws-ecr-assets@1.32.2", "@aws-cdk/aws-ecr-assets@^1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr-assets/-/aws-ecr-assets-1.32.2.tgz#b5f49e0068e52a498e9390e560587410c7f832e6"
+  integrity sha512-j8pjvY4WC70RmKHlIa8gBgJ2TSTDmpUmxloypC5QGHGkz3SSJRJrwhE7UMZ10zK2FgTErjgfHuXgW1FW97C8Yw==
   dependencies:
-    "@aws-cdk/assets" "1.32.0"
-    "@aws-cdk/aws-cloudformation" "1.32.0"
-    "@aws-cdk/aws-ecr" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-lambda" "1.32.0"
-    "@aws-cdk/aws-s3" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
-    "@aws-cdk/cx-api" "1.32.0"
+    "@aws-cdk/assets" "1.32.2"
+    "@aws-cdk/aws-cloudformation" "1.32.2"
+    "@aws-cdk/aws-ecr" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-lambda" "1.32.2"
+    "@aws-cdk/aws-s3" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
+    "@aws-cdk/cx-api" "1.32.2"
     constructs "^2.0.0"
     minimatch "^3.0.4"
 
-"@aws-cdk/aws-ecr@1.32.0", "@aws-cdk/aws-ecr@^1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr/-/aws-ecr-1.32.0.tgz#bf4c8d5eabb88845524995385e3d2437786577c1"
-  integrity sha512-wKRLtjaej/IqkDLy8d3hTatjcBwMsIcpUFV8IVy8/JHehaLpVZLVw2lQ3nvuPsF/nXJZr+NEOh7BIpXLhLQgGw==
+"@aws-cdk/aws-ecr@1.32.2", "@aws-cdk/aws-ecr@^1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecr/-/aws-ecr-1.32.2.tgz#4a43f399d68a531f1373eaf582156530e64d30ce"
+  integrity sha512-RVuhl4Jq/1sIAW3P5catwCCMlESU6UfH6BsTz2gNbtYm5yjn5qGtr8sxortca2OToMBO8iYtkk/Dev4/w3nOiA==
   dependencies:
-    "@aws-cdk/aws-events" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-events" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-ecs@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecs/-/aws-ecs-1.32.0.tgz#b1518aa87f5fe9e6d0c6fbcf2d017ca8818c820f"
-  integrity sha512-YgE7rr5png/brKE3H1yOjN/QQYlFYuRfNvcwS9Lfa/+1BOYsYL1zvfN5mNxRd2ixp03ou+l8UEvmwAy74wkyPA==
+"@aws-cdk/aws-ecs@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ecs/-/aws-ecs-1.32.2.tgz#23ed3e03754ec1819deb40acbfa9ce82d552a10a"
+  integrity sha512-pSCvWzztvLKvnl3UeRA+HK3ZIJu32LmxrbuIW9kNey05Ms75ZUxGgJVqiO76kjbbIP2MZPRmDw9v5WU2fJinZQ==
   dependencies:
-    "@aws-cdk/aws-applicationautoscaling" "1.32.0"
-    "@aws-cdk/aws-autoscaling" "1.32.0"
-    "@aws-cdk/aws-autoscaling-hooktargets" "1.32.0"
-    "@aws-cdk/aws-certificatemanager" "1.32.0"
-    "@aws-cdk/aws-cloudformation" "1.32.0"
-    "@aws-cdk/aws-cloudwatch" "1.32.0"
-    "@aws-cdk/aws-ec2" "1.32.0"
-    "@aws-cdk/aws-ecr" "1.32.0"
-    "@aws-cdk/aws-ecr-assets" "1.32.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.32.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-lambda" "1.32.0"
-    "@aws-cdk/aws-logs" "1.32.0"
-    "@aws-cdk/aws-route53" "1.32.0"
-    "@aws-cdk/aws-route53-targets" "1.32.0"
-    "@aws-cdk/aws-secretsmanager" "1.32.0"
-    "@aws-cdk/aws-servicediscovery" "1.32.0"
-    "@aws-cdk/aws-sns" "1.32.0"
-    "@aws-cdk/aws-sqs" "1.32.0"
-    "@aws-cdk/aws-ssm" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
-    "@aws-cdk/cx-api" "1.32.0"
+    "@aws-cdk/aws-applicationautoscaling" "1.32.2"
+    "@aws-cdk/aws-autoscaling" "1.32.2"
+    "@aws-cdk/aws-autoscaling-hooktargets" "1.32.2"
+    "@aws-cdk/aws-certificatemanager" "1.32.2"
+    "@aws-cdk/aws-cloudformation" "1.32.2"
+    "@aws-cdk/aws-cloudwatch" "1.32.2"
+    "@aws-cdk/aws-ec2" "1.32.2"
+    "@aws-cdk/aws-ecr" "1.32.2"
+    "@aws-cdk/aws-ecr-assets" "1.32.2"
+    "@aws-cdk/aws-elasticloadbalancing" "1.32.2"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-lambda" "1.32.2"
+    "@aws-cdk/aws-logs" "1.32.2"
+    "@aws-cdk/aws-route53" "1.32.2"
+    "@aws-cdk/aws-route53-targets" "1.32.2"
+    "@aws-cdk/aws-secretsmanager" "1.32.2"
+    "@aws-cdk/aws-servicediscovery" "1.32.2"
+    "@aws-cdk/aws-sns" "1.32.2"
+    "@aws-cdk/aws-sqs" "1.32.2"
+    "@aws-cdk/aws-ssm" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
+    "@aws-cdk/cx-api" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-elasticloadbalancing@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.32.0.tgz#883a6f644624d34c9c0bc97c556041ce526461e0"
-  integrity sha512-Uy2deSlgZZ6t9Dy9SyjMF6sc7odPkbdP/Kfhoy590DEhb8kuqlw2DW+kOlETny+eYEHzilncIckVuCfkYzsm/Q==
+"@aws-cdk/aws-elasticloadbalancing@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancing/-/aws-elasticloadbalancing-1.32.2.tgz#9b2abb30ec3a9127a4019dd1472622abfe2d8095"
+  integrity sha512-3SCj5r0OKJ1EuxhBpI0ZiS/LlV0ZJgN9pXUzZIg5UoQwTJTS4m/aprqnjTdU8RO2H7xqmvKvVvd9hTBICNsC2g==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-ec2" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-elasticloadbalancingv2-targets@^1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancingv2-targets/-/aws-elasticloadbalancingv2-targets-1.32.0.tgz#84ae9d998866a5665b4eaa0d21512fe7227a986d"
-  integrity sha512-mStM/+eZpd03t3mrXYrpODZf/U/wLGie0mI4M5+OSx/JtjjA8U8J3BOfm3dhwztvtev6KmyWERgXl87ZhhxrDA==
+"@aws-cdk/aws-elasticloadbalancingv2-targets@^1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancingv2-targets/-/aws-elasticloadbalancingv2-targets-1.32.2.tgz#1b93fba49b2e95601585f07ed5b3fdc31c02a52f"
+  integrity sha512-GCMH45Gh06MqKQh4EOLYrmMKWVmLE+GiQuKp2wlQL/HskCcMV4fnf6yrHnDyjO+GEn0gQZN6ppyjYMxzPqP7Sw==
   dependencies:
-    "@aws-cdk/assets" "1.32.0"
-    "@aws-cdk/aws-ec2" "1.32.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-lambda" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/assets" "1.32.2"
+    "@aws-cdk/aws-ec2" "1.32.2"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-lambda" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-elasticloadbalancingv2@1.32.0", "@aws-cdk/aws-elasticloadbalancingv2@^1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.32.0.tgz#07616022eb088e0b5204af75ef07b8784242cce5"
-  integrity sha512-uvCV2Y93/woAetBx/Y1DLvESgx/HpO+2F8Cu5cNUNwAc5yTiPj8hM6MDU/xYTzG7wWqVC6sgGoyZbfzaNzfArA==
+"@aws-cdk/aws-elasticloadbalancingv2@1.32.2", "@aws-cdk/aws-elasticloadbalancingv2@^1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-elasticloadbalancingv2/-/aws-elasticloadbalancingv2-1.32.2.tgz#944498f1ffe148a390ae34af0a3c6a1fe37c89e3"
+  integrity sha512-hyntuMSOETzLS/FU3TcLu5X3HQzlFJuzD22BBa3wo6I7BHysyzgUCiVIGZI8ylOtJnW1sJUXMPo1fHCW3fVrWA==
   dependencies:
-    "@aws-cdk/aws-certificatemanager" "1.32.0"
-    "@aws-cdk/aws-cloudwatch" "1.32.0"
-    "@aws-cdk/aws-ec2" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-lambda" "1.32.0"
-    "@aws-cdk/aws-s3" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-certificatemanager" "1.32.2"
+    "@aws-cdk/aws-cloudwatch" "1.32.2"
+    "@aws-cdk/aws-ec2" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-lambda" "1.32.2"
+    "@aws-cdk/aws-s3" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-events@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events/-/aws-events-1.32.0.tgz#d7961b288c00e47c8e5a95abcfff8843a338509d"
-  integrity sha512-mhtjRZIipvalJ68jts1YFm2qXWYNeKC5/eumGlxxM7Mi4V4BHCqE946ZVIUXsIbWxAQgJs3EB9XUEgTH3hvmUA==
+"@aws-cdk/aws-events@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-events/-/aws-events-1.32.2.tgz#664130414bc4772d20dba1b3710451b890c2b643"
+  integrity sha512-HmgngkQVE8ePAfy62dMb6bFzLT2XywrNb7JkcOk/u8VOCdWxMX10fk3YjMoNBknYdMaPolvDFPFURkWCsoMOSw==
   dependencies:
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-glue@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-glue/-/aws-glue-1.32.0.tgz#f78290567d90af68aefccc1ad46e6c5599680869"
-  integrity sha512-wNH2zTgOUKsClQjpMdu2fbf2ZWP3gRd98w7BYZm4kmWv3YFfajA4Qqui6vQ2Uef3/sigDG0l97Gzd+MERuvSsA==
+"@aws-cdk/aws-glue@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-glue/-/aws-glue-1.32.2.tgz#a0244aade3d8dae3b18c608c24df088d5362dee5"
+  integrity sha512-TSqJjbKLv9Px1qsGk+lqBsecpM28a9pxT+pnbMmCA3VUC3RvxtL6Sex0O27f6pMhbeYoWwXnYfe+GCr7Z8lbjw==
   dependencies:
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-kms" "1.32.0"
-    "@aws-cdk/aws-s3" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-kms" "1.32.2"
+    "@aws-cdk/aws-s3" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-iam@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iam/-/aws-iam-1.32.0.tgz#3a93c463d7337a25a92e535c309860d2c6734cc3"
-  integrity sha512-IdcA29eZsAv6qZ/D3JDwXTfuF9gdaMTwEWnzy9Ra2aJlbEMVC91DgEm7kv2C6ir+nli0NwTU816tM6wO2mvRpg==
+"@aws-cdk/aws-iam@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-iam/-/aws-iam-1.32.2.tgz#ffe3a9714a4a4ac8d7921f1c4889fea039500c65"
+  integrity sha512-fRFQCUBH7L3xUfzFExB2UCfv8bc5yxUbWh9oOqy3uawSP9g6eqgZZutCUp2qkCFfuJFe/gbFIWacpqvM9rQ7Sg==
   dependencies:
-    "@aws-cdk/core" "1.32.0"
-    "@aws-cdk/region-info" "1.32.0"
+    "@aws-cdk/core" "1.32.2"
+    "@aws-cdk/region-info" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-kms@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kms/-/aws-kms-1.32.0.tgz#941614c989b6ec13398d453f7f47376c82e69b82"
-  integrity sha512-OUxl55jr9oaQIIYndt4s5TygHtjHMFS5izuhptVe3Z52NecBNaptU+BM1gIFNRbx8RcVIv0LJHWGek1jdSOVig==
+"@aws-cdk/aws-kms@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-kms/-/aws-kms-1.32.2.tgz#be6ecc7d755e96285f8b3090b7a9e764c5edbd05"
+  integrity sha512-yjINmHXSd5r/XpqGuW0W5memx/LFMb4gKASDSbQPP4KZsP3xlJBQ1+t+ONeVe5iCJpAnh8uTCRNxgZ6CpopOrQ==
   dependencies:
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-lambda@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda/-/aws-lambda-1.32.0.tgz#aa8509d4db09a2d01c68740b76d05eb5aebb56de"
-  integrity sha512-4M6hJVO+IhullQIcgwzvJ74TSz66KTdAbmW8+jV39xmLA7NQDN2aEzMdcG7lJnjcAYusUFF8P3GcYFy35rGg5g==
+"@aws-cdk/aws-lambda@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-lambda/-/aws-lambda-1.32.2.tgz#2246602eb51865a02d9fac1e0674a25afb21889e"
+  integrity sha512-CXHhpYySI6osPQH05Pr4NbkI9zYjtBQSOC+P9jCbp29mRDw2H7hyMgAjKpfrdnjXfUB5uR9dObrxxTIHG3Nwkw==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.32.0"
-    "@aws-cdk/aws-ec2" "1.32.0"
-    "@aws-cdk/aws-events" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-logs" "1.32.0"
-    "@aws-cdk/aws-s3" "1.32.0"
-    "@aws-cdk/aws-s3-assets" "1.32.0"
-    "@aws-cdk/aws-sqs" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
-    "@aws-cdk/cx-api" "1.32.0"
+    "@aws-cdk/aws-cloudwatch" "1.32.2"
+    "@aws-cdk/aws-ec2" "1.32.2"
+    "@aws-cdk/aws-events" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-logs" "1.32.2"
+    "@aws-cdk/aws-s3" "1.32.2"
+    "@aws-cdk/aws-s3-assets" "1.32.2"
+    "@aws-cdk/aws-sqs" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
+    "@aws-cdk/cx-api" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-logs@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-logs/-/aws-logs-1.32.0.tgz#22495a2c039887d2f39c8a44324cb674e64411b6"
-  integrity sha512-PLMuCUSuNJea7eCjVQ2KDFDBhjDVk9R/iD10dzRC7Xv1uIf9NWHglQzHd7UOkOJotFd9SM8//pGG+zG8vaVNdA==
+"@aws-cdk/aws-logs@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-logs/-/aws-logs-1.32.2.tgz#c1002ed61cfd347f620f4c4c1f0662c3415c7c4a"
+  integrity sha512-wgR/OUraOumK9DCktO0w3+8W1pLm/9nwuYurigzahQTBZ35ueJfy7xUJ1yybjE5pGEV60IC+ps82hKCRK67obw==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-cloudwatch" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-route53-targets@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.32.0.tgz#7aa89460ce6f90903dbb9ccd9f3988a7197a2706"
-  integrity sha512-Yc1FoLTqPQo4sV4M/nOxQFOQinhRsffuRvPnF+nZug8YT/dgZlabhj+2x0Afui/XRUyPlOElM9GLx+QRKXXNew==
+"@aws-cdk/aws-route53-targets@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53-targets/-/aws-route53-targets-1.32.2.tgz#1c3bbd0393df09aae99c84e82fc5b07eff9ae0c2"
+  integrity sha512-doJVhFPimDz/eUIp6IliD+XXs3WjyT+KE0mfR57p2I4a9FRvcu2qv+HNTXAdkQfzL05w4xYvxqeDYnwNe9Faaw==
   dependencies:
-    "@aws-cdk/aws-apigateway" "1.32.0"
-    "@aws-cdk/aws-cloudfront" "1.32.0"
-    "@aws-cdk/aws-ec2" "1.32.0"
-    "@aws-cdk/aws-elasticloadbalancing" "1.32.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-route53" "1.32.0"
-    "@aws-cdk/aws-s3" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
-    "@aws-cdk/region-info" "1.32.0"
+    "@aws-cdk/aws-apigateway" "1.32.2"
+    "@aws-cdk/aws-cloudfront" "1.32.2"
+    "@aws-cdk/aws-ec2" "1.32.2"
+    "@aws-cdk/aws-elasticloadbalancing" "1.32.2"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-route53" "1.32.2"
+    "@aws-cdk/aws-s3" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
+    "@aws-cdk/region-info" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-route53@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53/-/aws-route53-1.32.0.tgz#31c816d8c7ae9bc1a0ed72fbbe848b0f4f22cf41"
-  integrity sha512-uNJWw70SC+NJnNwWYGswH4e6rD9q0m5R4TRxM3j9r2Y1l3hyh9ywD8kd21UQ0s72Clll7xG9nbi3p+z5Q/OwPA==
+"@aws-cdk/aws-route53@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-route53/-/aws-route53-1.32.2.tgz#ffa55ffb4655e9a29aaa0e3e7d2dcf9c333c21ed"
+  integrity sha512-veMCXXm/aFtntxe65WZB7LZpGWY/CBy64k9Ml+4MysSKqp9znO8vBiYQgjOc6sfsb1KC+5VJJs49EZXetoOsaQ==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.32.0"
-    "@aws-cdk/aws-logs" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
-    "@aws-cdk/cx-api" "1.32.0"
+    "@aws-cdk/aws-ec2" "1.32.2"
+    "@aws-cdk/aws-logs" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
+    "@aws-cdk/cx-api" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-s3-assets@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.32.0.tgz#f79de0ed4f63f72d9631ee3503c93e055f65f309"
-  integrity sha512-EYGlbJp8qzMw44vFUxb4rtF6XVfcZkSrKuKwM97d8Ixr/bCyooS7naYkBEzA0iDOy+fdEtnLjYSiOYuxp+7qIw==
+"@aws-cdk/aws-s3-assets@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3-assets/-/aws-s3-assets-1.32.2.tgz#d78a2b85ae2a2fc5262818b0dc969df735aed372"
+  integrity sha512-Tm+957UkyxJAznvSTbOR7aZ1kcukXLm8Ya/jvaz/rX39j4B57sPA+OwGyiSRSVJ9E7JvfGRyht9nVf2JW9o8Ng==
   dependencies:
-    "@aws-cdk/assets" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-s3" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
-    "@aws-cdk/cx-api" "1.32.0"
+    "@aws-cdk/assets" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-s3" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
+    "@aws-cdk/cx-api" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-s3@1.32.0", "@aws-cdk/aws-s3@^1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3/-/aws-s3-1.32.0.tgz#8bc59acc997a63342c0e12d6aedbce7fcacbf31a"
-  integrity sha512-QQ5/5BL4k7/A/iohfmqb4e2pgcZCEfyjp+JE3L4Nh4e1GHoKGoE3oPUDePKNxQVjaaC81xIlQrELDAsZ39sjrQ==
+"@aws-cdk/aws-s3@1.32.2", "@aws-cdk/aws-s3@^1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-s3/-/aws-s3-1.32.2.tgz#7deff0f42f487d4096596544bf61713b6f409030"
+  integrity sha512-11Jxbo7e1V9HkGzJB2mr+VPUyf98D7rFKK4hGaXMicXQE4o1OLuTvGdU4Zw/EmlmGQf5PtCLHBhzy9au+Bnekw==
   dependencies:
-    "@aws-cdk/aws-events" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-kms" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-events" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-kms" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-sam@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sam/-/aws-sam-1.32.0.tgz#8ba413f2a0c0d997f8162be14baa929f6261c3d8"
-  integrity sha512-B3Z7C4XXYPLJWbomLhPVg2PKz4t5mF6qhvXIBZ2S8LZ8E7rlaBUJgVa2XhphOSK5DkBqSwOmzG/dZRwKtU2iOw==
+"@aws-cdk/aws-sam@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sam/-/aws-sam-1.32.2.tgz#5711b89767c1b73d91c46b1d370a8895c8d9ab57"
+  integrity sha512-8jaYRtvDpqEoCtPcYqpHbeJ2yx7prDAkrNMppq7Vm5t4i4rWcPzN8mA4lKIYJ0bhMz2y3PxcOx0bPWsWDJ0i3Q==
   dependencies:
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-secretsmanager@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.32.0.tgz#0fedffee1ce16fc42a6a40ab4d0a4117285586f1"
-  integrity sha512-PEC0wmShkmtM5U+17J9iROQBX0uNxWHLNtLG1ZtCXgkPOBUz5hdCswDeKpUStbld7FKmKvGmaFWksCdMtJLHRA==
+"@aws-cdk/aws-secretsmanager@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-secretsmanager/-/aws-secretsmanager-1.32.2.tgz#c639eb6f4907a6298737081eda59a7dcb6dda6b0"
+  integrity sha512-oGEQJTZnvBptV2EckWayzmK1RsedhsOSfQOKw7p+7H/Ox5qgfMozGPq4VwpXE/xfuxxFhHP42qm0dT6XdPGtDw==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-kms" "1.32.0"
-    "@aws-cdk/aws-lambda" "1.32.0"
-    "@aws-cdk/aws-sam" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-ec2" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-kms" "1.32.2"
+    "@aws-cdk/aws-lambda" "1.32.2"
+    "@aws-cdk/aws-sam" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-servicediscovery@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-1.32.0.tgz#8a8ce7d9cb8297f7c4930a688e6d146eb9732526"
-  integrity sha512-dPrSihHq2nIoc4qyJA2usdClqUFOyl5S6dtV00f58Z4vwUju2WC/uITQQQL32B0Yq5WLuZm8PiFXdfhhQrH8rA==
+"@aws-cdk/aws-servicediscovery@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-servicediscovery/-/aws-servicediscovery-1.32.2.tgz#d7dd64121ddbd8f74d4de1a1e7cafc7a3da22aab"
+  integrity sha512-PEZG2U7illtKCIJCtKv0pZ8N4rqZIxzxT3kOgATWk4rmlaY3BEGfxpKRzzDre93YyrDcEn1rsSfSh9PiU9m6qw==
   dependencies:
-    "@aws-cdk/aws-ec2" "1.32.0"
-    "@aws-cdk/aws-elasticloadbalancingv2" "1.32.0"
-    "@aws-cdk/aws-route53" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-ec2" "1.32.2"
+    "@aws-cdk/aws-elasticloadbalancingv2" "1.32.2"
+    "@aws-cdk/aws-route53" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-sns-subscriptions@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.32.0.tgz#5f7f87be0fa07239c5dd52710589ad8fcdd1021b"
-  integrity sha512-+XA4LnAQG1G8Az+IZB1WVzfvI2kUch15BHif2n2W6Rn6n4dR5kf/QRQ5C/0uMsoe4ds8dRh+3ANG3sUhEN090w==
+"@aws-cdk/aws-sns-subscriptions@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns-subscriptions/-/aws-sns-subscriptions-1.32.2.tgz#13fec7e00f481dbb6c5c85012963f51dcc0da1b0"
+  integrity sha512-Y9NgIREAU5mtCoOGPqHzR9jNEvp69mBYm3k6kyMLSpNxOAakW27uHxXD/ZnYrJWGffTLUJyfdSNuPxkOFTYrQw==
   dependencies:
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-lambda" "1.32.0"
-    "@aws-cdk/aws-sns" "1.32.0"
-    "@aws-cdk/aws-sqs" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-lambda" "1.32.2"
+    "@aws-cdk/aws-sns" "1.32.2"
+    "@aws-cdk/aws-sqs" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-sns@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns/-/aws-sns-1.32.0.tgz#c427438f46337b90c3b80d85b5a93d60d4bd47ca"
-  integrity sha512-KX3IWJ9BuOwnwDPXs3cI67wbofmzpyX9QTiQCbljw/n0n2VU2+tRRCct+13z+dIVONisZHlcjqJ7fiLRZdtmXg==
+"@aws-cdk/aws-sns@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sns/-/aws-sns-1.32.2.tgz#0f1b391c47a818fbcc42bddd18438d0341bae79b"
+  integrity sha512-gGDIMwxjjf/2HltOJa8j2nGm/9Ck6bVddsm/a212abkxqXtPccNoZFyINFsONn+XA4jf+ikIfiT5SEgV4myGPA==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.32.0"
-    "@aws-cdk/aws-events" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-kms" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-cloudwatch" "1.32.2"
+    "@aws-cdk/aws-events" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-kms" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-sqs@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sqs/-/aws-sqs-1.32.0.tgz#d7de2bbbbf9f20819d6928d1327cfb1894ded6fd"
-  integrity sha512-WUYrpLTIWRA/FihoJkifBOOYXDun1hhivg4jrX8TZQ6XpnYgmV22GtbFrFCo+wJYFI/rD9T5UtLswEHJf0FPFQ==
+"@aws-cdk/aws-sqs@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-sqs/-/aws-sqs-1.32.2.tgz#d32baf37bff0a8706cb6490ec0c4c278c0ad7726"
+  integrity sha512-W82cMHO5OsNrapB5gjF+Gw/mOQahug5BZWAJ0AZ0BFyPJr/p30zCjIkJpmC1Ep9WtZCkichC+TJxvt3YJSLRPQ==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-kms" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-cloudwatch" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-kms" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-ssm@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ssm/-/aws-ssm-1.32.0.tgz#34cad8660007b9e636bd4ad13190c5d314c66528"
-  integrity sha512-GCo7mBXoMrzAzAXOkTt4/kqGe11ozgBxtGqAfV6sueNnZTQedNlIZ6SMTP8pcT85zUPBcBrXqu2EBuIGgwzrAg==
+"@aws-cdk/aws-ssm@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-ssm/-/aws-ssm-1.32.2.tgz#68afe9c33fc5eb453f8e0d6c79a29bb33267545f"
+  integrity sha512-sW68/G9NYf3+DsTDDGdT6pKMsujeH0Th8DFMFPl1BCD9wB5EVoS9dNUzKRzuNVHlwgtuSObI3XeWDza6UMy1wQ==
   dependencies:
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-kms" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
-    "@aws-cdk/cx-api" "1.32.0"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-kms" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
+    "@aws-cdk/cx-api" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-stepfunctions-tasks@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-stepfunctions-tasks/-/aws-stepfunctions-tasks-1.32.0.tgz#6e7cbc47d322b0631d9f842145ac36b96cfb1d69"
-  integrity sha512-uZyiHFCHrWi+0LcpBRiTQnLK6I1votBRa43SmJA+9090cEIBc+htljRHi4QzmxtIP7JL8OmbQcdtHTahUsS72Q==
+"@aws-cdk/aws-stepfunctions-tasks@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-stepfunctions-tasks/-/aws-stepfunctions-tasks-1.32.2.tgz#9a24417457345e908e4f7c2e97e0961f8e24fa2d"
+  integrity sha512-t+i+W1ti8ohLq/q2ABFE2lY8GTBv8lloM0JJWq93d3EGuVSCtclsNpAMTkPD7GA3M5/NdoicdYCHxOQNwXZ1tg==
   dependencies:
-    "@aws-cdk/assets" "1.32.0"
-    "@aws-cdk/aws-batch" "1.32.0"
-    "@aws-cdk/aws-cloudwatch" "1.32.0"
-    "@aws-cdk/aws-ec2" "1.32.0"
-    "@aws-cdk/aws-ecr" "1.32.0"
-    "@aws-cdk/aws-ecr-assets" "1.32.0"
-    "@aws-cdk/aws-ecs" "1.32.0"
-    "@aws-cdk/aws-glue" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-kms" "1.32.0"
-    "@aws-cdk/aws-lambda" "1.32.0"
-    "@aws-cdk/aws-s3" "1.32.0"
-    "@aws-cdk/aws-sns" "1.32.0"
-    "@aws-cdk/aws-sqs" "1.32.0"
-    "@aws-cdk/aws-stepfunctions" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/assets" "1.32.2"
+    "@aws-cdk/aws-batch" "1.32.2"
+    "@aws-cdk/aws-cloudwatch" "1.32.2"
+    "@aws-cdk/aws-ec2" "1.32.2"
+    "@aws-cdk/aws-ecr" "1.32.2"
+    "@aws-cdk/aws-ecr-assets" "1.32.2"
+    "@aws-cdk/aws-ecs" "1.32.2"
+    "@aws-cdk/aws-glue" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-kms" "1.32.2"
+    "@aws-cdk/aws-lambda" "1.32.2"
+    "@aws-cdk/aws-s3" "1.32.2"
+    "@aws-cdk/aws-sns" "1.32.2"
+    "@aws-cdk/aws-sqs" "1.32.2"
+    "@aws-cdk/aws-stepfunctions" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/aws-stepfunctions@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.32.0.tgz#415ef3ad0c609b68fd86291e74dbcd345282d6ad"
-  integrity sha512-hrVsgHCN3jPO8oMHilYBNyDl1ymXb7+OH3FZUuQ7MAghJvcbsY05Kg5LfWKamZLOodYllnRqSfw9BcjBQVdxiQ==
+"@aws-cdk/aws-stepfunctions@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-stepfunctions/-/aws-stepfunctions-1.32.2.tgz#faf33fe3f6b3738e3d83dd8492ca719ea61255a9"
+  integrity sha512-7FUBAvpc4JtHAZHFWZ35+FcCycuZKlVwiqPUbARB/a7j8r3F5A0JQCqzrYcXtgFQLZWX0DgEv0Tfi8ZCCV31qw==
   dependencies:
-    "@aws-cdk/aws-cloudwatch" "1.32.0"
-    "@aws-cdk/aws-events" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-logs" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-cloudwatch" "1.32.2"
+    "@aws-cdk/aws-events" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-logs" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/cdk-assets-schema@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cdk-assets-schema/-/cdk-assets-schema-1.32.0.tgz#449b4fe9326293125d5de40106be5582b6377a7f"
-  integrity sha512-DDdnYEKLfC5qqTXgSzMUTrQXWUWA+a/MT4/C4Yh7DWr5Avui4WBEJUh9bjhY/595IsUAH4bKFoYL0me2sdaXyQ==
+"@aws-cdk/cdk-assets-schema@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cdk-assets-schema/-/cdk-assets-schema-1.32.2.tgz#43d1eade28bbf4438080be8c2d4fee45cf0401d7"
+  integrity sha512-mwQ+6JSWPTvY9GqbMp+l7/1ZvFk0aJLchmGmCKtokbLi+2Qf7rYDAIqC26CV7Ilax/A3baxj8BWvaD1xgqYrhA==
   dependencies:
     semver "^7.2.1"
 
-"@aws-cdk/cfnspec@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-1.32.0.tgz#3a1fb5c86628aae916105019d1ae977845c6bfa9"
-  integrity sha512-YtA+QyPEjySB4IMHOliz0mCmrqV41WkzbdMZKPUEbyVRKp02go3dWnWLuoI2dfq7oCRtx17D6118kHxBiqO2vw==
+"@aws-cdk/cfnspec@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cfnspec/-/cfnspec-1.32.2.tgz#fd878830d84fc7fa9ccfc15c8100e13a2c0561d7"
+  integrity sha512-eg6NBCEz5en5p/4qx2xL13zScAdurs3YY4yyD8WaZF+8r4cPuJFxL2khwgAYEXf6USkTK+c8DmuDnePUMHoNdQ==
   dependencies:
     md5 "^2.2.1"
 
-"@aws-cdk/cloudformation-diff@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.32.0.tgz#6c82da94cf967d32d0ea1ce88a72008e7cfd3f40"
-  integrity sha512-eg9n+/G/b4YSPYs1UGDa1x0hF7HyojugNZMqEi26XdqFhVoa/Aba6ExRHVHqjEhbJsrsFvj9mKwotA2HPWSMPg==
+"@aws-cdk/cloudformation-diff@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cloudformation-diff/-/cloudformation-diff-1.32.2.tgz#69f28f8d51d9e5254c1e1f3d511220e99fae5af6"
+  integrity sha512-wcW46kR8HRmOFyPaTWfjmGaQO73KCkJbEhsNxxJjFK6w0j3tlci+ZHPRiq9SBwmYax9M4muqTg6uo3y0oi9etA==
   dependencies:
-    "@aws-cdk/cfnspec" "1.32.0"
+    "@aws-cdk/cfnspec" "1.32.2"
     colors "^1.4.0"
     diff "^4.0.2"
     fast-deep-equal "^3.1.1"
     string-width "^4.2.0"
     table "^5.4.6"
 
-"@aws-cdk/core@1.32.0", "@aws-cdk/core@^1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/core/-/core-1.32.0.tgz#fd9d6d06d738540f705836d0ee072b8bc6f4229c"
-  integrity sha512-kFVdTNGXPnJcxkBQbaUXYKYXN2Z36I9aLvChA/3kr992EXaDG3T607nDFA8ofnYJXhm154hyfsz7CDNEBa6Zmw==
+"@aws-cdk/core@1.32.2", "@aws-cdk/core@^1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/core/-/core-1.32.2.tgz#04b28f4c6bf7118b8184fad0f08979683c95b75a"
+  integrity sha512-gO+LpoGvToUwOGUhEsUAFAuRMjFhQvpbsurzJCEYFs/Je0vHX+b63iC4fkf74aZVHemKkDKY+xdzEAwIvIJB6Q==
   dependencies:
-    "@aws-cdk/cx-api" "1.32.0"
+    "@aws-cdk/cx-api" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/custom-resources@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/custom-resources/-/custom-resources-1.32.0.tgz#cc023f64796608fb15b4041f6ef74c3ed48a6aa8"
-  integrity sha512-iSPN9vOGbkFHvWwYyQKzujKw/AuEEmVgBWlE+0m46MmMpIy4UUrqXYajQycOVNIlvxLVTyRTsgkZvRsCVOJeXA==
+"@aws-cdk/custom-resources@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/custom-resources/-/custom-resources-1.32.2.tgz#6f413b20d864fae344aaccef89e609fbf739f4ad"
+  integrity sha512-YMrzyo3Ip9iSM2tuCAk27pQpuB2xBhnIPdSUJEjmF4gw+siHv+G8x2+fL1aWOdvN5QCodtSYulJFK9ZQ1fUsuw==
   dependencies:
-    "@aws-cdk/aws-cloudformation" "1.32.0"
-    "@aws-cdk/aws-iam" "1.32.0"
-    "@aws-cdk/aws-lambda" "1.32.0"
-    "@aws-cdk/aws-logs" "1.32.0"
-    "@aws-cdk/aws-sns" "1.32.0"
-    "@aws-cdk/aws-stepfunctions" "1.32.0"
-    "@aws-cdk/aws-stepfunctions-tasks" "1.32.0"
-    "@aws-cdk/core" "1.32.0"
+    "@aws-cdk/aws-cloudformation" "1.32.2"
+    "@aws-cdk/aws-iam" "1.32.2"
+    "@aws-cdk/aws-lambda" "1.32.2"
+    "@aws-cdk/aws-logs" "1.32.2"
+    "@aws-cdk/aws-sns" "1.32.2"
+    "@aws-cdk/aws-stepfunctions" "1.32.2"
+    "@aws-cdk/aws-stepfunctions-tasks" "1.32.2"
+    "@aws-cdk/core" "1.32.2"
     constructs "^2.0.0"
 
-"@aws-cdk/cx-api@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.32.0.tgz#d8066b74269f4b6f3e4fbd6ce10e4dbfb7db0a62"
-  integrity sha512-cmqAQm+FpMpXz6Y6tQnTOVHi73uhwv00lqjeDYIl91zTmuXib8EU1ggjO00/BKrx7VOl2odczOVLLAkOIWZjHw==
+"@aws-cdk/cx-api@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/cx-api/-/cx-api-1.32.2.tgz#d3d5f8ff37721941270e29b63bee4f41c58845e8"
+  integrity sha512-+QRa35r/54TTwegy8sLZLIwo1kAlQfYQtJ8KvlpapK7jvwJpbdQYjbPR/n0dYVmlTNb/R5Wb9+ulr5EYfJlXUw==
   dependencies:
     semver "^7.2.1"
 
-"@aws-cdk/region-info@1.32.0":
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.32.0.tgz#b13cd054d98f704d60c31fa5c6a5b715bed31dc6"
-  integrity sha512-HpFMSdtkklTwoxwCjc17jjGSw+xSRws0ftEXeUvjVA/cOmgKOlqdrkZDsKePKJDWAwqGcRoq7yxlN/3SyB/GPA==
+"@aws-cdk/region-info@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/region-info/-/region-info-1.32.2.tgz#41697d75c2da0151bd3edcfb0c554134bb215429"
+  integrity sha512-ssXm6oWpghBWQPOVHf7TZqjcYiLMqc6K7pNGbZYn/Lm7d1HMtAFoOZAsREoVluACWYRPrG/lT17zZzb5ArKObg==
 
 "@babel/code-frame@^7.0.0":
   version "7.8.3"
@@ -2223,19 +2223,19 @@ atomic-sleep@^1.0.0:
   resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
   integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
 
-aws-cdk@^1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-1.32.0.tgz#659e2079deb684e39c1c504f9adddeb07cf6b7ef"
-  integrity sha512-u+3yWG/TCpVkSgRztbHQZIfDZeEmAognl3b1H8HPE4lVj7LeLvt90YH7HVf0N00ZiJFUAkiKre8cu5RCG1QYeA==
+aws-cdk@^1.32.2:
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-1.32.2.tgz#b4c89e7bbb61e316756bdb6ed1be0c909b0fb0da"
+  integrity sha512-nBVTSb2HcOBxhfK3TP47BlYO1AzWD3OpRVJ8CLzy0/waDMheKAbfj9MERxBuBR6fkcW+rqiaaEFUkGMD14qX6g==
   dependencies:
-    "@aws-cdk/cdk-assets-schema" "1.32.0"
-    "@aws-cdk/cloudformation-diff" "1.32.0"
-    "@aws-cdk/cx-api" "1.32.0"
-    "@aws-cdk/region-info" "1.32.0"
+    "@aws-cdk/cdk-assets-schema" "1.32.2"
+    "@aws-cdk/cloudformation-diff" "1.32.2"
+    "@aws-cdk/cx-api" "1.32.2"
+    "@aws-cdk/region-info" "1.32.2"
     archiver "^3.1.1"
     aws-sdk "^2.654.0"
     camelcase "^6.0.0"
-    cdk-assets "1.32.0"
+    cdk-assets "1.32.2"
     colors "^1.4.0"
     decamelize "^4.0.0"
     fs-extra "^8.1.0"
@@ -2634,12 +2634,12 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-cdk-assets@1.32.0:
-  version "1.32.0"
-  resolved "https://registry.yarnpkg.com/cdk-assets/-/cdk-assets-1.32.0.tgz#93188eb71c0e268e9ea02e46919703766d8b882a"
-  integrity sha512-rwFbTycy91bIWD4LGEZI9I8dROjVcnSkh6MN82XCw29Uxy9ov6yfBi2h1ifYtzMbzqDLJBWmTw4GgINNlcaH3Q==
+cdk-assets@1.32.2:
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/cdk-assets/-/cdk-assets-1.32.2.tgz#98e0865040f8a646bc122bddc214f4705c0d4a42"
+  integrity sha512-WML4QrfIg8exwKunvK8j8FTQ4b0+qLVObnIjbFoad/7ftU7jXbgCfJC5M73mnE90WZnELnArFLOJWEhRagnyfw==
   dependencies:
-    "@aws-cdk/cdk-assets-schema" "1.32.0"
+    "@aws-cdk/cdk-assets-schema" "1.32.2"
     archiver "^3.1.1"
     aws-sdk "^2.654.0"
     glob "^7.1.6"


### PR DESCRIPTION
Upgrades aws-cdk to 1.32.2

Removes excess await