### PR TITLE
feat(cli): support webp quality setting

### DIFF
--- a/packages/cog/src/cli/cogify/action.job.ts
+++ b/packages/cog/src/cli/cogify/action.job.ts
@@ -56,15 +56,16 @@ export class CLiInputData {
 }
 
 export class ActionJobCreate extends CommandLineAction {
-    private source?: CLiInputData;
-    private output?: CLiInputData;
-    private maxConcurrency?: CommandLineIntegerParameter;
-    private generateVrt?: CommandLineFlagParameter;
-    private resampling?: CommandLineStringParameter;
-    private cutline?: CommandLineStringParameter;
-    private cutlineBlend?: CommandLineIntegerParameter;
-    private overrideId?: CommandLineStringParameter;
+    private source: CLiInputData;
+    private output: CLiInputData;
+    private maxConcurrency: CommandLineIntegerParameter;
+    private generateVrt: CommandLineFlagParameter;
+    private resampling: CommandLineStringParameter;
+    private cutline: CommandLineStringParameter;
+    private cutlineBlend: CommandLineIntegerParameter;
+    private overrideId: CommandLineStringParameter;
     private submitBatch: CommandLineFlagParameter;
+    private quality: CommandLineIntegerParameter;
 
     MaxCogsDefault = 50;
     MaxConcurrencyDefault = 5;
@@ -195,6 +196,7 @@ export class ActionJobCreate extends CommandLineAction {
             output: {
                 ...outputConfig,
                 resampling,
+                quality: this.quality.value ?? 90,
                 cutlineBlend: cutline != null ? this.cutlineBlend?.value ?? 0 : undefined,
                 nodata: metadata.nodata,
                 vrt: {
@@ -301,6 +303,13 @@ export class ActionJobCreate extends CommandLineAction {
         this.submitBatch = this.defineFlagParameter({
             parameterLongName: `--batch`,
             description: 'Submit the job to AWS Batch',
+            required: false,
+        });
+
+        this.quality = this.defineIntegerParameter({
+            argumentName: 'QUALITY',
+            parameterLongName: '--quality',
+            description: 'Compression quality (0-100)',
             required: false,
         });
     }

--- a/packages/cog/src/cog/__test__/cog.test.ts
+++ b/packages/cog/src/cog/__test__/cog.test.ts
@@ -42,6 +42,7 @@ o.spec('cog', () => {
                 compression: 'webp',
                 resampling: 'bilinear',
                 blockSize: 512,
+                quality: 90,
             });
             o(gdalCogBuilder!.source).equals('/tmp/test.vrt');
             o(gdalCogBuilder!.target).equals('/tmp/out-tiff');
@@ -65,6 +66,8 @@ o.spec('cog', () => {
                 'COMPRESS=webp',
                 '-co',
                 'ALIGNED_LEVELS=6',
+                '-co',
+                'QUALITY=90',
                 '-projwin',
                 '18472078.003508832',
                 '-5948635.289265559',

--- a/packages/cog/src/cog/cog.ts
+++ b/packages/cog/src/cog/cog.ts
@@ -62,6 +62,7 @@ export async function buildCogForQuadKey(
         bbox: [ulX, ulY, lrX, lrY],
         alignmentLevels,
         resampling: job.output.resampling,
+        quality: job.output.quality,
     });
     if (cogBuild.gdal.mount) {
         job.source.files.forEach((f) => cogBuild.gdal.mount?.(f));

--- a/packages/cog/src/cog/types.ts
+++ b/packages/cog/src/cog/types.ts
@@ -31,6 +31,11 @@ export interface CogJob {
     output: {
         resampling: GdalCogBuilderOptionsResampling;
         nodata?: number;
+        /**
+         * Quality level to use
+         * @default 90
+         */
+        quality: number;
         cutlineBlend?: number;
         vrt: {
             options: VrtOptions;

--- a/packages/cog/src/gdal/gdal.config.ts
+++ b/packages/cog/src/gdal/gdal.config.ts
@@ -34,6 +34,11 @@ export interface GdalCogBuilderOptions {
      * @default 512
      */
     blockSize: 256 | 512 | 1024 | 2048 | 4096;
+
+    /**
+     * Compression quality
+     */
+    quality: number;
 }
 
 export const GdalCogBuilderDefaults: GdalCogBuilderOptions = {
@@ -41,6 +46,7 @@ export const GdalCogBuilderDefaults: GdalCogBuilderOptions = {
     compression: 'webp',
     alignmentLevels: 1,
     blockSize: 512,
+    quality: 90,
 };
 
 export const GdalResamplingOptions: Record<string, GdalCogBuilderOptionsResampling> = {

--- a/packages/cog/src/gdal/gdal.ts
+++ b/packages/cog/src/gdal/gdal.ts
@@ -58,6 +58,7 @@ export class GdalCogBuilder {
             compression: config.compression ?? GdalCogBuilderDefaults.compression,
             resampling: config.resampling ?? GdalCogBuilderDefaults.resampling,
             blockSize: config.blockSize ?? GdalCogBuilderDefaults.blockSize,
+            quality: config.quality ?? GdalCogBuilderDefaults.quality,
         };
         this.gdal = GdalCogBuilder.getGdal();
 
@@ -104,6 +105,8 @@ export class GdalCogBuilder {
             // Number of levels to align to web mercator
             '-co',
             `ALIGNED_LEVELS=${this.config.alignmentLevels}`,
+            '-co',
+            `QUALITY=${this.config.quality}`,
             ...this.getBounds(),
 
             this.source,


### PR DESCRIPTION
This also bumps the quality number from 75 -> 90

This seems to add about 25% more to file size from my small test cases.


https://gdal.org/drivers/raster/cog.html 