### PR TITLE
feat(cli): output sparse cogs by default

### DIFF
--- a/packages/cli/src/cog/__test__/cog.test.ts
+++ b/packages/cli/src/cog/__test__/cog.test.ts
@@ -68,6 +68,8 @@ o.spec('cog', () => {
                 'ALIGNED_LEVELS=6',
                 '-co',
                 'QUALITY=90',
+                '-co',
+                'SPARSE_OK=YES',
                 '-projwin',
                 '18472078.003508832',
                 '-5948635.289265559',

--- a/packages/cli/src/gdal/gdal.ts
+++ b/packages/cli/src/gdal/gdal.ts
@@ -112,8 +112,12 @@ export class GdalCogBuilder {
             // Number of levels to align to web mercator
             '-co',
             `ALIGNED_LEVELS=${this.config.alignmentLevels}`,
+            // Default quality of 75 is too low for our needs
             '-co',
             `QUALITY=${this.config.quality}`,
+            // most of the imagery contains a lot of empty tiles, no need to output them
+            '-co',
+            `SPARSE_OK=YES`,
             ...this.getBounds(),
 
             this.source,


### PR DESCRIPTION
SPARSE_OK is new in GDAL 3.2

see https://github.com/OSGeo/gdal/pull/2551
