### PR TITLE
feat(cli): Allow creation of one cog covering entire extent

### DIFF
--- a/packages/cli/src/cli/cogify/action.cog.ts
+++ b/packages/cli/src/cli/cogify/action.cog.ts
@@ -113,6 +113,7 @@ export class ActionCogCreate extends CommandLineAction {
                 ProjectionTileMatrixSet.get(job.projection),
                 cutlineJson,
                 job.output.cutline?.blend,
+                job.files.length == 1 && job.files[0].name == Cutline.OneCogName,
             );
 
             const tmpVrtPath = await CogVrt.buildVrt(tmpFolder, job, cutline, name, logger);

--- a/packages/cli/src/cog/__test__/cog.test.ts
+++ b/packages/cli/src/cog/__test__/cog.test.ts
@@ -1,12 +1,11 @@
 import { Epsg } from '@basemaps/geo';
-import { LogConfig } from '@basemaps/shared';
+import { LogConfig, ProjectionTileMatrixSet } from '@basemaps/shared';
+import { round } from '@basemaps/test/build/rounding';
 import o from 'ospec';
 import { GdalCogBuilder } from '../../gdal/gdal.cog';
+import { TilingScheme } from '../../gdal/gdal.config';
 import { buildCogForName } from '../cog';
 import { SourceTiffTestHelper } from './source.tiff.testhelper';
-import { TilingScheme } from '../../gdal/gdal.config';
-import { round } from '@basemaps/test/build/rounding';
-import { qkToName } from '@basemaps/shared/build/proj/__test__/test.util';
 
 LogConfig.disable();
 
