### PR TITLE
fix(bathymetry): allow bathy command to be run outside of git repo

### DIFF
--- a/packages/bathymetry/src/stac.ts
+++ b/packages/bathymetry/src/stac.ts
@@ -10,7 +10,7 @@ import { Hash } from './hash';
 const packageJson = require('../package.json');
 
 function getCommitHash(): string {
-    return cp.execSync('git rev-parse HEAD').toString().trim();
+    return packageJson.gitHead ?? cp.execSync('git rev-parse HEAD').toString().trim();
 }
 
 /** Write some basic metadata about how the file was created*/


### PR DESCRIPTION
`packageJson.gitHead` is added when the package is published, so if it exists its from a npm install'd `@basemaps/bathymetry`
