### PR TITLE
Feat/cli/nztm tile cover

### DIFF
--- a/packages/cli/src/cog/__test__/quad.trie.test.ts
+++ b/packages/cli/src/cog/__test__/quad.trie.test.ts
@@ -1,0 +1,439 @@
+import * as o from 'ospec';
+import { QuadTrie } from '../quad.trie';
+
+o.spec('QuadTrie', () => {
+    function makeIndex(qk: string | string[]): QuadTrie {
+        if (Array.isArray(qk)) {
+            return QuadTrie.fromList(qk);
+        } else {
+            const index = new QuadTrie();
+            index.add(qk);
+            return index;
+        }
+    }
+
+    o.spec('intersectsTrie', () => {
+        o('should intersect big to small', () => {
+            o(makeIndex('').intersectsTrie(makeIndex('30'))).equals(true);
+            o(makeIndex('3').intersectsTrie(makeIndex('30'))).equals(true);
+            o(makeIndex('3').intersectsTrie(makeIndex('301'))).equals(true);
+            o(makeIndex('3').intersectsTrie(makeIndex('333'))).equals(true);
+            o(makeIndex('33').intersectsTrie(makeIndex('30'))).equals(false);
+            o(makeIndex('33').intersectsTrie(makeIndex('301'))).equals(false);
+            o(makeIndex('33').intersectsTrie(makeIndex('333'))).equals(true);
+        });
+
+        o('should not intersect other cells', () => {
+            o(makeIndex('0').intersectsTrie(makeIndex('30003303'))).equals(false);
+            o(makeIndex('1').intersectsTrie(makeIndex('30003303'))).equals(false);
+            o(makeIndex('2').intersectsTrie(makeIndex('30003303'))).equals(false);
+            o(makeIndex('31').intersectsTrie(makeIndex('30003303'))).equals(false);
+        });
+
+        o('should intersect small to big', () => {
+            o(makeIndex('331').intersectsTrie(makeIndex('3'))).equals(true);
+            o(makeIndex('331').intersectsTrie(makeIndex('30'))).equals(false);
+            o(makeIndex('331').intersectsTrie(makeIndex('301'))).equals(false);
+            o(makeIndex('331').intersectsTrie(makeIndex('333'))).equals(false);
+        });
+    });
+
+    o('should remove unneeded keys', () => {
+        o(Array.from(makeIndex(['31', '311']))).deepEquals(['31']);
+    });
+
+    o('iterators', () => {
+        const trie = makeIndex(['0', '3113', '31131']);
+        const list = Array.from(trie);
+        o(list).deepEquals(['0', '3113']);
+    });
+
+    o('intersection with key', () => {
+        const trie = QuadTrie.fromList(['2222', '2221']);
+
+        const intQK = (k: string): string[] => Array.from(trie.clone().intersection(QuadTrie.fromList([k])));
+
+        o(intQK('222211230')).deepEquals(['222211230']);
+        o(intQK('2222')).deepEquals(['2222']);
+        o(intQK('2')).deepEquals(['2221', '2222']);
+        o(intQK('2230')).deepEquals([]);
+        const itrie = new QuadTrie();
+        o(trie.clone().intersection(itrie).size).equals(0);
+        itrie.intersection(trie);
+        o(itrie.size).equals(0);
+    });
+
+    o('intersection', () => {
+        const trie1 = QuadTrie.fromList(['2222', '2221', '31']);
+        const trie2 = QuadTrie.fromList(['3111', '3112', '22']);
+        o(Array.from(trie1.clone().intersection(trie2))).deepEquals(['2221', '2222', '3111', '3112']);
+        o(Array.from(trie2.intersection(trie1))).deepEquals(['2221', '2222', '3111', '3112']);
+        o(Array.from(trie2)).deepEquals(['2221', '2222', '3111', '3112']);
+    });
+
+    o('nested intersection', () => {
+        const trie1 = QuadTrie.fromList(['2211', '22132', '331']);
+        const trie2 = QuadTrie.fromList(['3313', '2212', '22131']);
+
+        const ans = trie1.clone().intersection(trie2);
+        o(Array.from(ans)).deepEquals(['3313']);
+        o(ans.size).equals(1);
+        o((ans as any).nodes[0]).equals(10); // should delete node
+
+        o(Array.from(trie2.intersection(trie1))).deepEquals(['3313']);
+        o(trie2.size).equals(1);
+        o((trie2 as any).nodes[0]).equals(18); // should delete node
+    });
+
+    o.spec('union', () => {
+        o('empty A', () => {
+            const trie = new QuadTrie();
+            o(Array.from(trie.union(new QuadTrie()))).deepEquals([]);
+            o(trie.size).equals(0);
+
+            o(Array.from(trie.union(QuadTrie.fromList([''])))).deepEquals(['']);
+            trie.clear();
+
+            o(Array.from(trie.union(QuadTrie.fromList(['31', '32'])))).deepEquals(['31', '32']);
+        });
+
+        o('full B', () => {
+            const trie = QuadTrie.fromList(['3', '21']);
+            o(Array.from(trie.union(QuadTrie.fromList([''])))).deepEquals(['']);
+        });
+
+        o('top', () => {
+            const trie = QuadTrie.fromList(['']);
+            const trie2 = QuadTrie.fromList(['31']);
+            o(Array.from(trie.union(trie2))).deepEquals(['']);
+            o(trie.size).equals(1);
+
+            trie.clear();
+            o(Array.from(trie2)).deepEquals(['31']);
+            trie.union(QuadTrie.fromList(['0', '1', '2', '30', '32', '33']));
+            o(Array.from(trie.union(trie2))).deepEquals(['']);
+            o(trie.size).equals(1);
+        });
+
+        o('simple', () => {
+            const trie1 = QuadTrie.fromList(['31']);
+            const trie2 = QuadTrie.fromList(['32']);
+            o(Array.from(trie1.union(trie2))).deepEquals(['31', '32']);
+        });
+
+        o('complex', () => {
+            const trie1 = QuadTrie.fromList(['2222', '2221', '012', '02', '31', '30', '110', '113']);
+            const trie2 = QuadTrie.fromList(['3111', '3112', '011', '031', '22', '111', '112']);
+
+            trie1.union(trie2);
+            o(Array.from(trie1)).deepEquals(['011', '012', '02', '031', '11', '22', '30', '31']);
+        });
+    });
+
+    o('add over child', () => {
+        const trie = QuadTrie.fromList(['31112', '31113', '311011']);
+
+        trie.add('31101');
+        trie.add('311021');
+
+        o(Array.from(trie)).deepEquals(['31101', '311021', '31112', '31113']);
+        o(trie.size).equals(4);
+    });
+
+    o('add top level', () => {
+        const trie = new QuadTrie();
+
+        trie.add('');
+        o(trie.size).equals(1);
+        trie.add('1');
+        o(trie.size).equals(1);
+        o(Array.from(trie)).deepEquals(['']);
+
+        trie.clear();
+        trie.add('0');
+        trie.add('3');
+        o(trie.size).equals(2);
+        o(Array.from(trie)).deepEquals(['0', '3']);
+
+        trie.clear();
+        o(trie.size).equals(0);
+        o(Array.from(trie)).deepEquals([]);
+
+        trie.add('0');
+        trie.add('3');
+        o(Array.from(trie)).deepEquals(['0', '3']);
+        o(trie.size).equals(2);
+
+        trie.add('2');
+        trie.add('3');
+        trie.add('1');
+
+        o(Array.from(trie)).deepEquals(['0', '1', '2', '3']);
+        o(trie.size).equals(4);
+    });
+
+    o('add', () => {
+        const trie = new QuadTrie();
+
+        trie.add('30');
+        trie.add('31');
+        trie.add('32');
+        trie.add('33');
+        trie.add('33');
+
+        o(Array.from(trie)).deepEquals(['30', '31', '32', '33']);
+    });
+
+    o('fillRow simple', () => {
+        const trie = new QuadTrie();
+        trie.clear();
+        trie.fillRow(0, 0, 0, 0);
+        o(Array.from(trie)).deepEquals(['']);
+        o(trie.size).equals(1);
+        trie.fillRow(0, 0, 0, 1);
+        o(Array.from(trie)).deepEquals(['']);
+        o(trie.size).equals(1);
+
+        trie.clear();
+        trie.fillRow(0, 0, 0, 1);
+        o(Array.from(trie)).deepEquals(['2']);
+        o(trie.size).equals(1);
+
+        trie.fillRow(0, 1, 1, 1);
+        o(Array.from(trie)).deepEquals(['0', '1', '2']);
+        o(trie.size).equals(3);
+
+        trie.fillRow(1, 1, 0, 1);
+        o(Array.from(trie)).deepEquals(['']);
+        o(trie.size).equals(1);
+    });
+
+    o('fillRow complex', () => {
+        const trie = new QuadTrie();
+        for (let i = 0; i < 10; ++i) {
+            trie.fillRow(0, 9, i, 10);
+        }
+        const trie2 = new QuadTrie();
+        for (let i = 2; i < 12; ++i) {
+            trie2.fillRow(1 + (i >> 2), 5 + i, i, 10);
+        }
+
+        trie2.intersection(trie);
+
+        o(Array.from(trie2)).deepEquals([
+            '2222220231',
+            '2222220233',
+            '222222032',
+            '222222033',
+            '222222122',
+            '222222201',
+            '222222203',
+            '22222221',
+            '2222222201',
+            '2222222203',
+            '222222221',
+            '222222230',
+            '222222231',
+            '222222300',
+            '222222302',
+            '2222223200',
+        ]);
+    });
+
+    o('fillRow minSize', () => {
+        const trie = new QuadTrie();
+        trie.clear();
+        trie.fillRow(0, 1, 1, 2);
+        trie.fillRow(0, 3, 0, 2);
+        o(Array.from(trie)).deepEquals(['2', '32', '33']);
+        o(trie.size).equals(3);
+
+        trie.clear();
+        trie.fillRow(0, 1, 1, 3);
+        trie.add('223');
+        trie.fillRow(0, 3, 0, 3);
+        o(Array.from(trie)).deepEquals(['22', '232', '233']);
+        o(trie.size).equals(3);
+
+        trie.clear();
+        trie.fillRow(0, 1, 1, 3);
+        trie.add('2221');
+        trie.fillRow(1, 3, 0, 3);
+        o(Array.from(trie)).deepEquals(['220', '221', '2221', '223', '232', '233']);
+        o(trie.size).equals(6);
+    });
+
+    o('clone', () => {
+        const trie1 = new QuadTrie();
+        trie1.fillRow(1, 2, 0, 2);
+        const trie2 = trie1.clone();
+        trie1.clear();
+        o(Array.from(trie1)).deepEquals([]);
+        o(Array.from(trie2)).deepEquals(['23', '32']);
+        o(trie2.size).equals(2);
+    });
+
+    o('fillRow', () => {
+        const trie = new QuadTrie();
+        trie.clear();
+        trie.add('0032123');
+        trie.fillRow(700, 710, 3208, 12);
+        o(Array.from(trie)).deepEquals([
+            '0032123',
+            '003213220222',
+            '003213220223',
+            '003213220232',
+            '003213220233',
+            '003213220322',
+            '003213220323',
+            '003213220332',
+        ]);
+        o(trie.size).equals(8);
+
+        trie.clear();
+        trie.add('23');
+        trie.add('32');
+        trie.fillRow(0, 7, 1, 3);
+        o(Array.from(trie)).deepEquals(['220', '221', '23', '32', '330', '331']);
+        o(trie.size).equals(6);
+
+        trie.clear();
+        trie.fillRow(0, 8, 0, 3);
+        o(trie.size).equals(8);
+
+        trie.clear();
+        trie.add('2');
+        trie.fillRow(0, 3, 1, 2);
+        o(Array.from(trie)).deepEquals(['2', '30', '31']);
+        o(trie.size).equals(3);
+
+        trie.fillRow(0, 1, 0, 1);
+        o(Array.from(trie)).deepEquals(['2', '3']);
+
+        trie.clear();
+        trie.fillRow(2, 3, 2, 3);
+        o(Array.from(trie)).deepEquals(['212', '213']);
+
+        trie.clear();
+        trie.fillRow(1032692, 1032693, 393208, 20);
+        o(Array.from(trie)).deepEquals(['31311100000111110322', '31311100000111110323']);
+
+        trie.clear();
+        trie.fillRow(2, 2, 2, 3);
+        o(Array.from(trie)).deepEquals(['212']);
+
+        trie.clear();
+        trie.fillRow(0, 20, 10, 5);
+        o(Array.from(trie)).deepEquals([
+            '20202',
+            '20203',
+            '20212',
+            '20213',
+            '20302',
+            '20303',
+            '20312',
+            '20313',
+            '21202',
+            '21203',
+            '21212',
+            '21213',
+            '21302',
+            '21303',
+            '21312',
+            '21313',
+            '30202',
+            '30203',
+            '30212',
+            '30213',
+            '30302',
+        ]);
+
+        trie.clear();
+        trie.add('0032123');
+        trie.fillRow(700, 702, 3208, 12);
+        o(Array.from(trie)).deepEquals(['0032123']);
+        o(trie.size).equals(1);
+
+        trie.clear();
+        trie.add('2311');
+        trie.fillRow(0, 5, 1, 3);
+        o(Array.from(trie)).deepEquals(['220', '221', '230', '231', '320', '321']);
+        o(trie.size).equals(6);
+
+        trie.clear();
+        trie.add('0032123');
+        trie.fillRow(670, 705, 3208, 12);
+        o(Array.from(trie)).deepEquals(['003212231332', '003212231333', '0032123', '003213220222', '003213220223']);
+    });
+
+    o.spec('mergeQuadKeys', () => {
+        o('should not simplify if below percent', () => {
+            const trie = QuadTrie.fromList(['31121', '31122', '31123']);
+            const ans = trie.mergeTiles(4, 7, 0.79);
+
+            o(ans * (1 << 4)).equals(0.046875);
+            o(Array.from(trie)).deepEquals(['31121', '31122', '31123']);
+        });
+
+        o('should simplify if node not too big and populated enough', () => {
+            const trie = QuadTrie.fromList(['311', '313', '31201', '31202']);
+            const ans = trie.mergeTiles(4, 7, 0.3);
+
+            o(ans * (1 << 4)).equals(0.53125);
+            o(Array.from(trie).join(',')).equals('3110,3111,3112,3113,3120,3130,3131,3132,3133');
+            o(trie.size).equals(9);
+        });
+
+        o('should not go below minZ', () => {
+            const trie = QuadTrie.fromList(['31121', '31122', '31123']);
+            const ans = trie.mergeTiles(5, 7, 0.2);
+
+            o(ans * (1 << 4)).equals(0.046875);
+            o(Array.from(trie)).deepEquals(['31121', '31122', '31123']);
+            o(trie.size).equals(3);
+        });
+
+        o('should not go above maxZ', () => {
+            const trie = QuadTrie.fromList(['31122', '31123']);
+            trie.add('3121112');
+            trie.add('3121113');
+            const ans = trie.mergeTiles(2, 4, 0.8);
+
+            o(ans * (1 << 4)).equals(0.033203125);
+            o(Array.from(trie)).deepEquals(['3112', '312111']);
+            o(trie.size).equals(2);
+        });
+
+        o('should give correct size', () => {
+            const trie = QuadTrie.fromList(['31112', '31113', '31101']);
+
+            const ans = trie.mergeTiles(2, 2, 1);
+
+            o(ans).equals(0.0029296875);
+
+            o(Array.from(trie)).deepEquals(['311']);
+            o(trie.size).equals(1);
+        });
+
+        o('should expand tiles too big', () => {
+            const trie = QuadTrie.fromList(['']);
+            o(Array.from(trie)).deepEquals(['']);
+
+            trie.mergeTiles(1);
+            o(trie.size).equals(4);
+            o(Array.from(trie)).deepEquals(['0', '1', '2', '3']);
+
+            trie.mergeTiles(2);
+            o(trie.size).equals(16);
+            o(Array.from(trie).join('')).equals('00010203101112132021222330313233');
+
+            trie.clear();
+            trie.add('3120');
+            trie.add('311111');
+            trie.add('311112');
+            trie.mergeTiles(5, 10);
+            o(Array.from(trie)).deepEquals(['311111', '311112', '31200', '31201', '31202', '31203']);
+            o(trie.size).equals(6);
+        });
+    });
+});

