### PR TITLE
fix(cli):  quadkey.vrt missing argument 

### DIFF
--- a/packages/cli/src/cog/__test__/quadkey.vrt.test.ts
+++ b/packages/cli/src/cog/__test__/quadkey.vrt.test.ts
@@ -239,7 +239,7 @@ o.spec('quadkey.vrt', () => {
 
         o((runSpy.calls[0] as any).args).deepEquals([
             'gdalbuildvrt',
-            ['-hidenodata', '-addalpha', '/tmp/my-tmp-folder/source.vrt', vtif1, vtif2],
+            ['-hidenodata', '-allow_projection_difference', '-addalpha', '/tmp/my-tmp-folder/source.vrt', vtif1, vtif2],
             logger,
         ]);
 

--- a/packages/cli/src/cog/quadkey.vrt.ts
+++ b/packages/cli/src/cog/quadkey.vrt.ts
@@ -11,7 +11,7 @@ import { GdalCommand } from '../gdal/gdal.command';
  * Build the VRT for the needed source imagery
  */
 async function buildPlainVrt(job: CogJob, vrtPath: string, gdalCommand: GdalCommand, logger: LogType): Promise<void> {
-    const buildOpts = ['-hidenodata'];
+    const buildOpts = ['-hidenodata', '-allow_projection_difference'];
     if (job.output.vrt.addAlpha) {
         buildOpts.push('-addalpha');
     }


### PR DESCRIPTION
Fix regression missing argument '-allow_projection_difference'
