### PR TITLE
fix(lambda-shared): fix order equal priority images are sorted

### DIFF
--- a/packages/cli/src/cli/basemaps/__test__/test.update.test.ts
+++ b/packages/cli/src/cli/basemaps/__test__/test.update.test.ts
@@ -21,10 +21,12 @@ o.spec('TileSetUpdateAction', () => {
     let cmd: TileSetUpdateAction = new TileSetUpdateAction();
     let tileSet = fakeTileSet();
 
-    const TileSet = Aws.tileMetadata.TileSet;
-
     function tileSetId(t: TileMetadataSetRecord): string[] {
-        return TileSet.rules(t).map((c) => c.id);
+        const img = t.imagery;
+        return Object.keys(img).sort((a, b) => {
+            const diff = img[a].priority - img[b].priority;
+            return diff == 0 ? img[a].id.localeCompare(img[b].id) : diff;
+        });
     }
 
     o.beforeEach(() => {
@@ -154,7 +156,7 @@ o.spec('TileSetUpdateAction', () => {
 
         o('should update background', async () => {
             cmd.background = { value: '0xff00ff00' } as any;
-            const hasChanges = await cmd.updateBackground(tileSet);
+            const hasChanges = cmd.updateBackground(tileSet);
             o(hasChanges).equals(true);
             o(tileSet.background).deepEquals({ r: 255, g: 0, b: 255, alpha: 0 });
         });
@@ -162,7 +164,7 @@ o.spec('TileSetUpdateAction', () => {
         o('should only update if changes background', async () => {
             cmd.background = { value: '0xff00ff00' } as any;
             tileSet.background = { r: 255, g: 0, b: 255, alpha: 0 };
-            const hasChanges = await cmd.updateBackground(tileSet);
+            const hasChanges = cmd.updateBackground(tileSet);
             o(hasChanges).equals(false);
             o(tileSet.background).deepEquals({ r: 255, g: 0, b: 255, alpha: 0 });
         });

--- a/packages/cli/src/cli/basemaps/action.tileset.history.ts
+++ b/packages/cli/src/cli/basemaps/action.tileset.history.ts
@@ -1,9 +1,8 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { Aws, LogConfig, TileMetadataImageryRecord, TileMetadataSetRecord, TileSetTag } from '@basemaps/lambda-shared';
-import * as chalk from 'chalk';
 import { CliTable } from '../cli.table';
 import { TileSetBaseAction } from './tileset.action';
-import { printTileSet, TileSetTable } from './tileset.util';
+import { printTileSet, showDiff } from './tileset.util';
 
 const MaxHistory = 199;
 
@@ -87,41 +86,7 @@ export class TileSetHistoryAction extends TileSetBaseAction {
             const tileSetB = tileSets.get(tileSetBId);
             if (tileSetB == null) throw new Error(`Failed to fetch tag: ${tileSetBId}`);
 
-            this.showDiff(tileSetA, tileSetB, imagery);
+            console.log(showDiff(tileSetA, tileSetB, imagery));
         }
-    }
-
-    showDiff(
-        tsA: TileMetadataSetRecord,
-        tsB: TileMetadataSetRecord,
-        imagery: Map<string, TileMetadataImageryRecord>,
-    ): void {
-        for (const tsAImg of Object.values(tsA.imagery)) {
-            const tsBImg = tsB.imagery[tsAImg.id];
-            const img = imagery.get(tsAImg.id)!;
-            const lineA = TileSetTable.line({ rule: tsAImg, img });
-
-            if (tsBImg == null) {
-                console.log(chalk.green('\t+', lineA));
-                continue;
-            }
-
-            const lineB = TileSetTable.line({ rule: tsBImg, img });
-            if (lineA !== lineB) {
-                console.log(chalk.green('\t+', lineA));
-                console.log(chalk.red('\t-', lineB));
-            }
-        }
-
-        for (const tsBImg of Object.values(tsB.imagery)) {
-            const tsAImg = tsA.imagery[tsBImg.id];
-            const img = imagery.get(tsBImg.id)!;
-
-            if (tsAImg == null) {
-                const lineA = TileSetTable.line({ rule: tsBImg, img });
-                console.log(chalk.red('\t-', lineA));
-            }
-        }
-        console.log();
     }
 }

--- a/packages/cli/src/cli/basemaps/tileset.util.ts
+++ b/packages/cli/src/cli/basemaps/tileset.util.ts
@@ -2,31 +2,26 @@ import { EPSG } from '@basemaps/geo';
 import {
     Aws,
     LogConfig,
-    TileMetadataImageRule,
     TileMetadataImageryRecord,
     TileMetadataSetRecord,
+    TileSetRuleImagery,
     TileSetTag,
 } from '@basemaps/lambda-shared';
 import * as AWS from 'aws-sdk';
 import * as c from 'chalk';
+import * as chalk from 'chalk';
 import { CliId } from '../base.cli';
 import { CliTable } from '../cli.table';
 
-export const TileSetTable = new CliTable<{ rule: TileMetadataImageRule; img: TileMetadataImageryRecord }>();
+export const TileSetTable = new CliTable<TileSetRuleImagery>();
 TileSetTable.field('#', 4, (obj) => String(obj.rule.priority));
 TileSetTable.field('Id', 30, (obj) => c.dim(obj.rule.id));
-TileSetTable.field('Name', 40, (obj) => obj.img.name);
+TileSetTable.field('Name', 40, (obj) => obj.imagery.name);
 TileSetTable.field('Zoom', 10, (obj) => obj.rule.minZoom + ' -> ' + obj.rule.maxZoom);
-TileSetTable.field('CreatedAt', 10, (obj) => new Date(obj.img.createdAt).toISOString());
+TileSetTable.field('CreatedAt', 10, (obj) => new Date(obj.imagery.createdAt).toISOString());
 
 export async function printTileSetImagery(tsData: TileMetadataSetRecord): Promise<void> {
-    const imagery = await Aws.tileMetadata.Imagery.getAll(tsData);
-    console.log(c.bold('Imagery:'));
-    TileSetTable.header();
-    const fields = Aws.tileMetadata.TileSet.rules(tsData).map((rule) => {
-        return { rule, img: imagery.get(rule.id)! };
-    });
-    TileSetTable.print(fields);
+    TileSetTable.print(await Aws.tileMetadata.Imagery.getAll(tsData));
 }
 
 export async function printTileSet(tsData: TileMetadataSetRecord, printImagery = true): Promise<void> {
@@ -39,6 +34,41 @@ export async function printTileSet(tsData: TileMetadataSetRecord, printImagery =
     }
 
     if (printImagery) await printTileSetImagery(tsData);
+}
+
+export function showDiff(
+    tsA: TileMetadataSetRecord,
+    tsB: TileMetadataSetRecord,
+    imageSet: Map<string, TileMetadataImageryRecord>,
+): string {
+    let output = '';
+    for (const tsAImg of Object.values(tsA.imagery)) {
+        const tsBImg = tsB.imagery[tsAImg.id];
+        const imagery = imageSet.get(tsAImg.id)!;
+        const lineA = TileSetTable.line({ rule: tsAImg, imagery });
+
+        if (tsBImg == null) {
+            output += chalk.green('\t+', lineA) + '\n';
+            continue;
+        }
+
+        const lineB = TileSetTable.line({ rule: tsBImg, imagery });
+        if (lineA !== lineB) {
+            output += chalk.green('\t+', lineA) + '\n';
+            output += chalk.red('\t-', lineB) + '\n';
+        }
+    }
+
+    for (const tsBImg of Object.values(tsB.imagery)) {
+        const tsAImg = tsA.imagery[tsBImg.id];
+        const imagery = imageSet.get(tsBImg.id)!;
+
+        if (tsAImg == null) {
+            const lineA = TileSetTable.line({ rule: tsBImg, imagery });
+            output += chalk.red('\t-', lineA) + '\n';
+        }
+    }
+    return output;
 }
 
 // Coudfront has to be defined in us-east-1

--- a/packages/lambda-shared/src/aws/__test__/tile.metadata.tileset.test.ts
+++ b/packages/lambda-shared/src/aws/__test__/tile.metadata.tileset.test.ts
@@ -25,34 +25,6 @@ o.spec('tile.metadata.tileset', () => {
         metadata.put = o.spy(promiseNull);
     });
 
-    o.spec('rules', () => {
-        o('should sort rules by priority', () => {
-            const tileSet: any = {
-                imagery: [
-                    { id: '100', priority: 100 },
-                    { id: '10', priority: 10 },
-                ],
-            };
-
-            const rules = ts.rules(tileSet);
-            o(rules.map((c) => c.id)).deepEquals(['10', '100']);
-        });
-
-        o('should sort rules by id if priority is the same', () => {
-            const tileSet: any = {
-                imagery: [
-                    { id: 'B', priority: 10 },
-                    { id: 'A', priority: 10 },
-                    { id: 'D', priority: 10 },
-                    { id: 'C', priority: 10 },
-                ],
-            };
-
-            const rules = ts.rules(tileSet);
-            o(rules.map((c) => c.id)).deepEquals(['A', 'B', 'C', 'D']);
-        });
-    });
-
     o.spec('create', () => {
         o('Should create initial tags', async () => {
             await ts.create({ name: 'test', projection: EPSG.Google } as any);

--- a/packages/lambda-shared/src/aws/tile.metadata.imagery.ts
+++ b/packages/lambda-shared/src/aws/tile.metadata.imagery.ts
@@ -1,4 +1,32 @@
-import { TileMetadataTable, TileMetadataImageryRecord, TileMetadataSetRecord } from './tile.metadata';
+import {
+    TileMetadataImageryRecord,
+    TileMetadataSetRecord,
+    TileMetadataTable,
+    TileSetRuleImagery,
+} from './tile.metadata';
+
+function compareImageSets(a: TileSetRuleImagery, b: TileSetRuleImagery): number {
+    // Sort by priority, highest on top
+    if (a.rule.priority != b.rule.priority) {
+        return a.rule.priority - b.rule.priority;
+    }
+
+    const ai = a.imagery;
+    const bi = b.imagery;
+
+    // Sort by year, newest on top
+    if (ai.year != bi.year) {
+        return ai.year - bi.year;
+    }
+
+    // Resolution, highest resolution (lowest number) on top
+    if (ai.resolution != bi.resolution) {
+        return bi.resolution - ai.resolution;
+    }
+
+    // If everything is equal use the name to force a stable sort
+    return ai.id.localeCompare(bi.id);
+}
 
 export class TileMetadataImagery {
     imagery = new Map<string, TileMetadataImageryRecord>();
@@ -18,26 +46,28 @@ export class TileMetadataImagery {
         return item;
     }
 
-    public async getAll(record: TileMetadataSetRecord): Promise<Map<string, TileMetadataImageryRecord>> {
+    public async getAll(record: TileMetadataSetRecord): Promise<TileSetRuleImagery[]> {
         const toFetch = new Set<string>();
-        const output = new Map<string, TileMetadataImageryRecord>();
-        for (const ruleId of Object.keys(record.imagery)) {
-            const existing = this.imagery.get(ruleId);
-            if (existing == null) {
+        const output: TileSetRuleImagery[] = [];
+        const rules = record.imagery;
+        for (const ruleId in rules) {
+            const rule = rules[ruleId];
+            const imagery = this.imagery.get(ruleId);
+            if (imagery == null) {
                 toFetch.add(ruleId);
             } else {
-                output.set(existing.id, existing);
+                output.push({ rule, imagery });
             }
         }
 
         if (toFetch.size > 0) {
             const records = await this.metadata.batchGet<TileMetadataImageryRecord>(toFetch);
-            for (const rec of records.values()) {
-                this.imagery.set(rec.id, rec);
-                output.set(rec.id, rec);
+            for (const imagery of records.values()) {
+                this.imagery.set(imagery.id, imagery);
+                output.push({ rule: rules[imagery.id], imagery });
             }
         }
 
-        return output;
+        return output.sort(compareImageSets);
     }
 }

--- a/packages/lambda-shared/src/aws/tile.metadata.tileset.ts
+++ b/packages/lambda-shared/src/aws/tile.metadata.tileset.ts
@@ -59,14 +59,6 @@ export class TileMetadataTileSet {
         return `ts_${name}_${projection}_${tag}`;
     }
 
-    /**
-     * Get the imagery rules for a tileset sorted by rendering priority
-     * @param tileSet
-     */
-    rules(tileSet: TileMetadataSetRecord): TileMetadataImageRule[] {
-        return Object.values(tileSet.imagery).sort(sortRule);
-    }
-
     async get(name: string, projection: EPSG, version: number): Promise<TileMetadataSetRecord>;
     async get(name: string, projection: EPSG, tag: TileSetTag): Promise<TileMetadataSetRecord>;
     async get(

--- a/packages/lambda-shared/src/aws/tile.metadata.ts
+++ b/packages/lambda-shared/src/aws/tile.metadata.ts
@@ -63,7 +63,7 @@ export interface TileMetadataSetRecord extends BaseDynamoTable {
 
     projection: EPSG.Google;
 
-    /** first record is the first record drawn onto a tile */
+    /** the rendering rules for imagery in this tileset */
     imagery: Record<string, TileMetadataImageRule>;
 
     /** Current version number */
@@ -74,6 +74,11 @@ export interface TileMetadataSetRecord extends BaseDynamoTable {
 
     /** Background to render for areas where there is no data */
     background?: { r: number; g: number; b: number; alpha: number };
+}
+
+export interface TileSetRuleImagery {
+    rule: TileMetadataImageRule;
+    imagery: TileMetadataImageryRecord;
 }
 
 export enum RecordPrefix {

--- a/packages/lambda-xyz/src/cli/validate.ts
+++ b/packages/lambda-xyz/src/cli/validate.ts
@@ -20,7 +20,7 @@ async function main(): Promise<void> {
 
     let errorCount = 0;
     const logger = LogConfig.get();
-    for (const { imagery } of tileSet.allImagery()) {
+    for (const { imagery } of tileSet.imagery) {
         const path = TileSet.BasePath(imagery);
         logger.info({ path, quadKeys: imagery.quadKeys.length }, 'TestingMosaic');
 


### PR DESCRIPTION
Changed to compare year and resolution if priority the same.

Resolves linz/basemaps-team#159
