### PR TITLE
fix(landing): dont require clicking on the map for keyboard events

### DIFF
--- a/packages/landing/src/map.ts
+++ b/packages/landing/src/map.ts
@@ -103,6 +103,7 @@ export class Basemaps {
             target: this.el,
             view,
             layers: [layer],
+            keyboardEventTarget: document,
         });
 
         this.map.addEventListener('postrender', this.postRender);

--- a/packages/landing/static/index.html
+++ b/packages/landing/static/index.html
@@ -178,7 +178,7 @@
             </li>
         </ul>
     </div>
-    <div id="map" class="map" tabindex="0"></div>
+    <div id="map" class="map"></div>
     <footer class="g-footer-wrapper  g-footer__standard lui-footer lui-footer-x-sm" role="contentinfo">
         <div class="g-flex-container lui-max-width">
             <div class="g-flex-row align-center">


### PR DESCRIPTION
This means that arrow keys will now be used for map control, 

~hope noone needs arrow keys for input boxes?~ arrow keys in Input boxes work fine!