### PR TITLE
feat(landing): support different imagery sets other than aerial

### DIFF
--- a/packages/landing/static/index.html
+++ b/packages/landing/static/index.html
@@ -37,7 +37,9 @@
         <script type="text/javascript">
             const urlParams = new URLSearchParams(window.location.search);
             const urlTag = urlParams.get('v');
-            let imagerySet = `aerial`;
+            const urlId = urlParams.get('i');
+
+            let imagerySet = urlId || `aerial`;
             if (urlTag != null) imagerySet = imagerySet + '@' + urlTag;
 
             const basemapLayer = new ol.layer.Tile({


### PR DESCRIPTION
Using a query parameter `?i=:tileSetName` eg `?i=aerial`
