### PR TITLE
feat(cog): Allow supply of source projection

### DIFF
--- a/packages/cog/src/cli/cogify/action.job.ts
+++ b/packages/cog/src/cli/cogify/action.job.ts
@@ -66,6 +66,7 @@ export class ActionJobCreate extends CommandLineAction {
     private overrideId: CommandLineStringParameter;
     private submitBatch: CommandLineFlagParameter;
     private quality: CommandLineIntegerParameter;
+    private srcProj: CommandLineIntegerParameter;
 
     MaxCogsDefault = 50;
     MaxConcurrencyDefault = 5;
@@ -137,7 +138,7 @@ export class ActionJobCreate extends CommandLineAction {
         const cutlinePath = this.cutline?.value;
         const cutline = cutlinePath == null ? new Cutline() : await Cutline.loadCutline(cutlinePath);
 
-        const builder = new CogBuilder(maxConcurrency, logger);
+        const builder = new CogBuilder(maxConcurrency, logger, this.srcProj?.value);
         const metadata = await builder.build(tiffSource, cutline);
 
         const quadkeys = Array.from(metadata.covering).sort(QuadKey.compareKeys);
@@ -206,6 +207,7 @@ export class ActionJobCreate extends CommandLineAction {
             source: {
                 ...sourceConfig,
                 resolution: metadata.resolution,
+                projection: metadata.projection,
                 files: tiffList,
                 options: { maxConcurrency },
             },
@@ -310,6 +312,13 @@ export class ActionJobCreate extends CommandLineAction {
             argumentName: 'QUALITY',
             parameterLongName: '--quality',
             description: 'Compression quality (0-100)',
+            required: false,
+        });
+
+        this.srcProj = this.defineIntegerParameter({
+            argumentName: 'SOURCE_PROJECTION',
+            parameterLongName: '--src-proj',
+            description: 'The EPSG code of the source imagery',
             required: false,
         });
     }

--- a/packages/cog/src/cog/cog.vrt.ts
+++ b/packages/cog/src/cog/cog.vrt.ts
@@ -31,7 +31,7 @@ export async function buildVrtForTiffs(
     const gdalCommand = GdalCogBuilder.getGdal();
     gdalCommand.parser.on('progress', onProgress({ target: 'vrt' }, logger));
 
-    const buildVrtCmd = ['-hidenodata'];
+    const buildVrtCmd = ['-hidenodata', '-allow_projection_difference'];
     if (options.addAlpha) {
         buildVrtCmd.push('-addalpha');
     }

--- a/packages/cog/src/cog/cog.vrt.ts
+++ b/packages/cog/src/cog/cog.vrt.ts
@@ -93,6 +93,8 @@ export async function buildWarpedVrt(
         '-multi',
         '-wo',
         'NUM_THREADS=ALL_CPUS',
+        '-s_srs',
+        Projection.toEpsgString(job.source.projection),
         '-t_srs',
         Projection.toEpsgString(EPSG.Google),
         vrtPath,

--- a/packages/cog/src/cog/types.ts
+++ b/packages/cog/src/cog/types.ts
@@ -21,6 +21,8 @@ export interface CogJob {
          * for high quality aerial imagery this is generally 20-22
          */
         resolution: number;
+        /** EPSG input projection number */
+        projection: EPSG;
 
         options: {
             maxConcurrency: number;


### PR DESCRIPTION
Source projection can be used as a fallback when the source imagery does specify its projection

### Fixes

Allows processing of imagery sets that are missing a projection.  Add argument `--src-proj 2193` when running `cogify job`
