### PR TITLE
Feat/cli/improve cog aliged levels

### DIFF
--- a/packages/__tests__/src/rounding.ts
+++ b/packages/__tests__/src/rounding.ts
@@ -15,10 +15,15 @@ export function round(thing: any, z = 8): any {
         if (typeof obj === 'number') {
             return r(obj);
         }
+        if (typeof obj === 'string') {
+            const n = +obj;
+            if (isNaN(n)) return obj;
+            return r(n).toString();
+        }
         if (Array.isArray(obj)) {
             return obj.map(recurse);
         }
-        if (obj == null || typeof obj !== 'object') return obj;
+        if (obj == null || obj.constructor !== Object) return obj;
 
         const ans = Object.assign({}, obj);
         for (const key in ans) {

--- a/packages/__tests__/src/rounding.ts
+++ b/packages/__tests__/src/rounding.ts
@@ -16,7 +16,7 @@ export function round(thing: any, z = 8): any {
             return r(obj);
         }
         if (typeof obj === 'string') {
-            const n = +obj;
+            const n = Number(obj);
             if (isNaN(n)) return obj;
             return r(n).toString();
         }

--- a/packages/cli/src/cli/cogify/action.batch.ts
+++ b/packages/cli/src/cli/cogify/action.batch.ts
@@ -102,7 +102,7 @@ export class ActionBatchJob extends CommandLineAction {
         const targetProj = ProjectionTileMatrixSet.get(job.projection);
         const alignmentLevels = targetProj.findAlignmentLevels(
             targetProj.tms.quadKey.toTile(quadKey),
-            job.source.resZoom,
+            job.source.pixelScale,
         );
         // Give 25% more memory to larger jobs
         const resDiff = 1 + Math.max(alignmentLevels - MagicAlignmentLevel, 0) * 0.25;

--- a/packages/cli/src/cog/__test__/builder.test.ts
+++ b/packages/cli/src/cog/__test__/builder.test.ts
@@ -42,13 +42,13 @@ o.spec('Builder', () => {
         } as CogTiff;
 
         o('getTiffResZoom', () => {
-            o(googleBuilder.getTiffResZoom(10)).equals(13);
-            o(googleBuilder.getTiffResZoom(0.075)).equals(20);
+            o(googleBuilder.getTiffResZoom(10)).equals(14);
+            o(googleBuilder.getTiffResZoom(0.075)).equals(21);
 
             const nztmBuilder = new CogBuilder(ProjectionTileMatrixSet.get(EpsgCode.Nztm2000), 1, LogConfig.get());
 
-            o(nztmBuilder.getTiffResZoom(10)).equals(9);
-            o(nztmBuilder.getTiffResZoom(0.075)).equals(15);
+            o(nztmBuilder.getTiffResZoom(10)).equals(10);
+            o(nztmBuilder.getTiffResZoom(0.075)).equals(16);
         });
 
         o('getTifBounds', () => {

--- a/packages/cli/src/cog/__test__/builder.test.ts
+++ b/packages/cli/src/cog/__test__/builder.test.ts
@@ -41,16 +41,6 @@ o.spec('Builder', () => {
             },
         } as CogTiff;
 
-        o('getTiffResZoom', () => {
-            o(googleBuilder.getTiffResZoom(10)).equals(14);
-            o(googleBuilder.getTiffResZoom(0.075)).equals(21);
-
-            const nztmBuilder = new CogBuilder(ProjectionTileMatrixSet.get(EpsgCode.Nztm2000), 1, LogConfig.get());
-
-            o(nztmBuilder.getTiffResZoom(10)).equals(10);
-            o(nztmBuilder.getTiffResZoom(0.075)).equals(16);
-        });
-
         o('getTifBounds', () => {
             o(round(googleBuilder.getTifBounds(tiff), 2)).deepEquals({
                 type: 'Feature',

--- a/packages/cli/src/cog/__test__/cog.test.ts
+++ b/packages/cli/src/cog/__test__/cog.test.ts
@@ -39,7 +39,7 @@ o.spec('cog', () => {
             config.targetRes = round(config.targetRes, 4);
             o(config).deepEquals({
                 bbox: [17532819.7999, -5009377.0857, 20037527.452, -7514084.7378],
-                alignmentLevels: 4,
+                alignmentLevels: 10,
                 compression: 'webp',
                 tilingScheme: TilingScheme.Google,
                 projection: Epsg.Google,
@@ -69,7 +69,7 @@ o.spec('cog', () => {
                 '-co',
                 'COMPRESS=webp',
                 '-co',
-                'ALIGNED_LEVELS=4',
+                'ALIGNED_LEVELS=10',
                 '-co',
                 'QUALITY=90',
                 '-co',

--- a/packages/cli/src/cog/__test__/cog.test.ts
+++ b/packages/cli/src/cog/__test__/cog.test.ts
@@ -36,6 +36,7 @@ o.spec('cog', () => {
             // -projwin_srs EPSG:3857
             const { config } = gdalCogBuilder!;
             config.bbox = round(config.bbox, 4);
+            config.targetRes = round(config.targetRes, 4);
             o(config).deepEquals({
                 bbox: [17532819.7999, -5009377.0857, 20037527.452, -7514084.7378],
                 alignmentLevels: 4,
@@ -44,6 +45,7 @@ o.spec('cog', () => {
                 projection: Epsg.Google,
                 resampling: 'bilinear',
                 blockSize: 512,
+                targetRes: 19.1093,
                 quality: 90,
             });
             o(gdalCogBuilder!.source).equals('/tmp/test.vrt');
@@ -72,6 +74,9 @@ o.spec('cog', () => {
                 'QUALITY=90',
                 '-co',
                 'SPARSE_OK=YES',
+                '-tr',
+                '19.1093',
+                '19.1093',
                 '-projwin',
                 '17532819.7999',
                 '-5009377.0857',

--- a/packages/cli/src/cog/__test__/quadkey.vrt.test.ts
+++ b/packages/cli/src/cog/__test__/quadkey.vrt.test.ts
@@ -237,13 +237,24 @@ o.spec('quadkey.vrt', () => {
         o(runSpy.callCount).equals(2);
         o(mount.calls.map((c: any) => c.args[0])).deepEquals([tmpFolder, s3tif1, s3tif2]);
 
-        o((runSpy.calls[0] as any).args).deepEquals([
+        o(round((runSpy.calls[0] as any).args)).deepEquals([
             'gdalbuildvrt',
-            ['-hidenodata', '-allow_projection_difference', '-addalpha', '/tmp/my-tmp-folder/source.vrt', vtif1, vtif2],
+            [
+                '-hidenodata',
+                '-allow_projection_difference',
+                '-tr',
+                '19.10925707',
+                '19.10925707',
+                '-tap',
+                '-addalpha',
+                '/tmp/my-tmp-folder/source.vrt',
+                vtif1,
+                vtif2,
+            ],
             logger,
         ]);
 
-        o(runSpy.args).deepEquals([
+        o(round(runSpy.args)).deepEquals([
             'gdalwarp',
             [
                 '-of',
@@ -255,6 +266,10 @@ o.spec('quadkey.vrt', () => {
                 'EPSG:3857',
                 '-t_srs',
                 'EPSG:3857',
+                '-tr',
+                '19.10925707',
+                '19.10925707',
+                '-tap',
                 '-cutline',
                 '/tmp/my-tmp-folder/cutline.geojson',
                 '-cblend',

--- a/packages/cli/src/cog/__test__/source.tiff.testhelper.ts
+++ b/packages/cli/src/cog/__test__/source.tiff.testhelper.ts
@@ -8,6 +8,7 @@ export const SourceTiffTestHelper = {
             source: {
                 files: [] as string[],
                 resZoom: 13,
+                pixelScale: 9.55,
                 path: '',
                 options: {
                     maxConcurrency: 3,

--- a/packages/cli/src/cog/builder.ts
+++ b/packages/cli/src/cog/builder.ts
@@ -126,24 +126,8 @@ export class CogBuilder {
             bands,
             bounds: GeoJson.toFeatureCollection(polygons),
             pixelScale: resX,
-            resZoom: this.getTiffResZoom(resX),
+            resZoom: this.targetProj.getTiffResZoom(resX),
         };
-    }
-
-    /**
-     * Find the closest zoom level to `resX` (pixels per meter) that is at least as good as `resX`.
-
-     * @param resX
-     */
-    getTiffResZoom(resX: number): number {
-        // Get best image resolution
-        const { tms } = this.targetProj;
-        let z = 0;
-        for (; z < tms.zooms.length; ++z) {
-            if (tms.pixelScale(z) <= resX) return z;
-        }
-        if (z == tms.zooms.length) return z - 1;
-        return -1;
     }
 
     findProjection(tiff: CogTiff): Epsg {
@@ -236,7 +220,7 @@ export class CogBuilder {
         if (existsSync(cacheKey)) {
             this.logger.debug({ path: cacheKey }, 'MetadataCacheHit');
             const metadata = (await FileOperatorSimple.readJson(cacheKey)) as SourceMetadata;
-            metadata.resZoom = this.getTiffResZoom(metadata.pixelScale);
+            metadata.resZoom = this.targetProj.getTiffResZoom(metadata.pixelScale);
             return metadata;
         }
 

--- a/packages/cli/src/cog/cog.ts
+++ b/packages/cli/src/cog/cog.ts
@@ -62,7 +62,7 @@ export async function buildCogForQuadKey(
     const paddingY = ul.y > lr.y ? -px : px;
 
     const blockSize = tms.tileSize * targetProj.blockFactor;
-    const alignmentLevels = targetProj.findAlignmentLevels(tile, resZoom);
+    const alignmentLevels = targetProj.findAlignmentLevels(tile, job.source.pixelScale);
 
     const cogBuild = new GdalCogBuilder(vrtLocation, outputTiffPath, {
         bbox: [ul.x, ul.y, lr.x + paddingX, lr.y + paddingY],

--- a/packages/cli/src/cog/cog.ts
+++ b/packages/cli/src/cog/cog.ts
@@ -69,6 +69,7 @@ export async function buildCogForQuadKey(
         projection: targetProj.tms.projection,
         tilingScheme: tilingScheme(job.projection),
         blockSize,
+        targetRes: tms.pixelScale(resZoom),
         alignmentLevels,
         resampling: job.output.resampling,
         quality: job.output.quality,

--- a/packages/cli/src/gdal/gdal.config.ts
+++ b/packages/cli/src/gdal/gdal.config.ts
@@ -47,6 +47,8 @@ export interface GdalCogBuilderOptions {
      */
     blockSize: number;
 
+    targetRes: number;
+
     /**
      * Compression quality
      */
@@ -59,6 +61,7 @@ export const GdalCogBuilderDefaults: GdalCogBuilderOptions = {
     tilingScheme: TilingScheme.Google,
     projection: Epsg.Google,
     alignmentLevels: 1,
+    targetRes: 0,
     blockSize: 512,
     quality: 90,
 };

--- a/packages/cli/src/gdal/gdal.ts
+++ b/packages/cli/src/gdal/gdal.ts
@@ -66,6 +66,7 @@ export class GdalCogBuilder {
             tilingScheme: config.tilingScheme ?? GdalCogBuilderDefaults.tilingScheme,
             resampling: config.resampling ?? GdalCogBuilderDefaults.resampling,
             blockSize: config.blockSize ?? GdalCogBuilderDefaults.blockSize,
+            targetRes: config.targetRes ?? GdalCogBuilderDefaults.targetRes,
             quality: config.quality ?? GdalCogBuilderDefaults.quality,
         };
         this.gdal = GdalCogBuilder.getGdal();
@@ -85,6 +86,7 @@ export class GdalCogBuilder {
     }
 
     get args(): string[] {
+        const tr = this.config.targetRes.toString();
         return [
             // Force output using COG Driver
             '-of',
@@ -119,6 +121,9 @@ export class GdalCogBuilder {
             // most of the imagery contains a lot of empty tiles, no need to output them
             '-co',
             `SPARSE_OK=YES`,
+            '-tr',
+            tr,
+            tr,
             ...this.getBounds(),
 
             this.source,

--- a/packages/shared/src/tms/__test__/projection.tile.matrix.set.test.ts
+++ b/packages/shared/src/tms/__test__/projection.tile.matrix.set.test.ts
@@ -28,6 +28,16 @@ o.spec('ProjectionTileMatrixSet', () => {
     const googleProj = ProjectionTileMatrixSet.get(EpsgCode.Google);
     const nztmProj = ProjectionTileMatrixSet.get(EpsgCode.Nztm2000);
 
+    o('getTiffResZoom', () => {
+        o(googleProj.getTiffResZoom(10)).equals(14);
+        o(googleProj.getTiffResZoom(10, 2)).equals(13);
+        o(googleProj.getTiffResZoom(0.075)).equals(21);
+
+        o(nztmProj.getTiffResZoom(10)).equals(10);
+        o(nztmProj.getTiffResZoom(10, 2)).equals(9);
+        o(nztmProj.getTiffResZoom(0.075)).equals(16);
+    });
+
     o('getTileSize', async () => {
         o(googleProj.getImagePixelWidth({ x: 0, y: 0, z: 5 }, 10)).equals(16384);
         o(googleProj.getImagePixelWidth({ x: 0, y: 0, z: 13 }, 20)).equals(65536);
@@ -37,15 +47,16 @@ o.spec('ProjectionTileMatrixSet', () => {
     });
 
     o('findAlignmentLevels', () => {
-        o(googleProj.findAlignmentLevels({ x: 2, y: 0, z: 5 }, 20)).equals(9);
-        o(googleProj.findAlignmentLevels({ x: 2, y: 0, z: 5 }, 15)).equals(4);
-        o(googleProj.findAlignmentLevels({ x: 2, y: 0, z: 3 }, 10)).equals(3);
-        o(googleProj.findAlignmentLevels({ x: 2, y: 0, z: 8 }, 10)).equals(0);
+        o(googleProj.findAlignmentLevels({ x: 2, y: 0, z: 5 }, 0.075)).equals(15);
+        o(googleProj.findAlignmentLevels({ x: 2, y: 0, z: 5 }, 0.5)).equals(13);
+        o(googleProj.findAlignmentLevels({ x: 2, y: 0, z: 3 }, 1)).equals(14);
+        o(googleProj.findAlignmentLevels({ x: 2, y: 0, z: 8 }, 10)).equals(5);
+        o(googleProj.findAlignmentLevels({ x: 2, y: 0, z: 14 }, 10)).equals(0);
 
-        o(nztmProj.findAlignmentLevels({ x: 2, y: 0, z: 1 }, 15)).equals(12);
-        o(nztmProj.findAlignmentLevels({ x: 2, y: 0, z: 5 }, 15)).equals(4);
-        o(nztmProj.findAlignmentLevels({ x: 2, y: 0, z: 3 }, 9)).equals(2);
-        o(nztmProj.findAlignmentLevels({ x: 2, y: 0, z: 8 }, 10)).equals(0);
+        o(nztmProj.findAlignmentLevels({ x: 2, y: 0, z: 1 }, 0.075)).equals(14);
+        o(nztmProj.findAlignmentLevels({ x: 2, y: 0, z: 5 }, 0.5)).equals(8);
+        o(nztmProj.findAlignmentLevels({ x: 2, y: 0, z: 3 }, 7)).equals(6);
+        o(nztmProj.findAlignmentLevels({ x: 2, y: 0, z: 8 }, 14)).equals(0);
     });
 
     o('should convert to 2193', () => {


### PR DESCRIPTION
1. fix alignment levels to not assume powers of two
1. set explicit targetRes (`-tr`) for cog creation
1. use `-tap` 
    (target aligned pixels) align the coordinates of the extent of the output file to the values of the -tr, such that the aligned extent includes the minimum extent.