### PR TITLE
fix(cli): ensure fatal errors set process exit code to 1

### DIFF
--- a/packages/cli/src/cli/base.cli.ts
+++ b/packages/cli/src/cli/base.cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { Env, LogConfig } from '@basemaps/shared';
+import { Env, LogConfig, LoggerFatalError } from '@basemaps/shared';
 import { GitTag } from '@basemaps/shared/build/cli/git.tag';
 import { CommandLineParser } from '@rushstack/ts-command-line';
 import { PrettyTransform } from 'pretty-json-log';
@@ -57,7 +57,11 @@ export abstract class BaseCommandLine extends CommandLineParser {
 
     public run(): void {
         this.executeWithoutErrorHandling().catch((err) => {
-            LogConfig.get().fatal({ err }, 'Failed to run command');
+            if (err instanceof LoggerFatalError) {
+                LogConfig.get().fatal(err.obj, err.message);
+            } else {
+                LogConfig.get().fatal({ err }, 'Failed to run command');
+            }
             process.exit(1);
         });
     }

--- a/packages/cli/src/cog/builder.ts
+++ b/packages/cli/src/cog/builder.ts
@@ -1,5 +1,11 @@
 import { Epsg, GeoJson, Bounds } from '@basemaps/geo';
-import { CompositeError, FileOperatorSimple, LogType, ProjectionTileMatrixSet } from '@basemaps/shared';
+import {
+    CompositeError,
+    FileOperatorSimple,
+    LogType,
+    ProjectionTileMatrixSet,
+    LoggerFatalError,
+} from '@basemaps/shared';
 import { CogSource, CogTiff, TiffTag, TiffTagGeo } from '@cogeotiff/core';
 import { CogSourceFile } from '@cogeotiff/source-file';
 import { createHash } from 'crypto';
@@ -170,8 +176,10 @@ export class CogBuilder {
         const noDataNum = parseInt(noData);
 
         if (isNaN(noDataNum) || noDataNum < 0 || noDataNum > 256) {
-            this.logger.fatal({ tiff: tiff.source.name, noData }, 'Failed converting GDAL_NODATA, defaulting to 255');
-            throw new Error(`Invalid GDAL_NODATA: ${noData}`);
+            throw new LoggerFatalError(
+                { tiff: tiff.source.name, noData },
+                'Failed converting GDAL_NODATA, defaulting to 255',
+            );
         }
 
         return noDataNum;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,6 +8,7 @@ export { tileFromPath, TileType, TileData, TileDataWmts, TileDataXyz } from './a
 export { V, VNode, VNodeElement, VNodeText } from './vdom';
 export { VNodeParser } from './vdom.parse';
 export { CompositeError } from './composite.error';
+export { LoggerFatalError } from './logger.fatal.error';
 export * from './tms/projection.tile.matrix.set';
 
 export * from './aws/tile.metadata.base';

--- a/packages/shared/src/logger.fatal.error.ts
+++ b/packages/shared/src/logger.fatal.error.ts
@@ -1,0 +1,10 @@
+/**
+ * Utility error to throw expecting that Logger will fatal log its contents
+ */
+export class LoggerFatalError extends Error {
+    obj: Record<string, unknown>;
+    constructor(obj: Record<string, unknown>, msg: string) {
+        super(msg);
+        this.obj = obj;
+    }
+}


### PR DESCRIPTION
### Fixes

`cogify cog` was detecting `job.json` version mismatch but was exiting the process with code 0 (success); now exits with code 1.
