### PR TITLE
build: fix deployment to prod

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -14,8 +14,6 @@ jobs:
         with:
           node-version: "12.x"
           registry-url: https://registry.npmjs.org
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
       - name: Check Dependencies
         run: node scripts/detect.unlinked.dep.js

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -43,6 +43,7 @@ jobs:
         run: npx lerna run deploy:bundle --stream
 
       - name: Configure AWS Credentials (NonProd)
+        if: github.ref == 'refs/heads/master' && github.repository == 'linz/basemaps'
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -50,12 +51,6 @@ jobs:
           aws-region: ap-southeast-2
           mask-account-id: true
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_NON_PROD }}
-
-      - name: Deploy Diff (NonProd)
-        run: npx lerna run deploy:diff --stream
-        env:
-          ALB_CERTIFICATE_ARN: ${{secrets.ALB_CERTIFICATE_ARN}}
-          CLOUDFRONT_CERTIFICATE_ARN: ${{secrets.CLOUDFRONT_CERTIFICATE_ARN}}
 
       - name: Deploy (NonProd)
         if: github.ref == 'refs/heads/master' && github.repository == 'linz/basemaps'
@@ -65,14 +60,14 @@ jobs:
           CLOUDFRONT_CERTIFICATE_ARN: ${{secrets.CLOUDFRONT_CERTIFICATE_ARN}}
 
       - name: Publish NPM
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'linz/basemaps'
         run: npx lerna publish from-git --yes
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
       - name: Configure AWS Credentials (Prod)
+        if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'linz/basemaps'
         uses: aws-actions/configure-aws-credentials@v1
-        if: startsWith(github.ref, 'refs/tags/v')
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -81,7 +76,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_PROD }}
 
       - name: Deploy (Prod)
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'linz/basemaps'
         run: npx lerna run deploy:deploy --stream
         env:
           ALB_CERTIFICATE_ARN: ${{secrets.ALB_CERTIFICATE_ARN_PROD}}


### PR DESCRIPTION
We are unable to use configure-aws-actions twice in the same job, so only login right before the deployment