### PR TITLE
fix(cli): mitigate polygon intersection errors

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,6 +25,7 @@
     "@cogeotiff/source-url": "^2.1.1",
     "@rushstack/ts-command-line": "^4.3.13",
     "ansi-colors": "^4.1.1",
+    "lineclip": "^1.1.5",
     "p-limit": "^3.0.1",
     "polygon-clipping": "^0.14.3",
     "pretty-json-log": "^0.3.1"

--- a/packages/cli/src/cli/cogify/action.cog.ts
+++ b/packages/cli/src/cli/cogify/action.cog.ts
@@ -101,8 +101,6 @@ export class ActionCogCreate extends CommandLineAction {
         const tmpFolder = await makeTempFolder(`basemaps-${job.id}-${CliId}`);
 
         try {
-            const sourceGeo = (await inFp.readJson(getJobPath(job, 'source.geojson'))) as FeatureCollection;
-
             let cutlineJson: FeatureCollection | undefined;
             if (job.output.cutline != null) {
                 const cutlinePath = getJobPath(job, 'cutline.geojson.gz');
@@ -117,7 +115,7 @@ export class ActionCogCreate extends CommandLineAction {
                 job.output.cutline?.blend,
             );
 
-            const tmpVrtPath = await CogVrt.buildVrt(tmpFolder, job, sourceGeo, cutline, name, logger);
+            const tmpVrtPath = await CogVrt.buildVrt(tmpFolder, job, cutline, name, logger);
 
             if (tmpVrtPath == null) {
                 logger.warn({ name }, 'NoMatchingSourceImagery');

--- a/packages/cli/src/cog/__test__/clipped.multipolygon.test.ts
+++ b/packages/cli/src/cog/__test__/clipped.multipolygon.test.ts
@@ -1,0 +1,299 @@
+import { Bounds, GeoJson } from '@basemaps/geo';
+import o from 'ospec';
+import { MultiPolygon } from 'polygon-clipping';
+import { clipMultipolygon, removeDegenerateEdges, polyContainsBounds } from '../clipped.multipolygon';
+import { round } from '@basemaps/test/build/rounding';
+
+export function writeGeoJson(fn: string, poly: MultiPolygon): void {
+    require('fs').writeFileSync(fn, JSON.stringify(GeoJson.toFeatureCollection([GeoJson.toFeatureMultiPolygon(poly)])));
+}
+
+o.spec('clipped.multipolygon', () => {
+    const polys: MultiPolygon = [
+        [
+            [
+                [-4, 2],
+                [-2, 1],
+                [-4, -1],
+                [1, -5],
+                [2, -5],
+                [2, -2],
+                [4, -5],
+                [6, -2],
+                [2, 0],
+                [6, 3],
+                [2, 7],
+                [0, 3],
+                [-4, 6],
+                [-4, 10],
+                [10, 10],
+                [10, -10],
+                [-10, -10],
+                [-4, 2],
+            ],
+        ],
+        [
+            [
+                [2, 3],
+                [3, 3],
+                [3, 5],
+                [2, 5],
+                [2, 3],
+            ],
+        ],
+    ];
+
+    o('polyContainsBounds', () => {
+        o(polyContainsBounds(polys, Bounds.fromBbox([-6, -6, -3, -3]))).equals(true);
+
+        o(polyContainsBounds(polys, Bounds.fromBbox([-3, -4, 4, 4]))).equals(false);
+        o(polyContainsBounds(polys, new Bounds(6, -8, 5, 5))).equals(false);
+    });
+
+    o('clipMultipolygon', () => {
+        const bbox = Bounds.fromBbox([-3, -4, 4, 4]);
+
+        const cp = clipMultipolygon(polys, bbox);
+
+        o(cp).deepEquals([
+            [
+                [
+                    [-3, -4],
+                    [-3, 1.5],
+                    [-2, 1],
+                    [-3, 0],
+                    [-3, -1.8],
+                    [-0.25, -4],
+                    [2, -4],
+                    [2, -2],
+                    [3.333333333333333, -4],
+                    [4, -4],
+                    [4, -1],
+                    [2, 0],
+                    [4, 1.5],
+                    [4, 4],
+                    [0.5, 4],
+                    [0, 3],
+                    [-1.3333333333333333, 4],
+                    [4, 4],
+                    [4, -4],
+                    [-3, -4],
+                ],
+            ],
+            [
+                [
+                    [2, 3],
+                    [3, 3],
+                    [3, 4],
+                    [2, 4],
+                    [2, 3],
+                ],
+            ],
+        ]);
+    });
+
+    o.spec('removeDegenerateEdges', () => {
+        o('simple', () => {
+            const bbox = Bounds.fromBbox([-3, 1, 3, 3]);
+
+            const cp: MultiPolygon = [
+                [
+                    [
+                        [-2, 2],
+                        [-1.5, 1],
+                        [-0.5, 1],
+                        [0, 2],
+                        [0.5, 1],
+                        [-2, 1],
+                        [-2, 2],
+                    ],
+                ],
+            ];
+
+            const ans = removeDegenerateEdges(cp, bbox);
+
+            o(ans).deepEquals([
+                [
+                    [
+                        [-2, 1],
+                        [-1.5, 1],
+                        [-2, 2],
+                        [-2, 1],
+                    ],
+                ],
+                [
+                    [
+                        [-0.5, 1],
+                        [0.5, 1],
+                        [0, 2],
+                        [-0.5, 1],
+                    ],
+                ],
+            ]);
+        });
+
+        o('three bumps', () => {
+            const degen: MultiPolygon = [
+                [
+                    [
+                        [0, 0],
+                        [159, 0],
+                        [462, -3547],
+                        [840, -3547],
+                        [838, -3500],
+                        [984, -3500],
+                        [992, -3547],
+                        [999, -3547],
+                        [1013, -3444],
+                        [1026, -3441],
+                        [1045, -3442],
+                        [1050, -3547],
+                        [-693, -3547],
+                        [-693, -3000],
+                        [-2367, -3000],
+                        [-2372, -3547],
+                        [-2513, -3547],
+                        [-2528, 0],
+                        [0, 0],
+                    ],
+                ],
+            ];
+
+            const bbox = Bounds.fromBbox([-3000, -3547, 3000, 1000]);
+
+            const ans = removeDegenerateEdges(degen, bbox);
+
+            o(ans).deepEquals([
+                [
+                    [
+                        [-2528, 0],
+                        [-2513, -3547],
+                        [-2372, -3547],
+                        [-2367, -3000],
+                        [-693, -3000],
+                        [-693, -3547],
+                        [462, -3547],
+                        [159, 0],
+                        [-2528, 0],
+                    ],
+                ],
+                [
+                    [
+                        [838, -3500],
+                        [840, -3547],
+                        [992, -3547],
+                        [984, -3500],
+                        [838, -3500],
+                    ],
+                ],
+                [
+                    [
+                        [999, -3547],
+                        [1050, -3547],
+                        [1045, -3442],
+                        [1026, -3441],
+                        [1013, -3444],
+                        [999, -3547],
+                    ],
+                ],
+            ]);
+        });
+
+        o('loop', () => {
+            const bbox = Bounds.fromBbox([0, 3, 10, 8]);
+
+            const orig: MultiPolygon = [
+                [
+                    [
+                        [8, 6],
+                        [2, 6],
+                        [2, 1],
+                        [4, 1],
+                        [4, 4],
+                        [6, 4],
+                        [6, 1],
+                        [8, 1],
+                        [8, 6],
+                    ],
+                ],
+            ];
+
+            const cp = clipMultipolygon(orig, bbox);
+            const ans = removeDegenerateEdges(cp, bbox);
+
+            o(ans).deepEquals([
+                [
+                    [
+                        [2, 3],
+                        [4, 3],
+                        [4, 4],
+                        [6, 4],
+                        [6, 3],
+                        [8, 3],
+                        [8, 6],
+                        [2, 6],
+                        [2, 3],
+                    ],
+                ],
+            ]);
+        });
+
+        o('complex', () => {
+            const bbox = Bounds.fromBbox([-3, -4, 4, 4]);
+            const cp = clipMultipolygon(polys, bbox);
+            const ans = removeDegenerateEdges(cp, bbox);
+
+            o(round(ans, 2)).deepEquals([
+                [
+                    [
+                        [-3, -4],
+                        [-0.25, -4],
+                        [-3, -1.8],
+                        [-3, -4],
+                    ],
+                ],
+                [
+                    [
+                        [-3, 0],
+                        [-2, 1],
+                        [-3, 1.5],
+                        [-3, 0],
+                    ],
+                ],
+                [
+                    [
+                        [-1.33, 4],
+                        [0, 3],
+                        [0.5, 4],
+                        [-1.33, 4],
+                    ],
+                ],
+                [
+                    [
+                        [2, -4],
+                        [3.33, -4],
+                        [2, -2],
+                        [2, -4],
+                    ],
+                ],
+                [
+                    [
+                        [2, 0],
+                        [4, -1],
+                        [4, 1.5],
+                        [2, 0],
+                    ],
+                ],
+                [
+                    [
+                        [2, 3],
+                        [3, 3],
+                        [3, 4],
+                        [2, 4],
+                        [2, 3],
+                    ],
+                ],
+            ]);
+        });
+    });
+});

--- a/packages/cli/src/cog/__test__/source.tiff.testhelper.ts
+++ b/packages/cli/src/cog/__test__/source.tiff.testhelper.ts
@@ -1,4 +1,5 @@
-import { GeoJson, EpsgCode } from '@basemaps/geo';
+import { EpsgCode } from '@basemaps/geo';
+import { NamedBounds } from '@basemaps/shared';
 import { CogJob } from '../types';
 
 export const SourceTiffTestHelper = {
@@ -6,7 +7,7 @@ export const SourceTiffTestHelper = {
         return {
             projection: EpsgCode.Google,
             source: {
-                files: [] as string[],
+                files: [] as NamedBounds[],
                 resZoom: 13,
                 pixelScale: 9.55,
                 path: '',
@@ -20,35 +21,26 @@ export const SourceTiffTestHelper = {
         } as CogJob;
     },
 
-    tiffPolygons(): GeoJSON.Position[][] {
+    tiffNztmBounds(path = '/path/to'): NamedBounds[] {
         return [
-            [
-                [174.56568549279925, -40.83842049282911],
-                [174.57337757492053, -41.162595138463644],
-                [174.85931317513828, -41.15833331417625],
-                [174.85022498195937, -40.834206771481526],
-                [174.56568549279925, -40.83842049282911],
-            ],
-
-            [
-                [174.85022498195937, -40.834206771481526],
-                [174.85931317513828, -41.15833331417625],
-                [175.14518230301843, -41.15336229204068],
-                [175.13469922175867, -40.829291849263555],
-                [174.85022498195937, -40.834206771481526],
-            ],
+            {
+                name: path + '/tiff1.tiff',
+                x: 1732000,
+                y: 5442000,
+                width: 24000,
+                height: 36000,
+            },
+            {
+                name: path + '/tiff2.tiff',
+                x: 1756000,
+                y: 5442000,
+                width: 24000,
+                height: 36000,
+            },
         ];
     },
 
-    polygonsToPaths(polygons: GeoJSON.Position[][]): string[] {
-        return polygons.map((_, i): string => `/path/to/tiff${i}.tiff`);
-    },
-
-    makeTiffFeatureCollection(polygons?: GeoJSON.Position[][], paths?: string[]): GeoJSON.FeatureCollection {
-        if (polygons == null) polygons = SourceTiffTestHelper.tiffPolygons();
-        if (paths == null) paths = SourceTiffTestHelper.polygonsToPaths(polygons);
-        return GeoJson.toFeatureCollection(
-            polygons.map((coords, i) => GeoJson.toFeaturePolygon([coords], { tiff: paths![i] })),
-        );
+    namedBoundsToPaths(bounds: NamedBounds[]): string[] {
+        return bounds.map(({ name }): string => `/path/to/tiff${name}.tiff`);
     },
 };

--- a/packages/cli/src/cog/clipped.multipolygon.ts
+++ b/packages/cli/src/cog/clipped.multipolygon.ts
@@ -1,0 +1,31 @@
+import { Bounds } from '@basemaps/geo';
+import lineclip from 'lineclip';
+import pc, { MultiPolygon } from 'polygon-clipping';
+
+function samePoint(a: number[], b: number[]): boolean {
+    return a[0] == b[0] && a[1] == b[1];
+}
+
+export function clipMultipolygon(polygons: MultiPolygon, bounds: Bounds): MultiPolygon {
+    const result: MultiPolygon = [];
+    const bbox = bounds.toBbox();
+    for (const poly of polygons) {
+        const clipped = lineclip.polygon(poly[0], bbox);
+        if (clipped.length != 0) {
+            if (!samePoint(clipped[0], clipped[clipped.length - 1])) clipped.push(clipped[0]);
+            result.push([clipped]);
+        }
+    }
+    return result;
+}
+
+export function removeDegenerateEdges(polygons: MultiPolygon, bounds: Bounds): MultiPolygon {
+    return pc.intersection(polygons, bounds.toPolygon());
+}
+
+export function polyContainsBounds(poly: MultiPolygon, bounds: Bounds): boolean {
+    const clipped = clipMultipolygon(poly, bounds);
+    if (clipped.length != 1 || clipped[0].length != 1 || clipped[0][0].length != 5) return false;
+
+    return Bounds.fromMultiPolygon(clipped).containsBounds(bounds);
+}

--- a/packages/cli/src/cog/cutline.ts
+++ b/packages/cli/src/cog/cutline.ts
@@ -1,10 +1,10 @@
 import { Bounds, Epsg, GeoJson, Tile, TileMatrixSet } from '@basemaps/geo';
 import { compareName, FileOperator, NamedBounds, ProjectionTileMatrixSet } from '@basemaps/shared';
-import { FeatureCollection, Position } from 'geojson';
-import { basename } from 'path';
-import pc, { MultiPolygon, Polygon, Ring } from 'polygon-clipping';
+import { FeatureCollection } from 'geojson';
 import { CoveringFraction, MaxImagePixelWidth } from './constants';
 import { CogJob, SourceMetadata } from './types';
+import { clipMultipolygon, removeDegenerateEdges, polyContainsBounds } from './clipped.multipolygon';
+import pc, { MultiPolygon, Ring, Polygon } from 'polygon-clipping';
 const { intersection, union } = pc;
 
 /** Padding to always apply to image boundies */
@@ -14,18 +14,13 @@ function findGeoJsonProjection(geojson: any | null): Epsg {
     return Epsg.parse(geojson?.crs?.properties?.name ?? '') ?? Epsg.Wgs84;
 }
 
-function polysSameShape(a: Polygon, b: Polygon): boolean {
-    if (a.length != b.length) return false;
-    for (let i = 0; i < a.length; ++i) {
-        if (a[i].length != b[i].length) return false;
-    }
-    return true;
-}
-
 function namedBounds(tms: TileMatrixSet, tile: Tile): NamedBounds {
     return { name: TileMatrixSet.tileToName(tile), ...tms.tileToSourceBounds(tile).toJson() };
 }
 
+/**
+ * Filter out duplicate tiles
+ */
 function addNonDupes(list: Tile[], addList: Tile[]): void {
     const len = list.length;
     for (const add of addList) {
@@ -47,6 +42,7 @@ export class Cutline {
     targetProj: ProjectionTileMatrixSet;
     blend: number;
     tms: TileMatrixSet; // convience to targetProj.tms
+    private srcPoly: MultiPolygon = [];
 
     /**
      * Create a Cutline instance from a `GeoJSON FeatureCollection`.
@@ -98,38 +94,35 @@ export class Cutline {
      * @param job
      * @param  sourceGeo
      */
-    filterSourcesForName(name: string, job: CogJob, sourceGeo: FeatureCollection): void {
+    filterSourcesForName(name: string, job: CogJob): void {
         const tile = TileMatrixSet.nameToTile(name);
-        const qkBounds = this.targetProj.tileToSourceBounds(tile);
-        const qkPadded = this.padBounds(qkBounds, job.source.resZoom);
+        const { targetProj } = this;
+        const tileBounds = targetProj.tileToSourceBounds(tile);
+        const tilePadded = this.padBounds(tileBounds, job.source.resZoom);
 
-        const srcTiffs = new Set<string>();
+        let tileBoundsInSrcProj = tilePadded;
 
-        for (const f of sourceGeo.features) {
-            const { geometry } = f;
-            if (geometry.type === 'Polygon') {
-                const srcBounds = this.sourceWsg84PolyToBounds(geometry.coordinates[0]);
-                if (qkPadded.intersects(srcBounds)) {
-                    srcTiffs.add(basename(f.properties!.tiff!));
-                }
-            }
+        if (job.source.projection !== this.tms.projection.code) {
+            // convert the padded quadKey to source projection ensuring fully enclosed
+            const sourceProj = ProjectionTileMatrixSet.get(job.source.projection);
+            const poly = targetProj.projectMultipolygon([tileBoundsInSrcProj.toPolygon()], sourceProj);
+            tileBoundsInSrcProj = Bounds.fromMultiPolygon(poly);
         }
-        job.source.files = job.source.files.filter((path) => srcTiffs.has(basename(path)));
+
+        job.source.files = job.source.files.filter((image) => tileBoundsInSrcProj.intersects(Bounds.fromJson(image)));
 
         if (this.clipPoly.length > 0) {
-            const boundsPoly = GeoJson.toPositionPolygon(qkPadded.toBbox()) as Polygon;
-            const poly = intersection(boundsPoly, this.clipPoly);
-            if (poly == null || poly.length == 0) {
+            const poly = clipMultipolygon(this.clipPoly, tilePadded);
+            if (poly.length == 0) {
                 // this tile is not needed
                 this.clipPoly = [];
                 job.source.files = [];
-            } else if (
-                poly.length == 1 &&
-                polysSameShape(poly[0], boundsPoly) &&
-                this.sourcePolyToBounds(poly[0][0]).containsBounds(qkBounds)
-            ) {
+            } else if (polyContainsBounds(poly, tileBounds)) {
                 // tile is completely surrounded; no cutline polygons needed
                 this.clipPoly = [];
+            } else {
+                // set the cutline polygons to just the area of interest (minus degenerate edges)
+                this.clipPoly = removeDegenerateEdges(poly, tilePadded);
             }
         }
     }
@@ -139,7 +132,7 @@ export class Cutline {
      * @param featureCollection Source TIff Polygons in GeoJson WGS84
      */
     optimizeCovering(sourceMetadata: SourceMetadata): NamedBounds[] {
-        const srcArea = this.findCovering(sourceMetadata);
+        this.findCovering(sourceMetadata);
 
         const { resZoom } = sourceMetadata;
         // Look for the biggest tile size we are allowed to create.
@@ -154,7 +147,7 @@ export class Cutline {
 
         for (const tile of tms.topLevelTiles()) {
             // Don't make COGs with a tile.z < minZ.
-            tiles = tiles.concat(this.makeTiles(tile, srcArea, minZ, CoveringFraction).tiles);
+            tiles = tiles.concat(this.makeTiles(tile, this.srcPoly, minZ, CoveringFraction).tiles);
         }
 
         if (tiles.length == 0) {
@@ -182,36 +175,6 @@ export class Cutline {
     }
 
     /**
-     * Convert a Wsg84 "square" polygon to it's bounds
-     */
-    private sourcePolyToBounds(poly: Position[]): Bounds {
-        const [x1, y1] = poly[0];
-        const [x2, y2] = poly[2];
-
-        return new Bounds(Math.min(x1, x2), Math.min(y1, y2), Math.abs(x2 - x1), Math.abs(y2 - y1));
-    }
-
-    /**
-     * Convert a Wsg84 polygon to it's bounds
-     */
-    private sourceWsg84PolyToBounds(poly: Position[]): Bounds {
-        const { fromWsg84 } = this.targetProj;
-        let minX = Infinity;
-        let minY = Infinity;
-        let maxX = -Infinity;
-        let maxY = -Infinity;
-        for (const p of poly) {
-            const [x, y] = fromWsg84(p);
-            if (x < minX) minX = x;
-            if (y < minY) minY = y;
-            if (x > maxX) maxX = x;
-            if (y > maxY) maxY = y;
-        }
-
-        return new Bounds(minX, minY, maxX - minX, maxY - minY);
-    }
-
-    /**
      * Merge child nodes that have at least a covering fraction
      * @param tile the tile to descend
      * @param srcArea the aread of interest
@@ -226,12 +189,14 @@ export class Cutline {
         minZ: number,
         coveringFraction: number,
     ): { tiles: Tile[]; fractionCovered: number } {
-        const clip = this.targetProj.tileToPolygon(tile) as Polygon;
-        const intArea = intersection(srcArea, clip);
+        const clipBounds = this.targetProj.tileToSourceBounds(tile);
 
-        if (intArea.length == 0) {
+        srcArea = clipMultipolygon(srcArea, clipBounds);
+
+        if (srcArea.length == 0) {
             return { tiles: [], fractionCovered: 0 };
         }
+
         if (tile.z == minZ + 4) {
             return { tiles: [tile], fractionCovered: 1 };
         }
@@ -239,7 +204,7 @@ export class Cutline {
         const ans = { tiles: [] as Tile[], fractionCovered: 0 };
 
         for (const child of this.tms.coverTile(tile)) {
-            const { tiles, fractionCovered } = this.makeTiles(child, intArea, minZ, coveringFraction);
+            const { tiles, fractionCovered } = this.makeTiles(child, srcArea, minZ, coveringFraction);
             if (fractionCovered != 0) {
                 ans.fractionCovered += fractionCovered * 0.25;
                 addNonDupes(ans.tiles, tiles);
@@ -266,33 +231,38 @@ export class Cutline {
 
      * @param sourceMetadata
      */
-    private findCovering(sourceMetadata: SourceMetadata): MultiPolygon {
-        let srcArea: MultiPolygon = [];
+    private findCovering(sourceMetadata: SourceMetadata): void {
+        let srcPoly: MultiPolygon = [];
         const { resZoom } = sourceMetadata;
 
         // merge imagery bounds
-        for (const { geometry } of sourceMetadata.bounds.features) {
-            if (geometry.type === 'Polygon') {
-                // ensure source polys overlap by using their bounding box
-                const poly = GeoJson.toPositionPolygon(
-                    this.padBounds(this.sourceWsg84PolyToBounds(geometry.coordinates[0]), resZoom).toBbox(),
-                ) as Polygon;
-                if (srcArea.length == 0) {
-                    srcArea.push(poly);
-                } else {
-                    srcArea = union(srcArea, poly) as MultiPolygon;
-                }
-            }
+        for (const image of sourceMetadata.bounds) {
+            const poly = Bounds.fromJson(image).toPolygon() as Polygon;
+            srcPoly = union(srcPoly, poly);
         }
 
-        if (this.clipPoly.length != 0) {
-            // clip the imagery bounds
-            this.clipPoly = (intersection(srcArea, this.clipPoly) ?? []) as MultiPolygon;
-            return this.clipPoly;
-        }
+        // Convert polygon to target projection
+        const sourceProj = ProjectionTileMatrixSet.get(sourceMetadata.projection);
+        srcPoly = sourceProj.projectMultipolygon(srcPoly, this.targetProj) as MultiPolygon;
+        this.srcPoly = srcPoly;
 
-        // no cutline return imagery bounds
-        return srcArea;
+        if (this.clipPoly.length == 0) return;
+
+        const srcBounds = Bounds.fromMultiPolygon(srcPoly);
+        const boundsPadded = this.padBounds(srcBounds, resZoom);
+
+        const poly = clipMultipolygon(this.clipPoly, boundsPadded);
+        if (poly.length == 0) {
+            throw new Error('No intersection between source imagery and cutline');
+        }
+        if (polyContainsBounds(poly, srcBounds)) {
+            // tile is completely surrounded; no cutline polygons needed
+            this.clipPoly = [];
+        } else {
+            // set the cutline polygons to just the area of interest (minus degenerate edges)
+            this.clipPoly = removeDegenerateEdges(poly, boundsPadded);
+            this.srcPoly = intersection(srcPoly, this.clipPoly) ?? [];
+        }
     }
 
     /**
@@ -305,6 +275,8 @@ export class Cutline {
         const px = this.tms.pixelScale(resZoom);
 
         // Ensure cutline blend does not interferre with non-costal edges
-        return bounds.scaleFromCenter((bounds.width + px * (PixelPadding + this.blend) * 2) / bounds.width);
+        const widthScale = (bounds.width + px * (PixelPadding + this.blend) * 2) / bounds.width;
+        const heightScale = (bounds.height + px * (PixelPadding + this.blend) * 2) / bounds.height;
+        return bounds.scaleFromCenter(widthScale, heightScale);
     }
 }

--- a/packages/cli/src/cog/types.ts
+++ b/packages/cli/src/cog/types.ts
@@ -14,7 +14,7 @@ export interface CogJob {
 
     source: {
         /** List of input files */
-        files: string[];
+        files: NamedBounds[];
 
         /** The number of pixels per meter for the best source image */
         pixelScale: number;
@@ -78,7 +78,7 @@ export interface SourceMetadata {
     /** Number of imagery bands generally RGB (3) or RGBA (4) */
     bands: number;
     /** Bounding box for polygons */
-    bounds: GeoJSON.FeatureCollection;
+    bounds: NamedBounds[];
 
     /** The number of pixels per meter for the best source image */
     pixelScale: number;

--- a/packages/cli/src/lineclip.d.ts
+++ b/packages/cli/src/lineclip.d.ts
@@ -1,0 +1,3 @@
+declare module 'lineclip' {
+    export function polygon(points: number[][], bbox: number[]): [number, number][];
+}

--- a/packages/geo/src/__tests__/bounds.test.ts
+++ b/packages/geo/src/__tests__/bounds.test.ts
@@ -1,6 +1,6 @@
+import { Approx } from '@basemaps/test';
 import o from 'ospec';
 import { Bounds } from '../bounds';
-import { Approx } from '@basemaps/test';
 
 const TILE_SIZE = 256;
 function getTile(x = 0, y = 0): Bounds {
@@ -109,5 +109,33 @@ o.spec('Bounds', () => {
         o(compareArea(new Bounds(4, 5, 1, 1), new Bounds(4, 4, 1, 1))).equals(1);
 
         o(compareArea(new Bounds(3, 5, 1, 1), new Bounds(3, 5, 2, 5))).equals(-9);
+    });
+
+    o('fromMultiPolygon', () => {
+        const poly = [
+            [
+                [
+                    [84, -49],
+                    [74, -40],
+                    [90, -57],
+                    [94, -39],
+                    [84, -49],
+                ],
+            ],
+        ];
+
+        o(Bounds.fromMultiPolygon(poly).toJson()).deepEquals({ x: 74, y: -57, width: 20, height: 18 });
+    });
+
+    o('toPolygon', () => {
+        o(new Bounds(74, -57, 20, 18).toPolygon()).deepEquals([
+            [
+                [74, -57],
+                [74, -39],
+                [94, -39],
+                [94, -57],
+                [74, -57],
+            ],
+        ]);
     });
 });

--- a/packages/geo/src/bounds.ts
+++ b/packages/geo/src/bounds.ts
@@ -115,6 +115,21 @@ export class Bounds implements BoundingBox {
     }
 
     /**
+     * Convert to GeoJson Polygon coordinates
+     */
+    public toPolygon(): [number, number][][] {
+        return [
+            [
+                [this.x, this.y],
+                [this.x, this.bottom],
+                [this.right, this.bottom],
+                [this.right, this.y],
+                [this.x, this.y],
+            ],
+        ];
+    }
+
+    /**
      * Scale the bounding box adjusting top, left, width & height
      *
      * @param scaleX scale x parameters (left, width)
@@ -151,6 +166,29 @@ export class Bounds implements BoundingBox {
 
     public subtract(bounds: Point): Bounds {
         return new Bounds(this.x - bounds.x, this.y - bounds.y, this.width, this.height);
+    }
+
+    /**
+     * Find the bounds of a GeoJson MultiPolygon
+
+     * @param multipoly the polygon to measure
+     */
+    public static fromMultiPolygon(multipoly: number[][][][]): Bounds {
+        if (multipoly.length == 0) return new Bounds(0, 0, 0, 0);
+        let minX = multipoly[0][0][0][0];
+        let minY = multipoly[0][0][0][1];
+        let maxX = minX;
+        let maxY = minY;
+        for (const [poly] of multipoly) {
+            for (const [x, y] of poly) {
+                if (x < minX) minX = x;
+                else if (x > maxX) maxX = x;
+                if (y < minY) minY = y;
+                else if (y > maxY) maxY = y;
+            }
+        }
+
+        return new Bounds(minX, minY, maxX - minX, maxY - minY);
     }
 
     /**

--- a/packages/geo/src/geo.json.ts
+++ b/packages/geo/src/geo.json.ts
@@ -12,18 +12,6 @@ export const GeoJson = {
         };
     },
 
-    toPositionPolygon(bbox: [number, number, number, number]): Position[][] {
-        return [
-            [
-                [bbox[0], bbox[1]],
-                [bbox[0], bbox[3]],
-                [bbox[2], bbox[3]],
-                [bbox[2], bbox[1]],
-                [bbox[0], bbox[1]],
-            ],
-        ];
-    },
-
     toPolygon(coordinates: Position[][]): Polygon {
         return {
             type: 'Polygon',

--- a/packages/shared/src/tms/__test__/projection.tile.matrix.set.test.ts
+++ b/packages/shared/src/tms/__test__/projection.tile.matrix.set.test.ts
@@ -107,6 +107,33 @@ o.spec('ProjectionTileMatrixSet', () => {
         ]);
     });
 
+    o('projectMultipolygon', () => {
+        const poly = [
+            Bounds.fromBbox([
+                18494091.86765497,
+                -6051366.655280836,
+                19986142.659781612,
+                -4016307.214216303,
+            ]).toPolygon(),
+        ];
+
+        o(googleProj.projectMultipolygon(poly, googleProj)).equals(poly);
+
+        const ans = googleProj.projectMultipolygon(poly, nztmProj);
+
+        o(round(ans, 4)).deepEquals([
+            [
+                [
+                    [1084733.8967, 4698018.9435],
+                    [964788.1197, 6226878.2808],
+                    [2204979.5633, 6228860.047],
+                    [2090794.171, 4700144.6365],
+                    [1084733.8967, 4698018.9435],
+                ],
+            ],
+        ]);
+    });
+
     o.spec('TilingBounds', () => {
         // Approximate bounding box of new zealand
         const tifBoundingBox: [number, number, number, number] = [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4658,6 +4658,11 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lineclip@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/lineclip/-/lineclip-1.1.5.tgz#2bf26067d94354feabf91e42768236db5616fd13"
+  integrity sha1-K/JgZ9lDVP6r+R5CdoI221YW/RM=
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"


### PR DESCRIPTION
Use clipline to reduce polygon when we don't care about degenerate edges. When we do care call
intersection to remove the degenerate edges.

Store image bounds not polygons in SourceMetadata and also store in CogJob. This reduces
floating-point errors when combining source imagery bounds into composite polygons.

Note:

The Martinez polygon-clipping libraries can suffer from errors when lines align. Other intersection
libraries are intractable for the size of coastline polygons.  A solution is to call intersection
after first calling clipline.