--- a/packages/cli/src/cog/__test__/tile.cover.test.ts
+++ b/packages/cli/src/cog/__test__/tile.cover.test.ts
@@ -1,0 +1,347 @@
+import { Epsg, EpsgCode } from '@basemaps/geo';
+import * as o from 'ospec';
+import { GeoJson } from '@basemaps/geo';
+import { writeFileSync } from 'fs';
+import { QuadTrie } from '../quad.trie';
+import { TileGrid } from '../tile.grid';
+import { TileCover } from '../tile.cover';
+
+function round(z: number): (n: number) => number {
+    const p = 10 ** z;
+    return (n: number): number => Math.round(n * p) / p;
+}
+
+const DebugPolys = false;
+
+/** Write to ~/tmp for debugging in qgis */
+function writeDebugPolys(poly: number[][], trie: QuadTrie, tg = TileGrid.Google): void {
+    if (!DebugPolys) return;
+    writeFileSync(`${process.env.HOME}/tmp/poly.geojson`, JSON.stringify(GeoJson.toFeaturePolygon([poly])));
+    writeFileSync(`${process.env.HOME}/tmp/trie.geojson`, JSON.stringify(tg.toGeoJson(trie)));
+}
+
+o.spec('TileCover', () => {
+    o('fraction', () => {
+        const lw = new TileCover(new TileGrid(Epsg.Google, { x: -20, y: -20, width: 80, height: 80 }), 10);
+        o(lw.fraction([32.123456, -5.1234456]).map(round(8))).deepEquals([667.1802368, 190.41989632]);
+    });
+
+    o('toQuadTrie minKeysize', () => {
+        const tg = new TileCover(new TileGrid(Epsg.Google, { x: 0, y: 0, width: 100, height: 100 }), 3);
+        const square = [
+            [0, 0],
+            [100, 0],
+            [100, 100],
+            [0, 100],
+            [0, 0],
+        ];
+        tg.extent.toWsg84.inverse = (a): any => a;
+        const trie = tg.coverPolygon(square);
+        o(trie.size).equals(1);
+        o(Array.from(trie)).deepEquals(['']);
+    });
+
+    o('toQuadTrie simple', () => {
+        const tg = new TileCover(TileGrid.Google, 18);
+
+        const poly = [
+            [174.544582640664572, -40.973788438207819],
+            [174.541391829110751, -40.977115197677954],
+            [174.547013735181764, -40.982621189526625],
+            [174.550812320364884, -40.977918183449262],
+            [174.544582640664572, -40.973788438207819],
+        ];
+
+        const trie = tg.coverPolygon(poly);
+
+        writeDebugPolys(poly, trie);
+
+        o(Array.from(trie)).deepEquals([
+            '31133322222333303',
+            '311333222223333120',
+            '311333222223333122',
+            '311333222223333123',
+            '311333222223333201',
+            '311333222223333203',
+            '31133322222333321',
+            '311333222223333221',
+            '31133322222333323',
+            '31133322222333330',
+            '311333222223333310',
+            '311333222223333312',
+            '311333222223333313',
+            '31133322222333332',
+            '31133322222333333',
+            '311333222232222220',
+            '313111000001111011',
+            '31311100000111110',
+            '313111000001111110',
+            '313111000001111112',
+            '313111000001111120',
+            '313111000001111121',
+        ]);
+    });
+
+    o('toQuadTrie K complex', () => {
+        const poly = [
+            [19429858.86076585, -5008476.232882684],
+            [19430214.06028324, -5009678.631113113],
+            [19430907.54505528, -5009778.631113113],
+            [19430007.54505528, -5008778.631113113],
+            [19430214.06028324, -5008476.232882684],
+            [19429858.86076585, -5008476.232882684],
+        ].map(TileGrid.Google.toWsg84.forward);
+
+        const tg = new TileCover(TileGrid.Google, 18);
+
+        const trie = tg.coverPolygon(poly);
+
+        writeDebugPolys(poly, trie);
+
+        o(Array.from(trie)).deepEquals([
+            '311333222223333021',
+            '311333222223333023',
+            '311333222223333030',
+            '311333222223333031',
+            '311333222223333032',
+            '311333222223333201',
+            '311333222223333210',
+            '311333222223333212',
+            '311333222223333213',
+            '31133322222333323',
+            '311333222223333320',
+            '311333222223333322',
+            '311333222223333323',
+            '313111000001111010',
+            '313111000001111011',
+            '313111000001111013',
+            '313111000001111031',
+            '31311100000111110',
+            '313111000001111110',
+            '313111000001111112',
+            '313111000001111113',
+            '313111000001111120',
+            '313111000001111121',
+            '313111000001111130',
+            '313111000001111131',
+            '313111000010000020',
+        ]);
+    });
+
+    o('toQuadTrie ^ shape', () => {
+        const poly = [
+            [19429858.86076585, -5008476.232882684],
+            [19430214.06028324, -5008476.232882684],
+            [19430907.54505528, -5009778.631113113],
+            [19430007.54505528, -5008778.631113113],
+            [19430214.06028324, -5009678.631113113],
+            [19429858.86076585, -5008476.232882684],
+        ].map(TileGrid.Google.toWsg84.forward);
+
+        const tg = new TileCover(TileGrid.Google, 18);
+
+        const trie = tg.coverPolygon(poly);
+
+        writeDebugPolys(poly, trie);
+
+        o(Array.from(trie)).deepEquals([
+            '311333222223333021',
+            '311333222223333023',
+            '31133322222333303',
+            '311333222223333122',
+            '311333222223333201',
+            '31133322222333321',
+            '31133322222333323',
+            '31133322222333330',
+            '31133322222333332',
+            '311333222223333330',
+            '311333222223333332',
+            '313111000001111010',
+            '313111000001111011',
+            '313111000001111013',
+            '313111000001111101',
+            '31311100000111111',
+            '313111000001111131',
+            '313111000010000020',
+        ]);
+    });
+
+    o('nztm', () => {
+        const Nztm2000 = TileGrid.get(EpsgCode.Nztm2000);
+        const poly = [
+            [1729943.4690833676, 5462326.300432792],
+            [1730462.2021224778, 5462014.064809335],
+            [1729786.0304065342, 5462251.966211319],
+        ].map(Nztm2000.toWsg84.forward);
+
+        const tg = new TileCover(Nztm2000, 14);
+
+        const trie = tg.coverPolygon(poly);
+
+        writeDebugPolys(poly, trie, Nztm2000);
+
+        o(Array.from(trie)).deepEquals([
+            '30011130023133',
+            '30011130023310',
+            '30011130023311',
+            '30011130032022',
+            '30011130032023',
+            '30011130032032',
+            '30011130032033',
+            '30011130032200',
+            '30011130032201',
+            '3001113003221',
+            '3001113003230',
+            '30011130032312',
+            '30011130032313',
+            '30011130032330',
+            '30011130032331',
+            '30011130033220',
+            '30011130033221',
+        ]);
+    });
+
+    o.spec('toQuadTrie edge cases', () => {
+        const Z = 18;
+        function makePoly(poly: number[][]): number[][] {
+            return poly.map(([x, y]) => TileGrid.Google.toWsg84.forward([x * 100 + 19430000, y * 100 - 5008000]));
+        }
+
+        function coverRect(x1: number, y1: number, x2: number, y2: number, z = Z): QuadTrie {
+            const aoi = new QuadTrie();
+
+            for (let row = y1; row < y2; ++row) {
+                aoi.fillRow(x1, x2, row, z);
+            }
+
+            return aoi;
+        }
+
+        function makeAns(poly: number[][], aoi?: QuadTrie, z = Z): string[] {
+            const tg = new TileCover(TileGrid.Google, z);
+
+            const trie = tg.coverPolygon(poly);
+            const ans = aoi == null ? trie : trie.clone().intersection(aoi);
+            writeDebugPolys(poly, trie);
+            return Array.from(ans);
+        }
+
+        function makeExp(rows: number[][], z = Z): string[] {
+            const trie = new QuadTrie();
+
+            for (const [fx, tx, y] of rows) {
+                trie.fillRow(fx, tx, y, z);
+            }
+
+            return Array.from(trie);
+        }
+
+        o('bottom left rising one to right', () => {
+            const poly = makePoly([
+                [0, 0],
+                [25, 0],
+                [25, -13],
+                [0, -14],
+            ]);
+            const aoi = coverRect(258170, 98300, 258186, 98305);
+
+            o(makeAns(poly, aoi)).deepEquals(
+                makeExp([
+                    [258170, 258173, 98303],
+                    [258170, 258186, 98304],
+                ]),
+            );
+        });
+
+        o('bottom right rising one to left', () => {
+            const poly = makePoly([
+                [25, 0],
+                [0, 0],
+                [0, -13],
+                [25, -14],
+            ]);
+            const aoi = coverRect(258170, 98300, 258186, 98305);
+
+            o(makeAns(poly, aoi)).deepEquals(
+                makeExp([
+                    [258182, 258186, 98303],
+                    [258170, 258186, 98304],
+                ]),
+            );
+        });
+
+        o('top right decending one to left', () => {
+            const poly = makePoly([
+                [25, 0],
+                [0, 0],
+                [0, 13],
+                [25, 14],
+            ]);
+            const aoi = coverRect(258170, 98321, 258186, 98323);
+
+            o(makeAns(poly, aoi)).deepEquals(
+                makeExp([
+                    [258182, 258186, 98322],
+                    [258170, 258186, 98321],
+                ]),
+            );
+        });
+
+        o('top left decending one to right', () => {
+            const poly = makePoly([
+                [0, 0],
+                [25, 0],
+                [25, 13],
+                [0, 14],
+            ]);
+
+            o(makeAns(poly, coverRect(258170, 98313, 258186, 98314))).deepEquals(makeExp([[258170, 258186, 98313]]));
+            o(makeAns(poly, coverRect(258170, 98321, 258186, 98323))).deepEquals(
+                makeExp([
+                    [258170, 258174, 98322],
+                    [258170, 258186, 98321],
+                ]),
+            );
+        });
+
+        o('square', () => {
+            const poly = makePoly([
+                [0, 0],
+                [10, 0],
+                [10, 10],
+                [0, 10],
+            ]);
+
+            o(makeAns(poly)).deepEquals([
+                '31133322222333101',
+                '31133322222333103',
+                '3113332222233311',
+                '31133322222333121',
+                '311333222223331230',
+                '311333222223331231',
+                '31133322222333130',
+                '31133322222333131',
+                '311333222223331320',
+                '311333222223331321',
+                '311333222223331330',
+                '311333222223331331',
+                '311333222232220000',
+                '311333222232220002',
+                '311333222232220020',
+                '311333222232220022',
+                '311333222232220200',
+                '311333222232220202',
+                '311333222232220220',
+            ]);
+        });
+    });
+
+    o('whole world', () => {
+        const tgl = new TileCover(TileGrid.Google, 2);
+        const geojson = TileGrid.Google.toGeoJson(['']);
+
+        if (geojson.features[0].geometry.type !== 'Polygon') throw new Error('expected Polygon');
+        const trie = tgl.coverPolygon(geojson.features[0].geometry.coordinates[0]);
+        o(Array.from(trie)).deepEquals(['']);
+    });
+});

