### PR TITLE
fix(cutline): ignore path when updating vrt

### DIFF
--- a/packages/cog/src/cog/__test__/cog.cutline.test.ts
+++ b/packages/cog/src/cog/__test__/cog.cutline.test.ts
@@ -12,6 +12,7 @@ o.spec('cog.cutline', () => {
     const job = {
         source: {
             files: [] as string[],
+            path: '',
             options: {
                 maxConcurrency: 3,
                 maxCogs: 3,
@@ -60,6 +61,9 @@ o.spec('cog.cutline', () => {
 
         const [tif1, tif2] = [1, 2].map((i) => `${testDir}/tif${i}.tiff`);
 
+        const vtif1 = '/vsis3/' + tif1,
+            vtif2 = '/vsis3/' + tif2;
+
         const tif1Poly = [
             [174.56568549279925, -40.83842049282911],
             [174.57337757492053, -41.162595138463644],
@@ -92,7 +96,7 @@ o.spec('cog.cutline', () => {
   <VRTRasterBand dataType="Byte" band="${i + 1}">
     <HideNoDataValue>1</HideNoDataValue>
     <ColorInterp>${c}</ColorInterp>
-    ${tifs.map((n) => (c === 'alpha' ? complexSource(n) : simpleSource(n, i + 1))).join('\n')}
+    ${tifs.map((n) => (c === 'alpha' ? complexSource(n) : simpleSource('/vsis3/' + n, i + 1))).join('\n')}
   </VRTRasterBand>`,
             );
 
@@ -124,7 +128,7 @@ o.spec('cog.cutline', () => {
 
             const vrt = await Cutline.buildVrt(tmpFolder, job, sourceGeo, makeVrtString(), '313', logger);
 
-            o(Array.from(vrt.tags('SourceFilename')).map((e) => e.textContent)).deepEquals([tif2, tif2]);
+            o(Array.from(vrt.tags('SourceFilename')).map((e) => e.textContent)).deepEquals([vtif2, vtif2]);
         });
 
         o('not within quadKey', async () => {
@@ -139,7 +143,12 @@ o.spec('cog.cutline', () => {
         o('no cutline', async () => {
             const vrt = await Cutline.buildVrt(tmpFolder, job, sourceGeo, makeVrtString(), '31', logger);
 
-            o(Array.from(vrt.tags('SourceFilename')).map((e) => e.textContent)).deepEquals([tif1, tif2, tif1, tif2]);
+            o(Array.from(vrt.tags('SourceFilename')).map((e) => e.textContent)).deepEquals([
+                vtif1,
+                vtif2,
+                vtif1,
+                vtif2,
+            ]);
             o(cutTiffArgs.length).equals(0);
         });
 
@@ -150,7 +159,7 @@ o.spec('cog.cutline', () => {
 
             const vrt = await Cutline.buildVrt(tmpFolder, job, sourceGeo, makeVrtString(), qkey, logger);
 
-            o(Array.from(vrt.tags('SourceFilename')).map((e) => e.textContent)).deepEquals([tif2, tif2]);
+            o(Array.from(vrt.tags('SourceFilename')).map((e) => e.textContent)).deepEquals([vtif2, vtif2]);
             o(cutTiffArgs.length).equals(0);
         });
 
@@ -178,7 +187,7 @@ o.spec('cog.cutline', () => {
                 ]);
             }
 
-            o(Array.from(vrt.tags('SourceFilename')).map((e) => e.textContent)).deepEquals([tif1, tif1]);
+            o(Array.from(vrt.tags('SourceFilename')).map((e) => e.textContent)).deepEquals([vtif1, vtif1]);
         });
     });
 

--- a/packages/cog/src/cog/cog.cutline.ts
+++ b/packages/cog/src/cog/cog.cutline.ts
@@ -142,7 +142,7 @@ export const Cutline = {
             if (!imgBounds.intersects(tiffBounds.bounds)) continue; // image outside quadKey
 
             if (cutline == null) {
-                useTifs.add(path);
+                useTifs.add(tiffName);
                 continue;
             }
 
@@ -150,7 +150,7 @@ export const Cutline = {
 
             for (const p of polygons) {
                 if (booleanWithin(tiffBounds.poly, p)) {
-                    useTifs.add(path);
+                    useTifs.add(tiffName);
                     foundp.length = 0;
                     break;
                 }
@@ -161,12 +161,12 @@ export const Cutline = {
 
             if (foundp.length != 0) {
                 ++cropped;
-                useTifs.add(path);
+                useTifs.add(tiffName);
                 for (const p of foundp) usePolys.add(p);
             }
         }
 
-        job.source.files = Array.from(useTifs.values());
+        job.source.files = Array.from(useTifs.values()).map((n) => FileOperator.join(job.source.path, n));
 
         if (usePolys.size == 0) {
             job.output.cutline = undefined;
@@ -179,8 +179,8 @@ export const Cutline = {
             for (const elm of b.elementChildren()) {
                 if (elm.tag === 'SimpleSource' || elm.tag === 'ComplexSource') {
                     const sf = elm.tags('SourceFilename').next().value!;
-                    const path = sf.textContent;
-                    if (!useTifs.has(path)) continue;
+                    const name = basename(sf.textContent);
+                    if (!useTifs.has(name)) continue;
                 }
                 children.push(elm);
             }


### PR DESCRIPTION
#### Fixes
s3 paths are different for gdal /vsis3/ rather than s3://

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