@@ -30,7 +29,13 @@ o.spec('cog', () => {
             const job = SourceTiffTestHelper.makeCogJob();
             const logger = LogConfig.get();
 
-            await buildCogForName(job, qkToName('3131'), '/tmp/test.vrt', '/tmp/out-tiff', logger, true);
+            const targetPtms = ProjectionTileMatrixSet.get(job.projection);
+
+            const name = '4-15-10';
+
+            job.files = [{ name, ...targetPtms.tileToSourceBounds({ x: 15, y: 10, z: 4 }) }];
+
+            await buildCogForName(job, name, '/tmp/test.vrt', '/tmp/out-tiff', logger, true);
             o(convertArgs[0].info).equals(logger.info);
 
             const { config } = gdalCogBuilder!;

--- a/packages/cli/src/cog/__test__/cutline.test.ts
+++ b/packages/cli/src/cog/__test__/cutline.test.ts
@@ -69,6 +69,24 @@ o.spec('cutline', () => {
     o.spec('optmize', async () => {
         const bounds = SourceTiffTestHelper.tiffNztmBounds();
 
+        o('one-cog', () => {
+            const cutline = new Cutline(nztmPtms, undefined, 0, true);
+            const covering = cutline.optimizeCovering({
+                projection: EpsgCode.Nztm2000,
+                bounds,
+                resZoom: 14,
+            } as SourceMetadata);
+
+            o(covering.length).equals(1);
+            o(covering[0]).deepEquals({
+                x: 274000,
+                y: 3087000,
+                width: 3053000,
+                height: 4086000,
+                name: '0-0-0',
+            });
+        });
+
         o('nztm', () => {
             const cutline = new Cutline(nztmPtms);
 
@@ -78,7 +96,6 @@ o.spec('cutline', () => {
                 resZoom: 14,
             } as SourceMetadata);
 
-            o(covering.length).equals(covering.length);
             o(covering[4]).deepEquals({
                 name: '7-153-253',
                 x: 1741760,

--- a/packages/cli/src/cog/cutline.ts
+++ b/packages/cli/src/cog/cutline.ts
@@ -42,6 +42,7 @@ export class Cutline {
     clipPoly: MultiPolygon = [];
     targetPtms: ProjectionTileMatrixSet;
     blend: number;
+    oneCog: boolean;
     tms: TileMatrixSet; // convience to targetPtms.tms
     private srcPoly: MultiPolygon = [];
 
@@ -56,10 +57,11 @@ export class Cutline {
 
      * @param blend How much blending to consider when working out boundaries.
      */
-    constructor(targetPtms: ProjectionTileMatrixSet, clipPoly?: FeatureCollection, blend = 0) {
+    constructor(targetPtms: ProjectionTileMatrixSet, clipPoly?: FeatureCollection, blend = 0, oneCog = false) {
         this.targetPtms = targetPtms;
         this.tms = targetPtms.tms;
         this.blend = blend;
+        this.oneCog = oneCog;
         if (clipPoly == null) {
             return;
         }
@@ -79,6 +81,11 @@ export class Cutline {
     }
 
     /**
+     * The Name to used when just producing one cog to cover the full extent
+     */
+    static OneCogName = '0-0-0';
+
+    /**
      * Load a geojson cutline from the file-system.
      *
      * @param path the path of the cutline to load. Can be `s3://` or local file path.
@@ -96,6 +103,10 @@ export class Cutline {
      * @returns names of source files required to render Cog
      */
     filterSourcesForName(name: string, job: CogJob): string[] {
+        if (this.oneCog) {
+            return job.source.files.map(({ name }) => name);
+        }
+
         const tile = TileMatrixSet.nameToTile(name);
         const sourceCode = Projection.get(job.source.projection);
         const targetCode = this.targetPtms.proj;
@@ -135,6 +146,10 @@ export class Cutline {
      * @param sourceMetadata contains images bounds and projection info
      */
     optimizeCovering(sourceMetadata: SourceMetadata): NamedBounds[] {
+        if (this.oneCog) {
+            const extent = this.tms.extent.toJson();
+            return [{ ...extent, name: Cutline.OneCogName }];
+        }
         this.findCovering(sourceMetadata);
 
         const { resZoom } = sourceMetadata;

--- a/packages/cli/src/cog/types.ts
+++ b/packages/cli/src/cog/types.ts
@@ -1,6 +1,6 @@
-import { EpsgCode, BoundingBox } from '@basemaps/geo';
+import { BoundingBox, EpsgCode } from '@basemaps/geo';
 import { FileConfig, NamedBounds } from '@basemaps/shared';
-import { GdalCogBuilderOptionsResampling } from '../gdal/gdal.config';
+import { GdalCogBuilderResampling } from '../gdal/gdal.config';
 
 export interface CogJob {
     /** Unique processing Id */
@@ -33,7 +33,7 @@ export interface CogJob {
 
     /** Folder/S3 bucket to store the output */
     output: {
-        resampling: { warp: GdalCogBuilderOptionsResampling; overview: GdalCogBuilderOptionsResampling };
+        resampling: GdalCogBuilderResampling;
         nodata?: number;
         /**
          * Quality level to use

--- a/packages/cli/src/gdal/gdal.config.ts
+++ b/packages/cli/src/gdal/gdal.config.ts
@@ -9,6 +9,19 @@ export type GdalCogBuilderOptionsResampling =
     | 'average'
     | 'mode';
 
+export interface GdalCogBuilderResampling {
+    /**
+     * Resampling for warping
+     * @default 'bilinear'
+     */
+    warp: GdalCogBuilderOptionsResampling;
+    /**
+     * Resampling for overview
+     * @default 'lanczos'
+     */
+    overview: GdalCogBuilderOptionsResampling;
+}
+
 export enum TilingScheme {
     Google = 'GoogleMapsCompatible',
     Nztm2000 = 'NZTM2000',
@@ -39,18 +52,7 @@ export interface GdalCogBuilderOptions {
     /**
      * Resampling methods to use
      */
-    resampling: {
-        /**
-         * Resampling for warping
-         * @default 'bilinear'
-         */
-        warp: GdalCogBuilderOptionsResampling;
-        /**
-         * Resampling for overview
-         * @default 'lanczos'
-         */
-        overview: GdalCogBuilderOptionsResampling;
-    };
+    resampling: GdalCogBuilderResampling;
     /**
      * Output tile size
      * @default 512

--- a/packages/geo/src/__tests__/tile.matrix.set.test.ts
+++ b/packages/geo/src/__tests__/tile.matrix.set.test.ts
@@ -37,6 +37,25 @@ o.spec('TileMatrixSet', () => {
         });
     });
 
+    o('extent', () => {
+        o(GoogleTms.extent.toBbox()).deepEquals([
+            -20037508.3427892,
+            -20037508.3427892,
+            20037508.3427892,
+            20037508.3427892,
+        ]);
+
+        const { lowerCorner, upperCorner } = Nztm2000Tms.def.boundingBox;
+
+        o(Nztm2000Tms.extent.toBbox()).deepEquals([274000, 3087000, 3327000, 7173000]);
+        o(Nztm2000Tms.extent.toBbox()).deepEquals([
+            lowerCorner[Nztm2000Tms.indexX],
+            lowerCorner[Nztm2000Tms.indexY],
+            upperCorner[Nztm2000Tms.indexX],
+            upperCorner[Nztm2000Tms.indexY],
+        ]);
+    });
+
     o('should have correct maxZoom', () => {
         o(GoogleTms.maxZoom).equals(24);
         o(GoogleTms.pixelScale(24) > 0).equals(true);

--- a/packages/geo/src/tile.matrix.set.ts
+++ b/packages/geo/src/tile.matrix.set.ts
@@ -29,6 +29,9 @@ export class TileMatrixSet {
     /** Array index of y coordinate */
     indexY = 1;
 
+    /** The full extent (boundingBox) from the TileMatrixSetType definition */
+    readonly extent: Bounds;
+
     /**
      * Create using a WMTS EPSG definition
 
@@ -57,6 +60,11 @@ export class TileMatrixSet {
             this.indexX = 1;
             this.indexY = 0;
         }
+
+        const { lowerCorner, upperCorner } = def.boundingBox;
+        const x = lowerCorner[this.indexX];
+        const y = lowerCorner[this.indexY];
+        this.extent = new Bounds(x, y, upperCorner[this.indexX] - x, upperCorner[this.indexY] - y);
     }
 
     /**

--- a/packages/landing/src/nztm2000.ts
+++ b/packages/landing/src/nztm2000.ts
@@ -1,5 +1,4 @@
 import { Nztm2000Tms } from '@basemaps/geo/build/tms/nztm2000';
-import { Extent } from 'ol/extent';
 import { register } from 'ol/proj/proj4';
 import WMTSTileGrid from 'ol/tilegrid/WMTS.js';
 import Proj from 'proj4';
@@ -20,18 +19,10 @@ for (let i = 0; i < 2; ++i) {
     resolutions.push(resolutions[resolutions.length - 1] / 2);
 }
 
-const { lowerCorner, upperCorner } = Nztm2000Tms.def.boundingBox;
-const extent: Extent = [
-    lowerCorner[Nztm2000Tms.indexX],
-    lowerCorner[Nztm2000Tms.indexY],
-    upperCorner[Nztm2000Tms.indexX],
-    upperCorner[Nztm2000Tms.indexY],
-];
-
 export const NztmOl = {
     resolutions,
     origin,
     matrixIds,
-    extent,
+    extent: Nztm2000Tms.extent.toBbox(),
     TileGrid: new WMTSTileGrid({ origin, resolutions, matrixIds }),
 };


### PR DESCRIPTION
This is for use with creating the gebco COG because the default process can't handle the
anti-meridian and one cog is optimal for the gebco layer.

