### PR TITLE
fix(cli): make clipMultipolygon always remove degenerate edges

### DIFF
--- a/packages/cli/src/cog/__test__/clipped.multipolygon.test.ts
+++ b/packages/cli/src/cog/__test__/clipped.multipolygon.test.ts
@@ -1,7 +1,7 @@
 import { Bounds, GeoJson } from '@basemaps/geo';
 import o from 'ospec';
 import { MultiPolygon } from 'polygon-clipping';
-import { clipMultipolygon, removeDegenerateEdges, polyContainsBounds } from '../clipped.multipolygon';
+import { clipMultipolygon, polyContainsBounds } from '../clipped.multipolygon';
 import { round } from '@basemaps/test/build/rounding';
 
 export function writeGeoJson(fn: string, poly: MultiPolygon): void {
@@ -50,46 +50,72 @@ o.spec('clipped.multipolygon', () => {
         o(polyContainsBounds(polys, new Bounds(6, -8, 5, 5))).equals(false);
     });
 
-    o('clipMultipolygon', () => {
-        const bbox = Bounds.fromBbox([-3, -4, 4, 4]);
+    o.spec('clipMultipolygon', () => {
+        o('disjoint with intersecting bounds', () => {
+            const bbox = new Bounds(-2, -2, 1, 1);
 
-        const cp = clipMultipolygon(polys, bbox);
+            const cp = clipMultipolygon(polys, bbox);
 
-        o(cp).deepEquals([
-            [
+            o(cp).deepEquals([]);
+        });
+
+        o('intersect', () => {
+            const bbox = Bounds.fromBbox([-3, -4, 4, 4]);
+
+            const cp = clipMultipolygon(polys, bbox);
+
+            o(round(cp, 2)).deepEquals([
                 [
-                    [-3, -4],
-                    [-3, 1.5],
-                    [-2, 1],
-                    [-3, 0],
-                    [-3, -1.8],
-                    [-0.25, -4],
-                    [2, -4],
-                    [2, -2],
-                    [3.333333333333333, -4],
-                    [4, -4],
-                    [4, -1],
-                    [2, 0],
-                    [4, 1.5],
-                    [4, 4],
-                    [0.5, 4],
-                    [0, 3],
-                    [-1.3333333333333333, 4],
-                    [4, 4],
-                    [4, -4],
-                    [-3, -4],
+                    [
+                        [-3, -4],
+                        [-0.25, -4],
+                        [-3, -1.8],
+                        [-3, -4],
+                    ],
                 ],
-            ],
-            [
                 [
-                    [2, 3],
-                    [3, 3],
-                    [3, 4],
-                    [2, 4],
-                    [2, 3],
+                    [
+                        [-3, 0],
+                        [-2, 1],
+                        [-3, 1.5],
+                        [-3, 0],
+                    ],
                 ],
-            ],
-        ]);
+                [
+                    [
+                        [-1.33, 4],
+                        [0, 3],
+                        [0.5, 4],
+                        [-1.33, 4],
+                    ],
+                ],
+                [
+                    [
+                        [2, -4],
+                        [3.33, -4],
+                        [2, -2],
+                        [2, -4],
+                    ],
+                ],
+                [
+                    [
+                        [2, 0],
+                        [4, -1],
+                        [4, 1.5],
+                        [2, 0],
+                    ],
+                ],
+                [
+                    [
+                        [2, 3],
+                        [3, 3],
+                        [3, 4],
+                        [2, 4],
+                        [2, 3],
+                    ],
+                ],
+            ]);
+        });
     });
 
     o.spec('removeDegenerateEdges', () => {
@@ -110,7 +136,7 @@ o.spec('clipped.multipolygon', () => {
                 ],
             ];
 
-            const ans = removeDegenerateEdges(cp, bbox);
+            const ans = clipMultipolygon(cp, bbox);
 
             o(ans).deepEquals([
                 [
@@ -161,7 +187,7 @@ o.spec('clipped.multipolygon', () => {
 
             const bbox = Bounds.fromBbox([-3000, -3547, 3000, 1000]);
 
-            const ans = removeDegenerateEdges(degen, bbox);
+            const ans = clipMultipolygon(degen, bbox);
 
             o(ans).deepEquals([
                 [
@@ -218,8 +244,7 @@ o.spec('clipped.multipolygon', () => {
                 ],
             ];
 
-            const cp = clipMultipolygon(orig, bbox);
-            const ans = removeDegenerateEdges(cp, bbox);
+            const ans = clipMultipolygon(orig, bbox);
 
             o(ans).deepEquals([
                 [
@@ -240,8 +265,7 @@ o.spec('clipped.multipolygon', () => {
 
         o('complex', () => {
             const bbox = Bounds.fromBbox([-3, -4, 4, 4]);
-            const cp = clipMultipolygon(polys, bbox);
-            const ans = removeDegenerateEdges(cp, bbox);
+            const ans = clipMultipolygon(polys, bbox);
 
             o(round(ans, 2)).deepEquals([
                 [

--- a/packages/cli/src/cog/clipped.multipolygon.ts
+++ b/packages/cli/src/cog/clipped.multipolygon.ts
@@ -6,6 +6,10 @@ function samePoint(a: number[], b: number[]): boolean {
     return a[0] == b[0] && a[1] == b[1];
 }
 
+function removeDegenerateEdges(polygons: MultiPolygon, bounds: Bounds): MultiPolygon {
+    return pc.intersection(polygons, bounds.toPolygon());
+}
+
 export function clipMultipolygon(polygons: MultiPolygon, bounds: Bounds): MultiPolygon {
     const result: MultiPolygon = [];
     const bbox = bounds.toBbox();
@@ -16,11 +20,7 @@ export function clipMultipolygon(polygons: MultiPolygon, bounds: Bounds): MultiP
             result.push([clipped]);
         }
     }
-    return result;
-}
-
-export function removeDegenerateEdges(polygons: MultiPolygon, bounds: Bounds): MultiPolygon {
-    return pc.intersection(polygons, bounds.toPolygon());
+    return removeDegenerateEdges(result, bounds);
 }
 
 export function polyContainsBounds(poly: MultiPolygon, bounds: Bounds): boolean {

--- a/packages/cli/src/cog/cog.vrt.ts
+++ b/packages/cli/src/cog/cog.vrt.ts
@@ -97,8 +97,6 @@ export const CogVrt = {
     ): Promise<string | null> {
         logger.info({ name }, 'buildCogVrt');
 
-        const inputTotal = job.source.files.length;
-
         const sourceFiles = cutline.filterSourcesForName(name, job).map((name) => name.replace('s3://', '/vsis3/'));
 
         if (sourceFiles.length == 0) {
@@ -118,7 +116,11 @@ export const CogVrt = {
         }
 
         logger.info(
-            { inputTotal, outputTotal: job.source.files.length, cutlinePolygons: cutline.clipPoly.length },
+            {
+                inputTotal: job.source.files.length,
+                outputTotal: sourceFiles.length,
+                cutlinePolygons: cutline.clipPoly.length,
+            },
             'Tiff count',
         );
 

--- a/packages/cli/src/cog/cutline.ts
+++ b/packages/cli/src/cog/cutline.ts
@@ -3,7 +3,7 @@ import { compareName, FileOperator, NamedBounds, ProjectionTileMatrixSet } from 
 import { FeatureCollection } from 'geojson';
 import { CoveringFraction, MaxImagePixelWidth } from './constants';
 import { CogJob, SourceMetadata } from './types';
-import { clipMultipolygon, removeDegenerateEdges, polyContainsBounds } from './clipped.multipolygon';
+import { clipMultipolygon, polyContainsBounds } from './clipped.multipolygon';
 import pc, { MultiPolygon, Ring, Polygon } from 'polygon-clipping';
 import { Projection } from '@basemaps/shared/build/proj/projection';
 const { intersection, union } = pc;
@@ -115,13 +115,13 @@ export class Cutline {
             if (poly.length == 0) {
                 // this tile is not needed
                 this.clipPoly = [];
-                job.source.files = [];
+                return [];
             } else if (polyContainsBounds(poly, tileBounds)) {
                 // tile is completely surrounded; no cutline polygons needed
                 this.clipPoly = [];
             } else {
                 // set the cutline polygons to just the area of interest (minus degenerate edges)
-                this.clipPoly = removeDegenerateEdges(poly, tilePadded);
+                this.clipPoly = poly;
             }
         }
 
@@ -266,7 +266,7 @@ export class Cutline {
             this.clipPoly = [];
         } else {
             // set the cutline polygons to just the area of interest (minus degenerate edges)
-            this.clipPoly = removeDegenerateEdges(poly, boundsPadded);
+            this.clipPoly = poly;
             this.srcPoly = intersection(srcPoly, this.clipPoly) ?? [];
         }
     }


### PR DESCRIPTION
Some unnecessary cogs were being created because intersecting bounds but not intersecting polygons
was resulting in degenerate-edges-only-polygons which were not being interpreted as empty. By always
removing the degenerate edges we loose some performance but get the correct results.

We could restore most of the performance with some extra logic but for simplicity's sake it is not worth it.

