### PR TITLE
refactor(cog): remove global-mercator npm

### DIFF
--- a/packages/cog/package.json
+++ b/packages/cog/package.json
@@ -27,7 +27,6 @@
     "chalk": "^4.0.0",
     "p-limit": "^2.2.1",
     "pretty-json-log": "^0.2.2",
-    "global-mercator": "^3.1.0",
     "proj4": "^2.6.0"
   },
   "devDependencies": {

--- a/packages/cog/src/cog/builder.ts
+++ b/packages/cog/src/cog/builder.ts
@@ -6,7 +6,7 @@ import { createHash } from 'crypto';
 import { existsSync, mkdirSync } from 'fs';
 import pLimit, { Limit } from 'p-limit';
 import * as path from 'path';
-import { getProjection, guessProjection } from '../proj';
+import { getProjection } from '../proj';
 import { Covering } from './covering';
 import { JobCutline } from './job.cutline';
 import { CogBuilderMetadata, SourceMetadata } from './types';
@@ -134,7 +134,7 @@ export class CogBuilder {
         }
 
         const imgWkt = image.value(TiffTag.GeoAsciiParams);
-        projection = guessProjection(imgWkt) as number;
+        projection = Projection.parseEpsgString(imgWkt) as number;
         if (projection) {
             this.logger.trace({ tiff: tiff.source.name, imgWkt, projection }, 'GuessingProjection from GeoAsciiParams');
             return projection;

--- a/packages/cog/src/proj/__test__/index.test.ts
+++ b/packages/cog/src/proj/__test__/index.test.ts
@@ -1,5 +1,5 @@
 import * as o from 'ospec';
-import { getProjection } from '../index';
+import { getProjection, Wgs84ToGoogle } from '../index';
 
 function toFixed(f: number): string {
     return f.toFixed(6);
@@ -16,5 +16,9 @@ o.spec('Proj2193', () => {
 
         const reverse = Proj2193.forward(output);
         o(reverse.map((f) => Math.floor(f))).deepEquals([1180000.0, 4758000.0]);
+    });
+
+    o('Wgs84ToGoogle', () => {
+        o(Wgs84ToGoogle.forward([167.454458, -47.1970753])).deepEquals([18640944.995623615, -5974301.313247106]);
     });
 });

--- a/packages/cog/src/proj/index.ts
+++ b/packages/cog/src/proj/index.ts
@@ -4,30 +4,12 @@ import { NZGD2000 } from './nzgd2000';
 
 proj4.defs(Projection.toEpsgString(EPSG.Nztm), NZGD2000);
 
-/**
- * We need both NZTM and Google to work so assert they exist
- */
-proj4(Projection.toEpsgString(EPSG.Google));
-proj4(Projection.toEpsgString(EPSG.Nztm));
-
-export function getProjection(epsg: EPSG): proj4.Converter | null {
+export function getProjection(fromProjection: EPSG, toProjection?: EPSG): proj4.Converter | null {
     try {
-        return proj4(Projection.toEpsgString(epsg));
+        return proj4(Projection.toEpsgString(fromProjection), toProjection && Projection.toEpsgString(toProjection));
     } catch (e) {
         return null;
     }
 }
 
-/**
- * Attempt to guess the projection based off the WKT
- * @param wkt
- */
-export function guessProjection(wkt: string): EPSG | null {
-    if (wkt == null) {
-        return null;
-    }
-    if (wkt.includes('NZGD2000') || wkt.includes('NZGD_2000')) {
-        return EPSG.Nztm;
-    }
-    return null;
-}
+export const Wgs84ToGoogle = getProjection(EPSG.Wgs84, EPSG.Google)!;

--- a/packages/geo/src/__tests__/projection.test.ts
+++ b/packages/geo/src/__tests__/projection.test.ts
@@ -50,6 +50,7 @@ o.spec('Projection', () => {
         o(Projection.parseEpsgString('epsg:4326')).equals(EPSG.Wgs84);
         o(Projection.parseEpsgString('4326')).equals(EPSG.Wgs84);
 
+        o(Projection.parseEpsgString('NZGD_2000')).equals(EPSG.Nztm);
         o(Projection.parseEpsgString('nztm')).equals(EPSG.Nztm);
         o(Projection.parseEpsgString('epsg:2193')).equals(EPSG.Nztm);
         o(Projection.parseEpsgString('2193')).equals(EPSG.Nztm);

--- a/packages/geo/src/__tests__/quad.key.test.ts
+++ b/packages/geo/src/__tests__/quad.key.test.ts
@@ -93,6 +93,12 @@ o.spec('QuadKey', () => {
         o(QuadKey.toBbox('31021')).deepEquals([101.25, -31.95216223802496, 112.5, -21.943045533438177]);
     });
 
+    o('toXYZ', () => {
+        o(QuadKey.toXYZ('')).deepEquals([0, 0, 0]);
+        o(QuadKey.toXYZ('31')).deepEquals([3, 2, 2]);
+        o(QuadKey.toXYZ('31021')).deepEquals([25, 18, 5]);
+    });
+
     o('compareKeys', () => {
         o(QuadKey.compareKeys('3201', '33')).equals(2);
         o(QuadKey.compareKeys('33', '3201')).equals(-2);

--- a/packages/geo/src/projection.ts
+++ b/packages/geo/src/projection.ts
@@ -27,6 +27,7 @@ const EPSGTextMap: Record<string, EPSG> = {
     nztm: EPSG.Nztm,
     epsg2193: EPSG.Nztm,
     '2193': EPSG.Nztm,
+    nzgd2000: EPSG.Nztm,
 };
 
 export class Projection {

--- a/packages/geo/src/quad.key.ts
+++ b/packages/geo/src/quad.key.ts
@@ -39,6 +39,10 @@ export const QuadKey = {
         return qk.substr(0, qk.length - 1);
     },
 
+    toXYZ(quadKey: string): [number, number, number] {
+        return quadkeyToTile(quadKey);
+    },
+
     toBbox(quadKey: string): [number, number, number, number] {
         return tileToBBOX(quadkeyToTile(quadKey));
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5623,11 +5623,6 @@ glob@^7.0.0, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-global-mercator@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/global-mercator/-/global-mercator-3.1.0.tgz#011b37862f1ca858400d3e97a4e88f527148af2a"
-  integrity sha512-Ws/8nyCHDFzpDQjfr6fcbWY+yU/Oh6rk7+WXNr/pZl7O1WCktAnMZy+9wpJ2stNCqM2SWwvZoqWbIzTiFN++2A==
-
 global-modules@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-2.0.0.tgz#997605ad2345f27f51539bea26574421215c7780"


### PR DESCRIPTION
### Change Description:

`global-mercator` npm is no longer needed as `@mapbox/tilebelt` has needed functions

#### Source Code Documentation Tasks:
- [ ] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
