### PR TITLE
fix: default resampling cubic to bilinear

### DIFF
--- a/packages/cog/src/cog/__test__/cog.test.ts
+++ b/packages/cog/src/cog/__test__/cog.test.ts
@@ -40,7 +40,7 @@ o.spec('cog', () => {
                 bbox: [18472078.003508832, -5948635.289265559, 18785164.071364917, -6261721.357121641],
                 alignmentLevels: 6,
                 compression: 'webp',
-                resampling: 'cubic',
+                resampling: 'bilinear',
                 blockSize: 512,
             });
             o(gdalCogBuilder!.source).equals('/tmp/test.vrt');
@@ -60,7 +60,7 @@ o.spec('cog', () => {
                 '-co',
                 'BLOCKSIZE=512',
                 '-co',
-                'RESAMPLING=cubic',
+                'RESAMPLING=bilinear',
                 '-co',
                 'COMPRESS=webp',
                 '-co',

--- a/packages/cog/src/gdal/__test__/gdal.test.ts
+++ b/packages/cog/src/gdal/__test__/gdal.test.ts
@@ -8,7 +8,7 @@ o.spec('GdalCogBuilder', () => {
 
         o(builder.config.bbox).equals(undefined);
         o(builder.config.compression).equals('webp');
-        o(builder.config.resampling).equals('cubic');
+        o(builder.config.resampling).equals('bilinear');
         o(builder.config.blockSize).equals(512);
         o(builder.config.alignmentLevels).equals(1);
     });

--- a/packages/cog/src/gdal/gdal.config.ts
+++ b/packages/cog/src/gdal/gdal.config.ts
@@ -17,7 +17,7 @@ export interface GdalCogBuilderOptions {
 
     /**
      * Resampling method to use
-     * @default 'cubic'
+     * @default 'bilinear'
      */
     resampling: GdalCogBuilderOptionsResampling;
     /**
@@ -35,7 +35,7 @@ export type GdalCogBuilderOptionsResampling =
     | 'average'
     | 'mode';
 
-export const gdalCogBuilderOptionsResamplingDefault: GdalCogBuilderOptionsResampling = 'cubic';
+export const gdalCogBuilderOptionsResamplingDefault: GdalCogBuilderOptionsResampling = 'bilinear';
 
 const resampleMap: Record<string, GdalCogBuilderOptionsResampling> = {
     nearest: 'nearest',

--- a/packages/cog/src/gdal/gdal.ts
+++ b/packages/cog/src/gdal/gdal.ts
@@ -56,7 +56,7 @@ export class GdalCogBuilder {
             bbox: config.bbox,
             alignmentLevels: config.alignmentLevels ?? 1,
             compression: config.compression ?? 'webp',
-            resampling: config.resampling ?? 'cubic',
+            resampling: config.resampling ?? 'bilinear',
             blockSize: config.blockSize ?? 512,
         };
 


### PR DESCRIPTION
Fixes: #  
Problem occurring with white edges and random pixel artefacts appearing on dataset boundaries

### Change Description:
Changes the default resampling method from cubic to bilinear to prevent generation of edge artefacts

Addresses issue https://app.zenhub.com/workspaces/basemaps-5d3f61dd0406610875ab93c6/issues/linz/basemaps-team/121