--- a/packages/cli/src/cog/__test__/tile.grid.test.ts
+++ b/packages/cli/src/cog/__test__/tile.grid.test.ts
@@ -1,0 +1,59 @@
+import { Epsg } from '@basemaps/geo';
+import * as o from 'ospec';
+import { TileGrid } from '../tile.grid';
+
+o.spec('TileGrid', () => {
+    o('quadKey', () => {
+        const tg = TileGrid.Google;
+        o(tg.quadKey(0, 0, 20)).equals('00000000000000000000');
+        o(tg.quadKey(1032692, 655367, 20)).equals('31311100000111110322');
+        o(tg.quadKey(1032693, 655367, 20)).equals('31311100000111110323');
+
+        o(TileGrid.quadKeyToXyz('00000000000000000000')).deepEquals([0, 0, 20]);
+        o(TileGrid.quadKeyToXyz('31311100000111110322')).deepEquals([1032692, 655367, 20]);
+    });
+
+    o('quadKeyToBbox', () => {
+        const tg = new TileGrid(Epsg.Google, { x: -20, y: -20, width: 80, height: 80 });
+
+        o(tg.quadKeyToBbox('3212011013')).deepEquals([32.109375, -5.078125, 32.1875, -5.15625]);
+        o(tg.quadKeyToBbox('0')).deepEquals([-20, 60, 20, 20]);
+        o(tg.quadKeyToBbox('3')).deepEquals([20, 20, 60, -20]);
+        o(tg.quadKeyToBbox('30')).deepEquals([20, 20, 40, 0]);
+    });
+
+    o('toGeoJson', () => {
+        const tg = TileGrid.Google;
+        const geojson = tg.toGeoJson(['311333222223333030', '311333222223333031']);
+
+        o(geojson).deepEquals({
+            type: 'FeatureCollection',
+            features: [
+                {
+                    type: 'Feature',
+                    geometry: geojson.features[0].geometry,
+                    properties: { quadKey: '311333222223333030' },
+                },
+                {
+                    type: 'Feature',
+                    geometry: geojson.features[1].geometry,
+                    properties: { quadKey: '311333222223333031' },
+                },
+            ],
+        });
+
+        const geom = geojson.features[0].geometry as any;
+
+        o(geom.type).equals('Polygon');
+
+        o(geom.coordinates).deepEquals([
+            [
+                [174.54254150390588, -40.97367726477828],
+                [174.54254150390588, -40.974714106324576],
+                [174.5439147949215, -40.974714106324576],
+                [174.5439147949215, -40.97367726477828],
+                [174.54254150390588, -40.97367726477828],
+            ],
+        ]);
+    });
+});

