### PR TITLE
fix(serve): allow any tile set name to be used

### DIFF
--- a/packages/lambda-shared/src/__test__/api.path.test.ts
+++ b/packages/lambda-shared/src/__test__/api.path.test.ts
@@ -40,7 +40,7 @@ o.spec('api.path', () => {
 
             o(tileFromPath(ctx.action.rest)).deepEquals({
                 type: TileType.Image,
-                tileSet: TileSetType.aerial,
+                name: TileSetType.aerial,
                 projection: EPSG.Google,
                 x: 2,
                 y: 3,
@@ -54,7 +54,7 @@ o.spec('api.path', () => {
 
             o(tileFromPath(ctx.action.rest)).deepEquals({
                 type: TileType.Image,
-                tileSet: TileSetType.aerial,
+                name: TileSetType.aerial,
                 projection: EPSG.Google,
                 x: 5,
                 y: 6,

--- a/packages/lambda-shared/src/api.path.ts
+++ b/packages/lambda-shared/src/api.path.ts
@@ -10,8 +10,6 @@ export interface ActionData {
 
 export enum TileSetType {
     aerial = 'aerial',
-    aerialHead = 'aerial@head',
-    aerialBeta = 'aerial@beta',
 }
 
 export enum TileType {
@@ -23,7 +21,7 @@ export type TileData = TileDataXyz | TileDataWmts;
 
 export interface TileDataXyz {
     type: TileType.Image;
-    tileSet: TileSetType;
+    name: string;
     projection: EPSG;
     x: number;
     y: number;
@@ -39,11 +37,10 @@ export interface TileDataWmts {
 
 const TileSets: Record<string, TileSetType> = {
     aerial: TileSetType.aerial,
-    'aerial@head': TileSetType.aerialHead,
-    'aerial@beta': TileSetType.aerialBeta,
 };
 
-function tileXyzFromPath(path: string[], tileSet: TileSetType): TileData | null {
+function tileXyzFromPath(path: string[]): TileData | null {
+    const name = path[0];
     const projection = Projection.parseEpsgString(path[1]);
     if (projection == null) return null;
     const z = parseInt(path[2], 10);
@@ -56,7 +53,7 @@ function tileXyzFromPath(path: string[], tileSet: TileSetType): TileData | null 
     const ext = getImageFormat(extStr);
     if (ext == null) return null;
 
-    return { type: TileType.Image, tileSet, projection, x, y, z, ext };
+    return { type: TileType.Image, name, projection, x, y, z, ext };
 }
 
 /**
@@ -91,12 +88,11 @@ function tileWmtsFromPath(path: string[], tileSet: TileSetType): TileData | null
 export function tileFromPath(path: string[]): TileData | null {
     if (path.length < 1) return null;
 
-    const tileSet = TileSets[path[0]];
-    if (tileSet == null) return null;
-
     if (path.length == 5) {
-        return tileXyzFromPath(path, tileSet);
+        return tileXyzFromPath(path);
     }
 
+    const tileSet = TileSets[path[0]];
+    if (tileSet == null) return null;
     return tileWmtsFromPath(path, tileSet);
 }

--- a/packages/lambda-xyz/src/__test__/xyz.test.ts
+++ b/packages/lambda-xyz/src/__test__/xyz.test.ts
@@ -9,7 +9,7 @@ import { EPSG } from '@basemaps/geo';
 import { TileSets } from '../routes/tile';
 import { TileSet } from '../tile.set';
 
-const TileSetNames = ['aerial', 'aerial@head', 'aerial@beta'];
+const TileSetNames = ['aerial', 'aerial@head', 'aerial@beta', '01E7PJFR9AMQFJ05X9G7FQ3XMW'];
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 o.spec('LambdaXyz', () => {
     /** Generate mock ALBEvent */
@@ -95,7 +95,7 @@ o.spec('LambdaXyz', () => {
         const res = await handleRequest(request);
         o(res.status).equals(200);
         o(res.header('content-type')).equals('image/webp');
-        o(res.header('eTaG')).equals('kOkbgX07nGYNVt4RO5HxkKxfL2/uM4UJpf1IJl9ySTk=');
+        o(res.header('eTaG')).equals('9Iiu/i3ZzjiLKroRycpaD5eLk0BHUHX1hUsy0CCSoIM=');
         o(res.getBody()).equals(rasterMockBuffer.toString('base64'));
 
         o(tileMock.calls.length).equals(1);
@@ -120,12 +120,14 @@ o.spec('LambdaXyz', () => {
     });
 
     o('should 304 if a tile is not modified', async () => {
-        const key = 'Je+AcRSzbjT8XIAe/VK/Sfh9KlDHPAmq3BkBbpnN3/Q=';
+        const key = 'J6AksQQEhXqW/wywDDsAGtd0OVVqOlKs6M8ViZlOU1g=';
         const request = req('/v1/tiles/aerial/global-mercator/0/0/0.png', 'get', {
             'if-none-match': key,
         });
         const res = await handleRequest(request);
         o(res.status).equals(304);
+        o(res.header('eTaG')).equals(undefined);
+
         o(tileMock.calls.length).equals(1);
         o(rasterMock.calls.length).equals(0);
 

--- a/packages/lambda-xyz/src/routes/tile.ts
+++ b/packages/lambda-xyz/src/routes/tile.ts
@@ -82,10 +82,10 @@ export async function Tile(req: LambdaContext, xyzData: TileDataXyz): Promise<La
     req.set('location', latLon);
     req.set('quadKey', qk);
 
-    const tileSetId = `${xyzData.tileSet}_${xyzData.projection}`;
-    req.set('tileSet', xyzData.tileSet);
+    const tileSetId = `${xyzData.name}_${xyzData.projection}`;
+    req.set('tileSet', xyzData.name);
     req.set('projection', xyzData.projection);
-    const tileSet = TileSets.get(tileSetId) ?? new TileSet(xyzData.tileSet, xyzData.projection);
+    const tileSet = TileSets.get(tileSetId) ?? new TileSet(xyzData.name, xyzData.projection);
     TileSets.set(tileSet.id, tileSet);
 
     req.timer.start('tileset:load');


### PR DESCRIPTION
This allows any tile set in the database to be served, rather than 404ing on anything that is not "aerial"

TODO we should really lookup the WMTS stuff from the database too.