### PR TITLE
chore(ci): use npm-audit-resolver

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,7 +22,7 @@ jobs:
         run: yarn
 
       - name: Audit
-        run: yarn audit
+        run: npx check-audit --yarn
 
       - name: Build
         run: yarn run build

--- a/audit-resolve.json
+++ b/audit-resolve.json
@@ -1,0 +1,116 @@
+{
+  "decisions": {
+    "1523|@typescript-eslint/eslint-plugin>@typescript-eslint/experimental-utils>@typescript-eslint/typescript-estree>lodash": {
+      "decision": "ignore",
+      "madeAt": 1593732230431,
+      "expiresAt": 1594337019864
+    },
+    "1523|@typescript-eslint/parser>@typescript-eslint/experimental-utils>@typescript-eslint/typescript-estree>lodash": {
+      "decision": "ignore",
+      "madeAt": 1593732230432,
+      "expiresAt": 1594337019864
+    },
+    "1523|@typescript-eslint/parser>@typescript-eslint/typescript-estree>lodash": {
+      "decision": "ignore",
+      "madeAt": 1593732230432,
+      "expiresAt": 1594337019864
+    },
+    "1523|eslint>inquirer>lodash": {
+      "decision": "ignore",
+      "madeAt": 1593732230432,
+      "expiresAt": 1594337019864
+    },
+    "1523|eslint>lodash": {
+      "decision": "ignore",
+      "madeAt": 1593732230432,
+      "expiresAt": 1594337019864
+    },
+    "1523|eslint>table>lodash": {
+      "decision": "ignore",
+      "madeAt": 1593732230432,
+      "expiresAt": 1594337019864
+    },
+    "1523|lerna>@lerna/clean>@lerna/prompt>inquirer>lodash": {
+      "decision": "ignore",
+      "madeAt": 1593732230432,
+      "expiresAt": 1594337019864
+    },
+    "1523|lerna>@lerna/import>@lerna/prompt>inquirer>lodash": {
+      "decision": "ignore",
+      "madeAt": 1593732230432,
+      "expiresAt": 1594337019864
+    },
+    "1523|lerna>@lerna/publish>@lerna/npm-dist-tag>@lerna/otplease>@lerna/prompt>inquirer>lodash": {
+      "decision": "ignore",
+      "madeAt": 1593732230432,
+      "expiresAt": 1594337019864
+    },
+    "1523|lerna>@lerna/publish>@lerna/npm-publish>@lerna/otplease>@lerna/prompt>inquirer>lodash": {
+      "decision": "ignore",
+      "madeAt": 1593732230432,
+      "expiresAt": 1594337019864
+    },
+    "1523|lerna>@lerna/publish>@lerna/otplease>@lerna/prompt>inquirer>lodash": {
+      "decision": "ignore",
+      "madeAt": 1593732230432,
+      "expiresAt": 1594337019864
+    },
+    "1523|lerna>@lerna/publish>@lerna/prompt>inquirer>lodash": {
+      "decision": "ignore",
+      "madeAt": 1593732230432,
+      "expiresAt": 1594337019864
+    },
+    "1523|lerna>@lerna/publish>@lerna/version>@lerna/prompt>inquirer>lodash": {
+      "decision": "ignore",
+      "madeAt": 1593732230432,
+      "expiresAt": 1594337019864
+    },
+    "1523|lerna>@lerna/version>@lerna/prompt>inquirer>lodash": {
+      "decision": "ignore",
+      "madeAt": 1593732230432,
+      "expiresAt": 1594337019864
+    },
+    "1523|lerna>@lerna/publish>@lerna/version>@lerna/conventional-commits>conventional-changelog-core>conventional-changelog-writer>lodash": {
+      "decision": "ignore",
+      "madeAt": 1593732230432,
+      "expiresAt": 1594337019864
+    },
+    "1523|lerna>@lerna/version>@lerna/conventional-commits>conventional-changelog-core>conventional-changelog-writer>lodash": {
+      "decision": "ignore",
+      "madeAt": 1593732230432,
+      "expiresAt": 1594337019864
+    },
+    "1523|lerna>@lerna/publish>@lerna/version>@lerna/conventional-commits>conventional-changelog-core>conventional-commits-parser>lodash": {
+      "decision": "ignore",
+      "madeAt": 1593732230432,
+      "expiresAt": 1594337019864
+    },
+    "1523|lerna>@lerna/version>@lerna/conventional-commits>conventional-changelog-core>conventional-commits-parser>lodash": {
+      "decision": "ignore",
+      "madeAt": 1593732230432,
+      "expiresAt": 1594337019864
+    },
+    "1523|lerna>@lerna/publish>@lerna/version>@lerna/conventional-commits>conventional-recommended-bump>conventional-commits-parser>lodash": {
+      "decision": "ignore",
+      "madeAt": 1593732230432,
+      "expiresAt": 1594337019864
+    },
+    "1523|lerna>@lerna/version>@lerna/conventional-commits>conventional-recommended-bump>conventional-commits-parser>lodash": {
+      "decision": "ignore",
+      "madeAt": 1593732230432,
+      "expiresAt": 1594337019864
+    },
+    "1523|lerna>@lerna/publish>@lerna/version>@lerna/conventional-commits>conventional-changelog-core>lodash": {
+      "decision": "ignore",
+      "madeAt": 1593732230432,
+      "expiresAt": 1594337019864
+    },
+    "1523|lerna>@lerna/version>@lerna/conventional-commits>conventional-changelog-core>lodash": {
+      "decision": "ignore",
+      "madeAt": 1593732230432,
+      "expiresAt": 1594337019864
+    }
+  },
+  "rules": {},
+  "version": 1
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint-config-prettier": "^6.3.0",
     "eslint-plugin-prettier": "^3.1.0",
     "lerna": "^3.20.2",
+    "npm-audit-resolver": "^2.2.0",
     "ospec": "^4.0.1",
     "prettier": "^2.0.2",
     "rimraf": "^3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -646,6 +646,11 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
+"@korzio/djv-draft-04@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@korzio/djv-draft-04/-/djv-draft-04-2.0.1.tgz#2984289426cac5ed622b26a58c3af8584aefbdfe"
+  integrity sha512-MeTVcNsfCIYxK6T7jW1sroC7dBAb4IfLmQe6RoCqlxHN5NFkzNpgdnBPR+/0D2wJDUJHM9s9NQv+ouhxKjvUjg==
+
 "@lerna/add@3.21.0":
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.21.0.tgz#27007bde71cc7b0a2969ab3c2f0ae41578b4577b"
@@ -1998,6 +2003,17 @@ atomic-sleep@^1.0.0:
   resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
   integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
 
+audit-resolve-core@^1.1.7:
+  version "1.1.7"
+  resolved "https://registry.yarnpkg.com/audit-resolve-core/-/audit-resolve-core-1.1.7.tgz#2c04141e45b7464b0f683e57f32aa93a6cf218d0"
+  integrity sha512-9nLm9SgyMbMv86X5a/E6spcu3V+suceHF6Pg4BwjPqfxWBKDvISagJH9Ji592KihqBev4guKFO3BiNEVNnqh3A==
+  dependencies:
+    concat-stream "^1.6.2"
+    debug "^4.1.1"
+    djv "^2.1.2"
+    spawn-shell "^2.1.0"
+    yargs-parser "^10.1.0"
+
 aws-cdk@^1.46.0:
   version "1.46.0"
   resolved "https://registry.yarnpkg.com/aws-cdk/-/aws-cdk-1.46.0.tgz#1e6f5739f22f08bef5807083523f45f03a624a0d"
@@ -2300,7 +2316,7 @@ camelcase@^4.1.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
   integrity sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=
 
-camelcase@^5.0.0:
+camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
@@ -2545,7 +2561,7 @@ concat-map@0.0.1:
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
-concat-stream@^1.5.0:
+concat-stream@^1.5.0, concat-stream@^1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/concat-stream/-/concat-stream-1.6.2.tgz#904bdf194cd3122fc675c77fc4ac3d4ff0fd1a34"
   integrity sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
@@ -2872,6 +2888,11 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
+default-shell@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/default-shell/-/default-shell-1.0.1.tgz#752304bddc6174f49eb29cb988feea0b8813c8bc"
+  integrity sha1-dSMEvdxhdPSespy5iP7qC4gTyLw=
+
 defaults@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
@@ -2978,6 +2999,13 @@ dir-glob@^2.2.2:
   integrity sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==
   dependencies:
     path-type "^3.0.0"
+
+djv@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/djv/-/djv-2.1.2.tgz#5bf4344cdd5f7df82764d99a4f0684899d570216"
+  integrity sha512-ltQSINn+7aMTp7pKeQpfZg2ACd/Gy6VrL3LYuT25/plwPBb7xlGOekr463Luqn816AWJLuP7KZQGFct2JICyeA==
+  optionalDependencies:
+    "@korzio/djv-draft-04" "^2.0.1"
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -3567,6 +3595,13 @@ flat-cache@^2.0.1:
     flatted "^2.0.0"
     rimraf "2.6.3"
     write "1.0.3"
+
+flat@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/flat/-/flat-4.1.0.tgz#090bec8b05e39cba309747f1d588f04dbaf98db2"
+  integrity sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==
+  dependencies:
+    is-buffer "~2.0.3"
 
 flatstr@^1.0.12:
   version "1.0.12"
@@ -4229,6 +4264,11 @@ is-buffer@^1.1.5, is-buffer@~1.1.1:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
+is-buffer@~2.0.3:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
+  integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
+
 is-callable@^1.1.4, is-callable@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.5.tgz#f7e46b596890456db74e7f6e976cb3273d06faab"
@@ -4348,7 +4388,7 @@ is-obj@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
   integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
 
-is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
+is-plain-obj@^1.0.0, is-plain-obj@^1.1, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
@@ -4529,6 +4569,11 @@ jsonfile@^6.0.1:
     universalify "^1.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+jsonlines@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/jsonlines/-/jsonlines-0.1.1.tgz#4fcd246dc5d0e38691907c44ab002f782d1d94cc"
+  integrity sha1-T80kbcXQ44aRkHxEqwAveC0dlMw=
 
 jsonparse@^1.2.0:
   version "1.3.1"
@@ -4894,6 +4939,13 @@ merge-descriptors@1.0.1:
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-1.0.1.tgz#b00aaa556dd8b44568150ec9d1b953f3f90cbb61"
   integrity sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=
 
+merge-options@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/merge-options/-/merge-options-1.0.1.tgz#2a64b24457becd4e4dc608283247e94ce589aa32"
+  integrity sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==
+  dependencies:
+    is-plain-obj "^1.1"
+
 merge2@^1.2.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
@@ -5242,6 +5294,20 @@ normalize-url@^3.3.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
   integrity sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg==
 
+npm-audit-resolver@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/npm-audit-resolver/-/npm-audit-resolver-2.2.0.tgz#4091a33a47337cddfa8377edf1750fc40c42a0a1"
+  integrity sha512-nBhxrc0Y34vIFl38G42PkWSBEbOAL3Gg6aRxm1hYzM4Vm+Rv0ozALj2LixdeytkUC2OGWP4QqCF0fKAb14NnPQ==
+  dependencies:
+    audit-resolve-core "^1.1.7"
+    chalk "^2.4.2"
+    djv "^2.1.2"
+    jsonlines "^0.1.1"
+    read "^1.0.7"
+    spawn-shell "^2.1.0"
+    yargs-parser "^13.1.1"
+    yargs-unparser "^1.5.0"
+
 npm-bundled@^1.0.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
@@ -5296,7 +5362,7 @@ npm-pick-manifest@^3.0.0:
     npm-package-arg "^6.0.0"
     semver "^5.4.1"
 
-npm-run-path@^2.0.0:
+npm-run-path@^2.0.0, npm-run-path@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
   integrity sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
@@ -6167,7 +6233,7 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
-read@1, read@^1.0.4, read@~1.0.1:
+read@1, read@^1.0.4, read@^1.0.7, read@~1.0.1:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
   integrity sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=
@@ -6690,6 +6756,15 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+spawn-shell@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/spawn-shell/-/spawn-shell-2.1.0.tgz#dce87b911ff7339470c9ce39ab60c61bcc3891d0"
+  integrity sha512-mjlYAQbZPHd4YsoHEe+i0Xbp9sJefMKN09JPp80TqrjC5NSuo+y1RG3NBireJlzl1dDV2NIkIfgS6coXtyqN/A==
+  dependencies:
+    default-shell "^1.0.1"
+    merge-options "~1.0.1"
+    npm-run-path "^2.0.2"
 
 spdx-correct@^3.0.0:
   version "3.1.0"
@@ -7590,13 +7665,24 @@ yaml@^1.10.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.0.tgz#3b593add944876077d4d683fee01081bd9fff31e"
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
 
-yargs-parser@^10.0.0, yargs-parser@^15.0.0, yargs-parser@^18.1.1, yargs-parser@^18.1.2:
+yargs-parser@^10.0.0, yargs-parser@^10.1.0, yargs-parser@^13.1.1, yargs-parser@^15.0.0, yargs-parser@^15.0.1, yargs-parser@^18.1.1, yargs-parser@^18.1.2:
   version "18.1.3"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
   integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-unparser@^1.5.0:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/yargs-unparser/-/yargs-unparser-1.6.3.tgz#7b939b45c5a8d5ffb7648341792feba0fdae8117"
+  integrity sha512-xI32EGCq5mJiSCsQaEPLljD+R3Hq/VG08YGoLTOqu/gHAtCa2S4qPMG20ol4TpKWgSU7j3KMZHvSirNPK0DSjA==
+  dependencies:
+    camelcase "^5.3.1"
+    decamelize "^1.2.0"
+    flat "^4.1.0"
+    is-plain-obj "^1.1.0"
+    yargs "^14.2.3"
 
 yargs@^14.2.2:
   version "14.2.2"
@@ -7614,6 +7700,23 @@ yargs@^14.2.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^15.0.0"
+
+yargs@^14.2.3:
+  version "14.2.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-14.2.3.tgz#1a1c3edced1afb2a2fea33604bc6d1d8d688a414"
+  integrity sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==
+  dependencies:
+    cliui "^5.0.0"
+    decamelize "^1.2.0"
+    find-up "^3.0.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^3.0.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^15.0.1"
 
 yargs@^15.3.1:
   version "15.3.1"


### PR DESCRIPTION
When audit issues are not fixed in a timely manner allow change to ignore issues for a time period.

