### PR TITLE
fix(tiler): position non square COGs correctly

### DIFF
--- a/packages/tiler/package.json
+++ b/packages/tiler/package.json
@@ -6,7 +6,9 @@
   "license": "MIT",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",
-  "scripts": {},
+  "scripts": {
+    "test": "ospec --globs 'build/**/*.test.js' --preload ../../scripts/test.before.js"
+  },
   "dependencies": {
     "@basemaps/geo": "^1.4.2",
     "@basemaps/metrics": "^1.4.2",

--- a/packages/tiler/src/__test__/tiler.test.ts
+++ b/packages/tiler/src/__test__/tiler.test.ts
@@ -1,0 +1,40 @@
+import { Bounds } from '@basemaps/geo';
+import { BoundingBox } from '@cogeotiff/core/build/vector';
+import * as o from 'ospec';
+import { Tiler } from '../tiler';
+
+o.spec('tiler.test', () => {
+    o('createComposition should handle non square images', () => {
+        const tiler = new Tiler(256) as any;
+
+        const img = {
+            id: 6,
+            getTileBounds(): BoundingBox {
+                return { x: 0, y: 0, width: 512, height: 387 };
+            },
+            tif: { source: { name: '313111000120111.tiff' } },
+            tileSize: { width: 512, height: 512 },
+        } as any;
+
+        const raster = {
+            tiff: new Bounds(4133696, 2623424, 256, 192),
+            intersection: new Bounds(4133696, 2623488, 192, 128),
+            tile: new Bounds(4133632, 2623488, 256, 256),
+        };
+
+        const ans = tiler.createComposition(img, 0, 0, 0.5, raster);
+        const { getBuffer, crop } = ans;
+        o(ans).deepEquals({
+            id: '313111000120111.tiff',
+            source: { x: 0, y: 0, imageId: 6 },
+            getBuffer,
+            y: 0,
+            x: 64,
+            extract: { width: 512, height: 387 },
+            resize: { width: 256, height: 194 },
+            crop,
+        });
+
+        o(crop.toJson()).deepEquals(new Bounds(0, 64, 192, 130).toJson());
+    });
+});

--- a/packages/tiler/src/tiler.ts
+++ b/packages/tiler/src/tiler.ts
@@ -115,13 +115,13 @@ export class Tiler {
 
         // Sometimes the source image is smaller than the tile size,
         // Need to crop the tile down to the actual image extent
-        if (source.width < img.tileSize.width) {
+        if (source.width < img.tileSize.width || source.height < img.tileSize.height) {
             composition.extract = { width: source.width, height: source.height };
         }
 
         // Often COG tiles do not align to the same size as XYZ Tiles
         // This will scale the COG tile to the same size as a XYZ
-        if (source.width != target.width) {
+        if (source.width != target.width || source.height != target.height) {
             composition.resize = { width: target.width, height: target.height };
         }
 


### PR DESCRIPTION
### Fixes

Non square COGs were being shifted up from their intended position


