### PR TITLE
fix(tiler): try to minimize the error when rounding boundaries

### DIFF
--- a/packages/geo/src/__tests__/bounds.test.ts
+++ b/packages/geo/src/__tests__/bounds.test.ts
@@ -11,6 +11,12 @@ o.spec('Bounds', () => {
     const tileZero = getTile(0, 0);
     const tileMiddle = new Bounds(128, 128, 256, 256);
 
+    o('round', () => {
+        o(new Bounds(1.1, 10.1, 12.2, 11.2).round().toJson()).deepEquals({ x: 1, y: 10, width: 12, height: 11 });
+        o(new Bounds(1.4, 10.6, 12.2, 11.4).round().toJson()).deepEquals({ x: 1, y: 11, width: 13, height: 11 });
+        o(new Bounds(0.4, 0.6, 2.4, 1.6).round().toJson()).deepEquals({ x: 0, y: 1, width: 3, height: 1 });
+    });
+
     o('toBbox', () => {
         o(new Bounds(170, 40, 60, 45).toBbox()).deepEquals([170, 40, 230, 85]);
         o(new Bounds(10, -40, 60, -45).toBbox()).deepEquals([10, -40, 70, -85]);

--- a/packages/geo/src/bounds.ts
+++ b/packages/geo/src/bounds.ts
@@ -156,8 +156,13 @@ export class Bounds implements BoundingBox {
         );
     }
 
+    /**
+     * Round dimensions to integers keeping the error a low as possible
+     */
     public round(): Bounds {
-        return new Bounds(Math.round(this.x), Math.round(this.y), Math.round(this.width), Math.round(this.height));
+        const x = Math.round(this.x);
+        const y = Math.round(this.y);
+        return new Bounds(x, y, Math.round(this.right) - x, Math.round(this.bottom) - y);
     }
 
     public add(bounds: Point): Bounds {

--- a/packages/tiler/src/tiler.ts
+++ b/packages/tiler/src/tiler.ts
@@ -76,13 +76,7 @@ export class Tiler {
         scaleFactor: number,
         raster: RasterPixelBounds,
     ): Composition | null {
-        const tileSourceBounds = img.getTileBounds(x, y);
-        const source = new Bounds(
-            tileSourceBounds.x,
-            tileSourceBounds.y,
-            tileSourceBounds.width,
-            tileSourceBounds.height,
-        );
+        const source = Bounds.fromJson(img.getTileBounds(x, y));
 
         const target = source.scale(scaleFactor, scaleFactor).add(raster.tiff).round();
 


### PR DESCRIPTION
Overview tiles that do not align with the requested zoom level often leave multiple pixel gaps
between COGs. This fix reduces that size of that gap.