--- a/packages/cli/src/cog/quad.trie.ts
+++ b/packages/cli/src/cog/quad.trie.ts
@@ -232,7 +232,7 @@ function copyNodes(nodesA: number[], idxA: number, nodesB: number[], idxB: numbe
 }
 
 /**
- * Reduce nodesA to the intersection with nodesB
+ * Reduce `nodesA` to the intersection with `nodesB`
  */
 function intersection(nodesA: number[], idxA: number, nodesB: number[], idxB: number): boolean {
     let found = false;
@@ -260,7 +260,7 @@ function intersection(nodesA: number[], idxA: number, nodesB: number[], idxB: nu
 }
 
 /**
- * Reduce nodesA to the intersection with nodesB
+ * Combine `nodesA` with `nodesB`
  */
 function union(nodesA: number[], idxA: number, nodesB: number[], idxB: number): boolean {
     let full = 0;
@@ -285,7 +285,7 @@ function union(nodesA: number[], idxA: number, nodesB: number[], idxB: number): 
 }
 
 /**
- * Is there an intersection between nodesA and nodesB
+ * Is there an intersection between `nodesA` and `nodesB`
  */
 function hasIntersection(nodesA: number[], idxA: number, nodesB: number[], idxB: number): boolean {
     for (let key = 0; key < 4; ++key) {

--- a/packages/cli/src/cog/quad.trie.ts
+++ b/packages/cli/src/cog/quad.trie.ts
@@ -1,0 +1,523 @@
+const EMPTY = 0;
+const EXISTS = 1;
+const TOP = 2;
+
+/**
+ * Link list of freed nodes
+ * @param idx pointer to the node to free
+ */
+function freeSpace(nodes: number[], idx: number): void {
+    nodes[idx] = nodes[EMPTY];
+    nodes[EMPTY] = idx;
+}
+
+/**
+ * Recursively remove any children from node and free node
+ * @param firstChild must point to the first child (not the parent or any other child)
+ */
+function removeChildren(nodes: number[], firstChild: number): void {
+    for (let key = 0; key < 4; ++key) {
+        const newIdx = nodes[firstChild + key];
+        if (newIdx !== EMPTY) {
+            if (newIdx === EXISTS) {
+                --nodes[EXISTS];
+            } else {
+                removeChildren(nodes, newIdx);
+            }
+            nodes[firstChild + key] = EMPTY;
+        }
+    }
+
+    freeSpace(nodes, firstChild);
+}
+
+/**
+ * Delete a node (or leaf) and all its children
+ * @param idx pointer to the node to remove
+ */
+function delNode(nodes: number[], idx: number): void {
+    const childIdx = nodes[idx];
+    if (childIdx !== EMPTY) {
+        nodes[idx] = EMPTY;
+        if (childIdx === EXISTS) {
+            nodes[EXISTS]--;
+        } else {
+            removeChildren(nodes, childIdx);
+        }
+    }
+}
+
+/**
+ * Add a child leaf to parent at idx
+ * @param idx pointer to where the left is to be added
+ */
+function addLeaf(nodes: number[], idx: number): void {
+    const childIdx = nodes[idx];
+    if (childIdx !== EXISTS) {
+        nodes[idx] = EXISTS;
+        nodes[EXISTS]++;
+        if (childIdx !== EMPTY) removeChildren(nodes, childIdx);
+    }
+}
+
+/**
+ * Add a child node to parent at idx
+ * @param idx pointer to where the node is to be added
+ */
+function addNode(nodes: number[], idx = 0): number {
+    if (nodes.length == 2) {
+        if (nodes[EXISTS] == 1) return EXISTS; // top node is a leaf
+        nodes.push(EMPTY, EMPTY, EMPTY, EMPTY); // was empty
+        return TOP;
+    } else {
+        const newIdx = nodes[idx];
+        if (newIdx === EXISTS) return EXISTS; // leaf exists
+        if (newIdx !== EMPTY) return newIdx; // node exists
+    }
+
+    // need to add a node
+    const freeIdx = nodes[EMPTY];
+    if (freeIdx === EMPTY) {
+        // no free space; extend array
+        nodes.push(EMPTY, EMPTY, EMPTY, EMPTY);
+        return (nodes[idx] = nodes.length - 4);
+    }
+
+    // use free space
+    nodes[EMPTY] = nodes[freeIdx]; // unlink free node
+    nodes[freeIdx] = EMPTY; // clear free ptr
+
+    nodes[idx] = freeIdx; // allocate free node to child
+    return freeIdx;
+}
+
+/**
+ * iterate through all leafs in nodes yielding the computed quadkey.
+ */
+function* iterate(nodes: number[], nodeIdx = TOP, currentStr = ''): Generator<string, null, void> {
+    for (let key = 0; key < 4; ++key) {
+        const newIdx = nodes[nodeIdx + key];
+        if (newIdx === EXISTS) yield currentStr + key.toString();
+        else if (newIdx !== EMPTY) yield* iterate(nodes, newIdx, currentStr + key.toString());
+    }
+    return null;
+}
+
+// recursive function called from QuadTrie.mergeTiles
+function mergeTiles(
+    nodes: number[],
+    minZ: number,
+    maxZ: number,
+    coveringPercentage: number,
+    z = 0,
+    parentIdx = TOP,
+): number {
+    let coverCount = 0;
+    let childCount = 0;
+    for (let key = 0; key < 4; ++key) {
+        const childIdx = nodes[parentIdx + key];
+        if (childIdx !== EMPTY) {
+            ++childCount;
+            if (childIdx === EXISTS) {
+                if (z + 1 < minZ) {
+                    nodes[parentIdx + key] = EMPTY;
+                    const idx = addNode(nodes, parentIdx + key);
+                    for (let i = 0; i < 4; ++i) {
+                        nodes[idx + i] = EXISTS;
+                    }
+                    nodes[EXISTS] += 3;
+                }
+                coverCount += 0.25;
+            } else {
+                let pc = mergeTiles(nodes, minZ, maxZ, coveringPercentage, z + 1, childIdx);
+                if (pc < 0) {
+                    // child wants us to remove them
+                    pc = -pc;
+                    addLeaf(nodes, parentIdx + key);
+                }
+                coverCount += pc * 0.25;
+            }
+        }
+    }
+
+    if (
+        // node not too big and populated enough
+        (z >= minZ && coverCount >= coveringPercentage) ||
+        // node too small and would reduce node count
+        (z >= maxZ && childCount > 1)
+    ) {
+        return -coverCount; // indicate remove us
+    }
+    return coverCount;
+}
+
+/**
+ * Add and trace path to ancesstors of a row of tiles
+
+ * @param level the width of the level
+ */
+function fillRow(nodes: number[], parentIdx: number, fromX: number, toX: number, y: number, level: number): boolean {
+    let nodeCount = 0;
+    const row = y < level ? 2 : 0;
+    const left = fromX < level; // left or right quadrant?
+    const right = toX >= level;
+    const leftIdx = nodes[parentIdx + row];
+    const rightIdx = nodes[parentIdx + row + 1];
+
+    const mask = level - 1;
+    fromX &= mask;
+    toX &= mask;
+    y &= mask;
+    level = level >> 1;
+
+    if (leftIdx === EXISTS) {
+        ++nodeCount;
+    } else if (left) {
+        if (
+            level == 0 ||
+            fillRow(
+                nodes,
+                leftIdx === EMPTY ? addNode(nodes, parentIdx + row) : leftIdx,
+                fromX,
+                right ? mask : toX,
+                y,
+                level,
+            )
+        ) {
+            ++nodeCount;
+            addLeaf(nodes, parentIdx + row);
+        }
+    }
+
+    if (rightIdx === EXISTS) {
+        ++nodeCount;
+    } else if (right) {
+        if (
+            level == 0 ||
+            fillRow(
+                nodes,
+                rightIdx === EMPTY ? addNode(nodes, parentIdx + row + 1) : rightIdx,
+                left ? 0 : fromX,
+                toX,
+                y,
+                level,
+            )
+        ) {
+            ++nodeCount;
+            addLeaf(nodes, parentIdx + row + 1);
+        }
+    }
+
+    if (nodeCount != 2) return false;
+
+    const oRow = row == 2 ? 0 : 2;
+    return nodes[parentIdx + oRow] == EXISTS && nodes[parentIdx + oRow + 1] == EXISTS;
+}
+
+/**
+ * copy nodes from `nodeB` to `nodeA`
+ */
+function copyNodes(nodesA: number[], idxA: number, nodesB: number[], idxB: number): void {
+    for (let key = 0; key < 4; ++key) {
+        const cB = nodesB[idxB + key];
+        if (cB !== EMPTY) {
+            if (cB === EXISTS) {
+                nodesA[idxA + key] = EXISTS;
+                nodesA[EXISTS]++;
+            } else {
+                copyNodes(nodesA, addNode(nodesA, idxA + key), nodesB, cB);
+            }
+        }
+    }
+}
+
+/**
+ * Reduce nodesA to the intersection with nodesB
+ */
+function intersection(nodesA: number[], idxA: number, nodesB: number[], idxB: number): boolean {
+    let found = false;
+    for (let key = 0; key < 4; ++key) {
+        const cA = nodesA[idxA + key];
+        const cB = nodesB[idxB + key];
+        if (cA !== EMPTY) {
+            if (cB === EMPTY) {
+                delNode(nodesA, idxA + key);
+            } else if (cB === EXISTS) {
+                found = true;
+            } else if (cA === EXISTS) {
+                found = true;
+                nodesA[EXISTS]--;
+                nodesA[idxA + key] = EMPTY;
+                copyNodes(nodesA, addNode(nodesA, idxA + key), nodesB, cB);
+            } else if (intersection(nodesA, cA, nodesB, cB)) {
+                found = true;
+            } else {
+                delNode(nodesA, idxA + key);
+            }
+        }
+    }
+    return found;
+}
+
+/**
+ * Reduce nodesA to the intersection with nodesB
+ */
+function union(nodesA: number[], idxA: number, nodesB: number[], idxB: number): boolean {
+    let full = 0;
+    for (let key = 0; key < 4; ++key) {
+        const cA = nodesA[idxA + key];
+        const cB = nodesB[idxB + key];
+        if (cA === EXISTS) {
+            ++full;
+        } else if (cB !== EMPTY) {
+            if (cB === EXISTS) {
+                addLeaf(nodesA, idxA + key);
+                ++full;
+            } else if (cA === EMPTY) {
+                copyNodes(nodesA, addNode(nodesA, idxA + key), nodesB, cB);
+            } else if (union(nodesA, cA, nodesB, cB)) {
+                addLeaf(nodesA, idxA + key);
+                ++full;
+            }
+        }
+    }
+    return full == 4;
+}
+
+/**
+ * Is there an intersection between nodesA and nodesB
+ */
+function hasIntersection(nodesA: number[], idxA: number, nodesB: number[], idxB: number): boolean {
+    for (let key = 0; key < 4; ++key) {
+        const cA = nodesA[idxA + key];
+        const cB = nodesB[idxB + key];
+        if (cA !== EMPTY && cB !== EMPTY) {
+            if (cB === EXISTS || cA === EXISTS || hasIntersection(nodesA, cA, nodesB, cB)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+/**
+ * Special logic to determine if top node is a leaf
+ */
+function topIsLeaf(nodes: number[]): boolean {
+    return nodes.length == 2 && nodes[EXISTS] === EXISTS;
+}
+function topLeaf(): [number, number] {
+    return [EMPTY, EXISTS];
+}
+
+export class QuadTrie {
+    /** The trie structure including size and free space list */
+    private nodes: number[];
+
+    /**
+     * An Iterate-able Trie container of XYZ tiles
+     */
+    constructor() {
+        this.clear();
+    }
+
+    /**
+     * How many quadkeys (leafs) in this container
+     */
+    get size(): number {
+        return this.nodes[EXISTS];
+    }
+
+    /**
+     * Build a QuadTrie container from a list of quad keys
+     */
+    static fromList(quadKeys: string[]): QuadTrie {
+        const trie = new QuadTrie();
+        for (const s of quadKeys) trie.add(s);
+        return trie;
+    }
+
+    /**
+     * Clear all contents from this trie
+     */
+    clear(): void {
+        this.nodes = [EMPTY, EMPTY];
+    }
+
+    /**
+     * Create an identical copy of this Trie
+     */
+    clone(): QuadTrie {
+        const trie = new QuadTrie();
+        trie.nodes = this.nodes.slice();
+        return trie;
+    }
+
+    /**
+     * Add a quad key to the trie.
+     *
+     * Does not allow adding higher resolution keys beneath an existing key. If a key is being added
+     * over the top of any higher resolution keys they will be deleted. Does not merge full quadrants
+
+     * @param quadKey Quadkey to add
+     */
+    add(quadKey: string): void {
+        const { nodes } = this;
+        if (topIsLeaf(nodes)) return; // top is a leaf
+        if (quadKey === '') {
+            this.nodes = topLeaf();
+            return;
+        }
+        if (nodes.length == 2) {
+            addNode(nodes);
+        }
+        let idx = TOP;
+        for (let i = 0; i < quadKey.length - 1; i++) {
+            idx = addNode(nodes, idx + (quadKey.charCodeAt(i) & 11));
+            if (idx === EXISTS) return; // parent is a leaf
+        }
+
+        idx += quadKey.charCodeAt(quadKey.length - 1) & 11;
+
+        addLeaf(nodes, idx);
+    }
+
+    /**
+     * Fill a row of the trie container
+
+     * @param fromX the X coord of the tile to start filling from (inclusive)
+     * @param toX the X coord of the tile to end filling on (inclusive)
+     * @param y the Y coord of the row to fill
+     * @param z the depth (zoom level) to fill at
+     */
+    fillRow(fromX: number, toX = fromX, y: number, z: number): void {
+        if (toX < fromX) {
+            const swap = toX;
+            toX = fromX;
+            fromX = swap;
+        }
+
+        if (fromX > toX || z < 0) return; // nothing to fill
+
+        if (z == 0) {
+            this.nodes = topLeaf();
+            return;
+        }
+
+        const level = 1 << z; // width in pixels of world at zoom level
+        const mask = level - 1;
+
+        // ensure arguments are within boundry (0 to level -1)
+        if (fromX < 0) fromX = 0;
+        if (fromX >= level) fromX = mask;
+        if (toX < 0) toX = 0;
+        if (toX >= level) toX = mask;
+        if (y < 0) y = 0;
+        if (y >= level) y = mask;
+
+        const { nodes } = this;
+
+        if (nodes.length == 2) {
+            if (topIsLeaf(nodes)) return;
+            addNode(nodes);
+        }
+
+        if (fillRow(this.nodes, TOP, fromX, toX, y, level >> 1)) {
+            this.nodes = topLeaf();
+        }
+    }
+
+    /**
+     * Do the two Tries intersect
+     * @param other
+     */
+    intersectsTrie(other: QuadTrie): boolean {
+        const nodesA = this.nodes;
+        const nodesB = other.nodes;
+        if (this.size == 0 || other.size == 0) return false;
+        if (topIsLeaf(nodesA) || topIsLeaf(nodesB)) return true;
+        return hasIntersection(nodesA, TOP, nodesB, TOP);
+    }
+
+    /**
+     * Make a new QuadTrie which the intersection of this QuadTrie and `other`
+
+     * @param other
+     * @return the new intersection QuadTrie
+     */
+    intersection(other: QuadTrie): QuadTrie {
+        const nodesA = this.nodes;
+        const nodesB = other.nodes;
+        if (topIsLeaf(nodesA)) {
+            this.clear();
+            this.nodes = nodesB.slice();
+        } else if (!topIsLeaf(nodesB) && nodesA.length != 2) {
+            if (nodesB.length == 2) {
+                this.clear();
+            } else {
+                intersection(nodesA, TOP, nodesB, TOP);
+            }
+        }
+
+        return this;
+    }
+
+    /**
+     * @param other
+     * @return the new intersection QuadTrie
+     */
+    union(other: QuadTrie): QuadTrie {
+        const nodesA = this.nodes;
+        const nodesB = other.nodes;
+        if (nodesA.length == 2) {
+            if (topIsLeaf(nodesA)) return this;
+            this.nodes = nodesB.slice();
+        } else if (nodesB.length == 2) {
+            if (topIsLeaf(nodesB)) {
+                this.nodes = topLeaf();
+            }
+        } else if (union(nodesA, TOP, nodesB, TOP)) {
+            this.nodes = topLeaf();
+        }
+
+        return this;
+    }
+
+    /**
+     * Merge child nodes that have at least `coveringPercentage` within a zoom range of `minZ` to
+     * `maxz`.
+
+     * @param coveringPercentage min coverage in order to merge when between minZ and maxZ
+     * @param minZ Don't merge any quadKeys of this length or less and split any tiles bigger than this
+     * @param maxZ Merge any quadKeys of at least this length if they are an only child
+     * @return the percentage covered of the world by this covering set
+     */
+    mergeTiles(minZ: number, maxZ = minZ, coveringPercentage = 1): number {
+        const { nodes } = this;
+        if (nodes.length == 2) {
+            if (topIsLeaf(nodes)) {
+                if (minZ < 1) return 1;
+                nodes.push(EXISTS, EXISTS, EXISTS, EXISTS);
+                nodes[EXISTS] = 4;
+            }
+        }
+        const pc = mergeTiles(nodes, minZ, maxZ, coveringPercentage);
+        if (pc == 1 && minZ == 0) {
+            // all full
+            this.nodes = topLeaf();
+        }
+        return pc;
+    }
+
+    /**
+     * Iterate over all quad keys
+     */
+    *[Symbol.iterator](): Generator<string, null, void> {
+        const { nodes } = this;
+        if (nodes.length == 2) {
+            if (nodes[EXISTS] === EXISTS) yield '';
+            return null;
+        }
+        return yield* iterate(nodes);
+    }
+}

--- a/packages/cli/src/cog/tile.cover.ts
+++ b/packages/cli/src/cog/tile.cover.ts
@@ -1,0 +1,185 @@
+import { QuadTrie } from './quad.trie';
+import { TileGrid } from './tile.grid';
+
+type Position = number[];
+
+/**
+ * Fill top or bottom nearly horizontal edges
+ */
+function fillEdgeCase(trie: QuadTrie, row: number, yi: number, lx: number, xi: number, xj: number, z: number): void {
+    let tx = lx;
+    if (yi > row && yi < row + 1) {
+        if (xi < lx) {
+            lx = Math.floor(xi);
+        } else {
+            tx = Math.floor(xi);
+        }
+    } else if (xj < lx) {
+        lx = Math.floor(xj);
+    } else {
+        tx = Math.floor(xj);
+    }
+    trie.fillRow(lx, tx, row, z);
+}
+
+function xIntersetPoint(row: number, xi: number, xj: number, yi: number, yj: number): number {
+    return Math.floor(xi + ((row - yi) / (yj - yi)) * (xj - xi));
+}
+
+/**
+ * Fill a polygon (in tile units) with QuadKeys returning a `QuadTrie`
+
+ * This is a standard polygon fill with extensions to ensure all polygon edges are completely
+ * covered by a tile.
+ */
+function fill(poly: Position[], bbox: number[], trie = new QuadTrie(), z: number): QuadTrie {
+    const [minX, minY, maxX, maxY] = bbox;
+    const polyLen = poly.length;
+
+    // For each row find the xpoints that cross the bottom of the row (`xrow`) and fill in the edge
+    // of the polygon
+    for (let row = minY; row <= maxY; ++row) {
+        const top = row + 1;
+        const xrow: number[] = [];
+        //  Build a list of nodes.
+        let j = polyLen - 1;
+        for (let i = 0; i < polyLen; i++) {
+            const yi = poly[i][1];
+            const yj = poly[j][1];
+            if ((yi < row && yj >= row) || (yj < row && yi >= row)) {
+                // Line crosses row bottom
+                const xi = poly[i][0];
+                const xj = poly[j][0];
+                const lx = xIntersetPoint(row, xi, xj, yi, yj);
+                if ((yi < row && yj < top) || (yj < row && yi < top)) {
+                    // Line does not cross row top
+                    fillEdgeCase(trie, row, yi, lx, xi, xj, z);
+                } else {
+                    //  Line crosses row top
+                    const ux = xIntersetPoint(top, xi, xj, yi, yj);
+                    trie.fillRow(lx, ux, row, z);
+                }
+
+                xrow.push(Math.floor(lx)); // Need to fill polygon
+            } else if ((yi < top && yj >= row) || (yj < top && yi >= row)) {
+                // Line touches row quadrant
+                const xi = poly[i][0];
+                const xj = poly[j][0];
+                const ux = xIntersetPoint(top, xi, xj, yi, yj);
+                if ((yi < top && yj >= top) || (yj < top && yi >= top)) {
+                    // Line crosses row top
+                    fillEdgeCase(trie, row, yi, ux, xi, xj, z);
+                } else {
+                    // Line within row quadrant
+                    trie.fillRow(Math.floor(xi), Math.floor(xj), row, z);
+                }
+            }
+            j = i;
+        }
+        const lastx = xrow.length - 1;
+        if (lastx == -1) {
+            continue;
+        }
+
+        //  Sort the nodes, via a simple “Bubble” sort.
+        let i = 0;
+        while (i < lastx) {
+            if (xrow[i] > xrow[i + 1]) {
+                const swap = xrow[i];
+                xrow[i] = xrow[i + 1];
+                xrow[i + 1] = swap;
+                if (i != 0) i--;
+            } else {
+                i++;
+            }
+        }
+
+        //  Fill the tiles between node pairs.
+        for (i = 0; i <= lastx; i += 2) {
+            const px = xrow[i];
+            if (px > maxX) break;
+            const ex = xrow[i + 1];
+            if (ex != px) {
+                trie.fillRow((px < minX ? minX : px) + 1, (ex > maxX ? maxX : ex) - 1, row, z);
+            }
+        }
+    }
+
+    return trie;
+}
+
+export class TileCover {
+    extent: TileGrid;
+    /** The zoom level */
+    x: number;
+    y: number;
+    z: number;
+    /** The number of tiles wide and high of this `TileGrid` (`2**z`) */
+    xRatio: number;
+    yRatio: number;
+
+    /**
+     *
+     * @param z The zoom level determines how long quadKeys will be and what size a tile will be
+     */
+    constructor(extent: TileGrid, z: number) {
+        this.extent = extent;
+        this.x = extent.x;
+        this.y = extent.y;
+        this.z = z;
+        const dim = 1 << z;
+        this.xRatio = dim / extent.width;
+        this.yRatio = dim / extent.height;
+    }
+
+    /**
+     * Convert a Position that is relative to this `TileGrid` to a fractional tile with `(0,0)`
+     * being the `x,y` of the bounds.
+
+     * @param coord the coordoinates to convert to fractional tile
+     */
+    fraction(coord: Position): Position {
+        return [(coord[0] - this.x) * this.xRatio, (coord[1] - this.y) * this.yRatio];
+    }
+
+    /**
+     * Convert `polygon` to a `QuadTrie`
+     * @param polygon A single polygon in the units of this `TileGrid`
+     */
+    coverPolygon(polygon: Position[]): QuadTrie {
+        const trie = new QuadTrie();
+
+        if (polygon.length < 3) return trie;
+
+        const convert = this.extent.toWsg84.inverse;
+
+        let p = this.fraction(convert(polygon[0]));
+        let pi = [Math.floor(p[0]), Math.floor(p[1])];
+
+        const bbox = [pi[0], pi[1], pi[0], pi[1]];
+
+        const lp: Position[] = [p];
+        let li = 0;
+
+        for (let i = 1; i < polygon.length; ++i) {
+            const c = this.fraction(convert(polygon[i]));
+            const ci = [Math.floor(c[0]), Math.floor(c[1])];
+            if (ci[0] != pi[0] || ci[1] != pi[1]) {
+                // calculate bounding box
+                if (bbox[0] > ci[0]) bbox[0] = ci[0];
+                if (bbox[2] < ci[0]) bbox[2] = ci[0];
+                if (bbox[1] > ci[1]) bbox[1] = ci[1];
+                if (bbox[3] < ci[1]) bbox[3] = ci[1];
+
+                // store only the entry and exit points to a tile
+                if (i - 1 !== li) lp.push(p);
+                lp.push(c);
+                li = i;
+            }
+            p = c;
+            pi = ci;
+        }
+
+        return fill(lp, bbox, trie, this.z);
+    }
+}

--- a/packages/cli/src/cog/tile.grid.ts
+++ b/packages/cli/src/cog/tile.grid.ts
@@ -1,0 +1,157 @@
+import { GeoJson, BoundingBox, Epsg } from '@basemaps/geo';
+import { getProjection } from '../proj';
+import { QuadTrie } from './quad.trie';
+
+/**
+ * Split a quuadKey into an x and y component
+ */
+function quadKeyToTile(qk: string): [number, number] {
+    let x = 0;
+    let y = 0;
+    for (let i = 0; i < qk.length; ++i) {
+        const k = qk[i];
+        x = x << 1;
+        y = y << 1;
+        if (k === '1' || k === '3') {
+            x = x | 1;
+        }
+        if (k === '2' || k === '3') {
+            y = y | 1;
+        }
+    }
+
+    return [x, y];
+}
+
+const Codes = new Map<number, TileGrid>();
+
+export class TileGrid implements BoundingBox {
+    epsg: Epsg;
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+    private _toWsg84?: proj4.Converter;
+
+    static Google = new TileGrid(Epsg.Google, {
+        x: -20037508.3427892,
+        y: -20037508.3427892,
+        width: 20037508.3427892 * 2,
+        height: 20037508.3427892 * 2,
+    });
+
+    /**
+     * Create a TileGrid suitable for creating quadKeys for a given bounds and precision
+
+     * @param bounds The boundary of the `TileGrid`
+     */
+    constructor(epsg: Epsg, bounds: BoundingBox) {
+        this.epsg = epsg;
+        this.x = bounds.x;
+        this.y = bounds.y;
+        this.width = bounds.width;
+        this.height = bounds.height;
+    }
+
+    /**
+     * Return the `TileGrid` for the `EPSG` projection.
+     */
+    static get(code: number): TileGrid {
+        const tg = Codes.get(code);
+        if (tg == null) throw new Error('Invalid EPSG code: ' + code);
+        return tg;
+    }
+
+    static quadKeyToXyz(quadKey: string): [number, number, number] {
+        const [x, y] = quadKeyToTile(quadKey);
+        return [x, y, quadKey.length];
+    }
+
+    get toWsg84(): proj4.Converter {
+        if (this._toWsg84 == null) {
+            const _projection = getProjection(this.epsg, Epsg.Wgs84);
+            if (_projection == null) throw new Error('Invalid prohection! ' + this.epsg.code);
+            this._toWsg84 = _projection;
+        }
+        return this._toWsg84;
+    }
+
+    /**
+     * Return the bounding box of a `quadKey` in the units of this `TileGrid`
+     * @param quadKey a quadKey relative to this `TileGrid`
+     */
+    quadKeyToBbox(qk: string): [number, number, number, number] {
+        const tcount = 1 << qk.length;
+        const [qx, qy] = quadKeyToTile(qk);
+        const fx = this.width / tcount;
+        const fy = this.height / tcount;
+        return [
+            this.x + qx * fx,
+            this.y + this.height - qy * fy,
+            this.x + (qx + 1) * fx,
+            this.y + this.height - (qy + 1) * fy,
+        ];
+    }
+
+    /**
+     * Return the `quadKey` of `z` length for coordinates `x`, `y`
+     * @param x in the units of this `TileGrid`
+     * @param y in the units of this `TileGrid`
+     * @param z
+     */
+    quadKey(x: number, y: number, z: number): string {
+        let level = 1 << z;
+        if (x < 0 || x > level || y < 0 || y > level) return '';
+
+        let qk = '';
+        let hl = 0;
+        let mask = 0;
+        while (level > 1) {
+            hl = level >> 1;
+            mask = hl - 1;
+
+            if (x < hl) {
+                qk += y < hl ? '0' : '2';
+            } else {
+                qk += y < hl ? '1' : '3';
+            }
+            level = hl;
+            x &= mask;
+            y &= mask;
+        }
+        return qk;
+    }
+
+    /** Convert a quadkey covering to a GeoJSON FeatureCollection in WSG84
+
+     * @param covering a list of quadKeys or a `QuadTrie`
+     */
+    toGeoJson(covering: string[] | QuadTrie): GeoJSON.FeatureCollection {
+        const toWgs84 = this.toWsg84.forward;
+        const polygons: GeoJSON.Feature[] = [];
+        for (const quadKey of covering) {
+            const poly = GeoJson.toPositionPolygon(this.quadKeyToBbox(quadKey))[0].map(toWgs84);
+            const polygon = GeoJson.toFeaturePolygon([poly], { quadKey });
+            polygons.push(polygon);
+        }
+
+        return GeoJson.toFeatureCollection(polygons);
+    }
+}
+
+Codes.set(
+    Epsg.Nztm2000.code,
+    ((): TileGrid => {
+        const { forward } = getProjection(Epsg.Wgs84, Epsg.Nztm2000)!;
+        const [x, y] = forward([166.37, -47.3]);
+        const [ex, ey] = forward([178.63, -34.1]);
+        return new TileGrid(Epsg.Nztm2000, {
+            x,
+            y,
+            width: ex - x,
+            height: ey - y,
+        });
+    })(),
+);
+
+Codes.set(Epsg.Google.code, TileGrid.Google);


### PR DESCRIPTION
Create a `TileCover` class that can handle projections other the Google Mercator.

I have split my work into multiple PRs.  This is the first PR. The next PR will use the added classes to build quadkeys for any projection.

Note it is a replacement for the current `QuadKeyTrie` in `geo` package with the methods needed to cover a polygon

The next PR will replace the `@turf` packages with the super cool much smaller `martinez-polygon-clipping` package
