### PR TITLE
feat(lambda-xyz): Serve WMTSCapabilities for all TileSets

### DIFF
--- a/packages/__tests__/src/rounding.ts
+++ b/packages/__tests__/src/rounding.ts
@@ -33,3 +33,8 @@ export function round(thing: any, z = 8): any {
     };
     return recurse(thing);
 }
+
+export function roundString(str: string, z = 8): string {
+    const r = makeRound(z);
+    return str.replace(/\d+\.\d+/g, (n) => r(parseFloat(n)).toString());
+}

--- a/packages/cli/src/cog/cutline.ts
+++ b/packages/cli/src/cog/cutline.ts
@@ -67,7 +67,7 @@ export class Cutline {
 
      * @param clipPoly the optional cutline. The source imagery outline used by default. This
      * `FeatureCollection` is converted to one `MultiPolygon` with any holes removed and the
-     * coordinates transposed from `Wsg84` to the target projection (unless already in target projection).
+     * coordinates transposed from `Wgs84` to the target projection (unless already in target projection).
 
      * @param blend How much blending to consider when working out boundaries.
      */
@@ -86,7 +86,7 @@ export class Cutline {
         if (needProj && proj !== Epsg.Wgs84) {
             throw new Error('Invalid geojson; CRS may not be set for cutline!');
         }
-        const convert = needProj ? this.targetPtms.proj.fromWsg84 : copyPoint;
+        const convert = needProj ? this.targetPtms.proj.fromWgs84 : copyPoint;
         for (const { geometry } of clipPoly.features) {
             if (geometry.type === 'MultiPolygon') {
                 for (const coords of geometry.coordinates) {

--- a/packages/geo/src/wmts/wmts.ts
+++ b/packages/geo/src/wmts/wmts.ts
@@ -1,4 +1,5 @@
 import type { Epsg } from '../epsg';
+import { Bounds } from '../bounds';
 
 /**
  * Cut down interface, with only the information needed to render a tileset
@@ -9,6 +10,7 @@ export interface WmtsLayer {
     description: string;
     projection: Epsg;
     taggedName: string;
+    extent: Bounds;
 }
 
 /** WMTS Provider information */

--- a/packages/lambda-xyz/src/__test__/tile.set.cache.test.ts
+++ b/packages/lambda-xyz/src/__test__/tile.set.cache.test.ts
@@ -1,0 +1,197 @@
+import { Epsg } from '@basemaps/geo';
+import o from 'ospec';
+import { TileSet } from '../tile.set';
+import { loadTileSets, TileSets, loadTileSet } from '../tile.set.cache';
+import { TileMetadataImageryRecordV1, TileSetName } from '@basemaps/shared';
+
+o.spec('TileSetCache', () => {
+    const origLoad = TileSet.prototype.load;
+
+    class MyTileSet extends TileSet {
+        async load(): Promise<boolean> {
+            if (this.projection == Epsg.Google && this.name === TileSetName.aerial) {
+                this.tileSet = {
+                    title: 'parent aerial title',
+                    name: 'aerial',
+                    background: { r: 200, g: 50, b: 100, alpha: 0.5 },
+                } as any;
+                this.imagery = [
+                    {
+                        rule: {
+                            id: 'im_id1',
+                            minZoom: 10,
+                            maxZoom: 31,
+                            priority: 2000,
+                        },
+                        imagery: {
+                            id: 'im_id1',
+                            name: 'tasman_rural_2018-19_0-3m',
+                            bounds: { x: 123, y: 456, width: 200, height: 300 },
+                        } as TileMetadataImageryRecordV1,
+                    },
+
+                    {
+                        rule: {
+                            id: 'im_id2',
+                            minZoom: 8,
+                            maxZoom: 21,
+                            priority: 1000,
+                        },
+                        imagery: {
+                            id: 'im_id2',
+                            name: 'sub image 2',
+                            bounds: { x: 1230, y: 4560, width: 2000, height: 3000 },
+                        } as TileMetadataImageryRecordV1,
+                    },
+                ];
+                return true;
+            }
+            if (this.projection == Epsg.Nztm2000 && this.name === TileSetName.aerial) {
+                this.tileSet = {
+                    background: { r: 200, g: 50, b: 100, alpha: 0.5 },
+                    name: TileSetName.aerial,
+                } as any;
+                this.imagery = [
+                    {
+                        rule: {
+                            id: 'im_id3',
+                            minZoom: 10,
+                            maxZoom: 31,
+                            priority: 2000,
+                        },
+                        imagery: {
+                            id: 'im_id3',
+                            name: 'tasman_rural_2018-19_0-3m',
+                            bounds: { x: 321, y: 654, width: 250, height: 220 },
+                        } as TileMetadataImageryRecordV1,
+                    },
+                ];
+                return true;
+            }
+            return false;
+        }
+    }
+
+    o.afterEach(() => {
+        TileSets.clear();
+        TileSet.prototype.load = origLoad;
+    });
+
+    o.spec('loadTileSet', () => {
+        o('load individual set', async () => {
+            const loadSpy = o.spy(MyTileSet.prototype.load);
+            (TileSet.prototype.load as any) = loadSpy;
+            TileSets.set('ts1', new TileSet('aerial@head', Epsg.Google));
+
+            const parentTileSet = await loadTileSet('aerial@head', Epsg.Google);
+
+            if (parentTileSet == null) throw new Error('null parentTileSet');
+
+            const subTileSet = await loadTileSet('aerial@head:tasman_rural_2018-19_0-3m', Epsg.Google);
+
+            if (subTileSet == null) throw new Error('null subTileSet');
+
+            o(subTileSet.title).equals('parent aerial title Tasman rural 2018-19 0.3m');
+            o(subTileSet.name).equals('id1');
+            o(subTileSet.imagery).deepEquals([
+                {
+                    rule: { id: 'im_id1', minZoom: 0, maxZoom: 31, priority: 0 },
+                    imagery: {
+                        id: 'im_id1',
+                        name: 'tasman_rural_2018-19_0-3m',
+                        bounds: { x: 123, y: 456, width: 200, height: 300 },
+                    } as TileMetadataImageryRecordV1,
+                },
+            ]);
+            o(subTileSet.tileSet.imagery).deepEquals({
+                // eslint-disable-next-line @typescript-eslint/camelcase
+                im_id1: { id: 'im_id1', minZoom: 0, maxZoom: 31, priority: 0 },
+            });
+            o(subTileSet.background).equals(undefined);
+
+            o(parentTileSet.tileSet.background).deepEquals({ r: 200, g: 50, b: 100, alpha: 0.5 });
+            o(parentTileSet.tileSet.background).equals(Object.getPrototypeOf(subTileSet.tileSet).background);
+        });
+    });
+
+    o.spec('loadTileSets', () => {
+        o('load all', async () => {
+            const loadSpy = o.spy(MyTileSet.prototype.load);
+            (TileSet.prototype.load as any) = loadSpy;
+            const ts1 = new TileSet('aerial', Epsg.Google);
+            TileSets.set('ts1', ts1);
+            const tileSets = await loadTileSets('', null);
+
+            o(tileSets.length).deepEquals(4);
+
+            o(tileSets[0].title).equals(TileSetName.aerial);
+            o(tileSets[0].name).equals(TileSetName.aerial);
+            o(tileSets[0].projection.code).equals(2193);
+            o(tileSets[0].extent.toBbox()).deepEquals([274000, 3087000, 3327000, 7173000]);
+
+            o(tileSets[1].title).equals('parent aerial title');
+            o(tileSets[1].name).equals('aerial');
+            o(tileSets[1].background).deepEquals({ r: 200, g: 50, b: 100, alpha: 0.5 });
+            o(tileSets[1].imagery[0].imagery.name).equals('tasman_rural_2018-19_0-3m');
+
+            o(tileSets[2].title).equals('parent aerial title Sub image 2');
+            o(tileSets[2].name).equals('aerial:sub image 2');
+            o(tileSets[2].imagery).deepEquals([
+                {
+                    rule: { id: 'im_id2', minZoom: 0, maxZoom: 21, priority: 0 },
+                    imagery: {
+                        id: 'im_id2',
+                        name: 'sub image 2',
+                        bounds: { x: 1230, y: 4560, width: 2000, height: 3000 },
+                    } as TileMetadataImageryRecordV1,
+                },
+            ]);
+
+            o(tileSets[3].title).equals('parent aerial title Tasman rural 2018-19 0.3m');
+            o(tileSets[3].name).equals('aerial:tasman_rural_2018-19_0-3m');
+            o(tileSets[3].background).equals(undefined);
+            o(tileSets[3].imagery).deepEquals([
+                {
+                    rule: { id: 'im_id1', minZoom: 0, maxZoom: 31, priority: 0 },
+                    imagery: {
+                        id: 'im_id1',
+                        name: 'tasman_rural_2018-19_0-3m',
+                        bounds: { x: 123, y: 456, width: 200, height: 300 },
+                    } as TileMetadataImageryRecordV1,
+                },
+            ]);
+
+            o(tileSets[3].extent.toBbox()).deepEquals([123, 456, 323, 756]);
+        });
+
+        o('load all subset projections', async () => {
+            const loadSpy = o.spy(MyTileSet.prototype.load);
+            (TileSet.prototype.load as any) = loadSpy;
+            const ts1 = new TileSet('aerial@head', Epsg.Google);
+            TileSets.set('ts1', ts1);
+            const tileSets = await loadTileSets('aerial@head:tasman_rural_2018-19_0-3m', null);
+
+            o(tileSets.length).deepEquals(2);
+
+            o(tileSets[0].name).equals('aerial@head:tasman_rural_2018-19_0-3m');
+            o(tileSets[0].projection).equals(Epsg.Nztm2000);
+            o(tileSets[1].name).equals('aerial@head:tasman_rural_2018-19_0-3m');
+            o(tileSets[1].projection).equals(Epsg.Google);
+        });
+
+        o('load all @tag', async () => {
+            const loadSpy = o.spy(MyTileSet.prototype.load);
+            (TileSet.prototype.load as any) = loadSpy;
+            const ts1 = new TileSet('aerial@head', Epsg.Google);
+            TileSets.set('ts1', ts1);
+            const tileSets = await loadTileSets('@head', null);
+
+            o(tileSets.length).deepEquals(4);
+
+            o(tileSets[0].name).equals(TileSetName.aerial);
+            o(tileSets[1].name).equals('aerial');
+            o(tileSets[2].name).equals('aerial@head:sub image 2');
+            o(tileSets[3].name).equals('aerial@head:tasman_rural_2018-19_0-3m');
+        });
+    });
+});

--- a/packages/lambda-xyz/src/__test__/tile.set.test.ts
+++ b/packages/lambda-xyz/src/__test__/tile.set.test.ts
@@ -1,11 +1,23 @@
 import { TileMetadataImageryRecord } from '@basemaps/shared';
 import o from 'ospec';
 import { TileSet } from '../tile.set';
+import { Epsg } from '@basemaps/geo';
 
 o.spec('tile.set', () => {
     o('basePath', () => {
         const rec = { uri: 's3://test-bucket/3857/aerail/job123' } as TileMetadataImageryRecord;
         o(TileSet.basePath(rec)).equals('s3://test-bucket/3857/aerail/job123');
         o(TileSet.basePath(rec, '31223')).equals('s3://test-bucket/3857/aerail/job123/31223.tiff');
+    });
+
+    o('extent', () => {
+        o(new TileSet('google', Epsg.Google).extent.toBbox()).deepEquals([
+            -20037508.3427892,
+            -20037508.3427892,
+            20037508.3427892,
+            20037508.3427892,
+        ]);
+
+        o(new TileSet('nztm', Epsg.Nztm2000).extent.toBbox()).deepEquals([274000, 3087000, 3327000, 7173000]);
     });
 });

--- a/packages/lambda-xyz/src/__test__/xyz.test.ts
+++ b/packages/lambda-xyz/src/__test__/xyz.test.ts
@@ -1,6 +1,13 @@
 import { Epsg } from '@basemaps/geo';
 import { GoogleTms } from '@basemaps/geo/build/tms/google';
-import { Aws, Env, LogConfig, TileMetadataProviderRecord, VNodeParser } from '@basemaps/shared';
+import {
+    Aws,
+    Env,
+    LogConfig,
+    TileMetadataProviderRecord,
+    VNodeParser,
+    ProjectionTileMatrixSet,
+} from '@basemaps/shared';
 import { round } from '@basemaps/test/build/rounding';
 import { Tiler } from '@basemaps/tiler';
 import o from 'ospec';
@@ -42,10 +49,12 @@ o.spec('LambdaXyz', () => {
         TileComposer.compose = rasterMock as any;
 
         for (const tileSetName of TileSetNames) {
-            const tileSet = new FakeTileSet(tileSetName, Epsg.Google);
-            TileSets.set(tileSet.id, tileSet);
-            tileSet.load = () => Promise.resolve(true);
-            tileSet.getTiffsForTile = (): [] => [];
+            for (const code of ProjectionTileMatrixSet.targetCodes()) {
+                const tileSet = new FakeTileSet(tileSetName, Epsg.get(code));
+                TileSets.set(tileSet.id, tileSet);
+                tileSet.load = () => Promise.resolve(true);
+                tileSet.getTiffsForTile = (): [] => [];
+            }
         }
 
         (Aws.tileMetadata.Provider as any).get = async (): Promise<TileMetadataProviderRecord> => Provider;
@@ -148,8 +157,8 @@ o.spec('LambdaXyz', () => {
         });
 
         o('should 304 if a xml is not modified', async () => {
-            const key = 'J/PRQuAAaF/8Ni2zdUJnsSFrfRtzQzYkBFY0kxMfWx8=';
-            const request = mockRequest('/v1/tiles/aerial/WMTSCapabilities.xml', 'get', { 'if-none-match': key });
+            const key = 'biarWiiP+sp+4QsJnuQwxlxW3zEnipGptLywav1E7Cs=';
+            const request = mockRequest('/v1/tiles/WMTSCapabilities.xml', 'get', { 'if-none-match': key });
 
             const res = await handleRequest(request);
             if (res.status == 200) o(res.header('eTaG')).equals(key); // this line is useful for discovering the new etag
@@ -179,8 +188,8 @@ o.spec('LambdaXyz', () => {
             const vdom = await VNodeParser.parse(body);
             const url = vdom.tags('ResourceURL').next().value;
             o(url?.toString()).equals(
-                '<ResourceURL format="image/png" resourceType="tile" ' +
-                    'template="https://tiles.test/v1/tiles/aerial@beta/3857/{TileMatrix}/{TileCol}/{TileRow}.png?api=secretKey" />',
+                '<ResourceURL format="image/jpeg" resourceType="tile" ' +
+                    'template="https://tiles.test/v1/tiles/aerial@beta/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.jpeg?api=secretKey" />',
             );
         });
     });

--- a/packages/lambda-xyz/src/cli/serve.ts
+++ b/packages/lambda-xyz/src/cli/serve.ts
@@ -45,10 +45,27 @@ async function handleRequest(
     }
 }
 
-async function main(): Promise<void> {
-    if (Env.get(Env.PublicUrlBase) == '') {
-        process.env[Env.PublicUrlBase] = `http://localhost:${port}`;
-    }
+function useAws(): void {
+    app.get('/v1/*', async (req: express.Request, res: express.Response) => {
+        const startTime = Date.now();
+        const requestId = ulid.ulid();
+        const logger = LogConfig.get().child({ id: requestId });
+        const ctx = new LambdaContext(
+            {
+                httpMethod: 'get',
+                path: req.path,
+                queryStringParameters: req.query,
+            } as any,
+            logger,
+        );
+
+        await handleRequest(ctx, res, startTime, logger);
+    });
+
+    LogConfig.get().info({ port, base: process.env[Env.PublicUrlBase], aws: process.env['AWS_PROFILE'] }, 'Listen');
+}
+
+async function useLocal(): Promise<void> {
     let projection: number = Epsg.Google.code;
     const filePath = process.argv[2];
 
@@ -93,12 +110,24 @@ async function main(): Promise<void> {
     });
 
     app.use(express.static(__dirname + '/../../../landing/dist/'));
-    await new Promise((resolve) => app.listen(port, resolve));
 
     const url = Env.get(Env.PublicUrlBase) + `/?i=${tileSetName}&p=${projection}`;
     const wmts = Env.get(Env.PublicUrlBase) + `/v1/WMTSCapabilities.xml`;
     const xyz = Env.get(Env.PublicUrlBase) + `/v1/tiles/${tileSetName}/${projection}/{z}/{x}/{y}.png`;
     LogConfig.get().info({ url, wmts, xyz }, 'Listen');
+}
+
+async function main(): Promise<void> {
+    if (Env.get(Env.PublicUrlBase) == '') {
+        process.env[Env.PublicUrlBase] = `http://localhost:${port}`;
+    }
+
+    if (process.argv.length < 3) {
+        useAws();
+    } else {
+        await useLocal();
+    }
+    await new Promise((resolve) => app.listen(port, resolve));
 }
 
 main().catch((e) => console.error(e));

--- a/packages/lambda-xyz/src/cli/validate.ts
+++ b/packages/lambda-xyz/src/cli/validate.ts
@@ -1,5 +1,5 @@
 import pLimit from 'p-limit';
-import { Env, LogConfig } from '@basemaps/shared';
+import { Env, LogConfig, TileSetName } from '@basemaps/shared';
 import { TileSet } from '../tile.set';
 import { Epsg } from '@basemaps/geo';
 import { CogTiff } from '@cogeotiff/core';
@@ -11,7 +11,7 @@ const Q = pLimit(Env.getNumber(Env.TiffConcurrency, 25));
  * CLI to iterate over all imagery sets that have been defined and determine if all the COGS are present and optimized
  */
 async function main(): Promise<void> {
-    const tileSet = new TileSet('aerial', Epsg.Google);
+    const tileSet = new TileSet(TileSetName.aerial, Epsg.Google);
     await tileSet.load();
 
     let errorCount = 0;

--- a/packages/lambda-xyz/src/routes/tile.ts
+++ b/packages/lambda-xyz/src/routes/tile.ts
@@ -1,14 +1,14 @@
-import { Epsg, TileMatrixSet, Tile } from '@basemaps/geo';
+import { Tile, TileMatrixSet } from '@basemaps/geo';
 import { HttpHeader, LambdaContext, LambdaHttpResponse } from '@basemaps/lambda';
 import {
     Aws,
     Env,
+    ProjectionTileMatrixSet,
     TileDataWmts,
     TileDataXyz,
     tileFromPath,
     TileMetadataTag,
     TileType,
-    ProjectionTileMatrixSet,
 } from '@basemaps/shared';
 import { TileMakerSharp } from '@basemaps/tiler-sharp';
 import { CogTiff } from '@cogeotiff/core';
@@ -16,7 +16,7 @@ import { createHash } from 'crypto';
 import pLimit from 'p-limit';
 import { EmptyPng } from '../png';
 import { TileSet } from '../tile.set';
-import { loadTileSet } from '../tile.set.cache';
+import { loadTileSet, loadTileSets } from '../tile.set.cache';
 import { Tilers } from '../tiler';
 import { WmtsCapabilities } from '../wmts.capability';
 import { TileEtag } from './tile.etag';
@@ -39,6 +39,8 @@ const LoadingQueue = pLimit(Env.getNumber(Env.TiffConcurrency, 5));
 
 /** Background color of tiles where the tileset does not define a color */
 const DefaultBackground = { r: 0, g: 0, b: 0, alpha: 0 };
+
+const NotFound = new LambdaHttpResponse(404, 'Not Found');
 
 /** Initialize the tiffs before reading */
 async function initTiffs(tileSet: TileSet, tms: TileMatrixSet, tile: Tile, ctx: LambdaContext): Promise<CogTiff[]> {
@@ -86,7 +88,9 @@ export async function tile(req: LambdaContext, xyzData: TileDataXyz): Promise<La
     const latLon = ProjectionTileMatrixSet.get(xyzData.projection.code).tileCenterToLatLon(xyzData);
     req.set('location', latLon);
 
-    const tileSet = await loadTileSet(req, xyzData.name, xyzData.projection);
+    req.timer.start('tileset:load');
+    const tileSet = await loadTileSet(xyzData.name, xyzData.projection);
+    req.timer.end('tileset:load');
     if (tileSet == null) return new LambdaHttpResponse(404, 'Tileset Not Found');
 
     const tiffs = await initTiffs(tileSet, tiler.tms, xyzData, req);
@@ -132,13 +136,16 @@ export async function wmts(req: LambdaContext, wmtsData: TileDataWmts): Promise<
 
     const host = Env.get(Env.PublicUrlBase) ?? '';
 
-    // TODO when we support more than one projection
-    const tileSet = await loadTileSet(req, wmtsData.name, wmtsData.projection ?? Epsg.Google);
-    const provider = await Aws.tileMetadata.Provider.get(TileMetadataTag.Production);
-    if (tileSet == null || provider == null) return new LambdaHttpResponse(404, 'Not Found');
+    req.timer.start('tileset:load');
+    const tileSets = await loadTileSets(wmtsData.name, wmtsData.projection);
+    req.timer.end('tileset:load');
+    if (tileSets.length == 0) return NotFound;
 
-    const xml = WmtsCapabilities.toXml(host, provider, [tileSet], req.apiKey);
-    if (xml == null) return new LambdaHttpResponse(404, 'Not Found');
+    const provider = await Aws.tileMetadata.Provider.get(TileMetadataTag.Production);
+    if (provider == null) return NotFound;
+
+    const xml = WmtsCapabilities.toXml(host, provider, tileSets, req.apiKey);
+    if (xml == null) return NotFound;
 
     const data = Buffer.from(xml);
 
@@ -155,7 +162,11 @@ export async function wmts(req: LambdaContext, wmtsData: TileDataWmts): Promise<
 
 export async function TileOrWmts(req: LambdaContext): Promise<LambdaHttpResponse> {
     const xyzData = tileFromPath(req.action.rest);
-    if (xyzData == null) return new LambdaHttpResponse(404, 'Not Found');
+    if (xyzData == null) return NotFound;
+
+    req.set('tileSet', xyzData.name);
+    req.set('projection', xyzData.projection);
+
     if (xyzData.type === TileType.WMTS) {
         return wmts(req, xyzData);
     } else {

--- a/packages/lambda-xyz/src/tile.set.cache.ts
+++ b/packages/lambda-xyz/src/tile.set.cache.ts
@@ -1,6 +1,13 @@
+import { Bounds, Epsg } from '@basemaps/geo';
+import {
+    Aws,
+    ProjectionTileMatrixSet,
+    RecordPrefix,
+    TileMetadataTable,
+    TileSetNameValues,
+    TileSetRuleImagery,
+} from '@basemaps/shared';
 import { TileSet } from './tile.set';
-import { LambdaContext } from '@basemaps/lambda';
-import { Epsg } from '@basemaps/geo';
 
 export const TileSets = new Map<string, TileSet>();
 
@@ -9,20 +16,128 @@ export function getTileSet(name: string, projection: Epsg): TileSet | undefined 
     return TileSets.get(tileSetId);
 }
 
-export async function loadTileSet(req: LambdaContext, name: string, projection: Epsg): Promise<TileSet | null> {
-    req.set('tileSet', name);
-    req.set('projection', projection);
+/**
+ * Make a tileSet name nicer to display as a Title
+ * @example
+ *  'tasman_rural_2018-19_0-3m' => 'Tasman rural 2018-19 0.3m'
+ */
+function titleizeName(name: string): string {
+    return name[0].toUpperCase() + name.slice(1).replace(/_0-/g, ' 0.').replace(/_/g, ' ');
+}
+
+function individualTileSet(parent: TileSet, image: TileSetRuleImagery, setId?: string): TileSet {
+    const { id } = image.imagery;
+    if (setId == null) {
+        setId = TileMetadataTable.unprefix(RecordPrefix.Imagery, id);
+    }
+    const copy = new TileSet(setId, parent.projection);
+    // use parent data as prototype for child;
+    copy.tileSet = Object.create(parent.tileSet ?? null);
+    copy.tileSet.background = undefined;
+
+    copy.titleOverride = `${parent.title} ${titleizeName(image.imagery.name)}`;
+    copy.extentOverride = Bounds.fromJson(image.imagery.bounds);
+
+    const rule = {
+        id,
+        minZoom: 0,
+        maxZoom: image.rule.maxZoom,
+        priority: 0,
+    };
+    copy.tileSet.imagery = { [id]: rule };
+
+    copy.imagery = [
+        {
+            rule,
+            imagery: image.imagery,
+        },
+    ];
+
+    return copy;
+}
+
+/**
+ * Load a single Tileset from cache or DB
+
+ * @param name consisting of the `TileSetName` with optional `@tag` and `:subset_name`. When a
+ * subset name is present its id will be looked up from the parent tileSet.
+
+ * Example: `aerial@beta:tasman_rural_2018-19_0-3m`
+
+ * @param projection find TileSet for this projection.
+ */
+export async function loadTileSet(name: string, projection: Epsg): Promise<TileSet | null> {
+    const subsetIndex = name.indexOf(':');
+    const subsetName = subsetIndex == -1 ? '' : name.slice(subsetIndex + 1);
+    if (subsetName !== '') {
+        name = name.slice(0, subsetIndex);
+    }
     let tileSet = getTileSet(name, projection);
     if (tileSet == null) {
         tileSet = new TileSet(name, projection);
         TileSets.set(tileSet.id, tileSet);
     }
-    req.timer.start('tileset:load');
     const loaded = await tileSet.load();
-    req.timer.end('tileset:load');
     if (!loaded) {
         TileSets.delete(tileSet.id);
         return null;
     }
+    if (subsetName !== '') {
+        const image = tileSet.imagery.find((i) => i.imagery.name === subsetName);
+        if (image == null) return null;
+        const subTileSet = individualTileSet(tileSet, image);
+        return subTileSet;
+    }
     return tileSet;
+}
+
+function compareByTitle(a: TileSet, b: TileSet): number {
+    return a.title.localeCompare(b.title);
+}
+
+/**
+ * Load a collection of TileSets. Used by WMTSCapabilities
+
+ * @param nameStr if an empty string load all TileSets
+ * @param projection if null load all projections
+ */
+export async function loadTileSets(nameStr: string, projection: Epsg | null): Promise<TileSet[]> {
+    if (nameStr !== '' && nameStr[0] !== '@' && projection != null) {
+        // single tileSet
+        const ts = await loadTileSet(nameStr, projection);
+
+        return ts == null ? [] : [ts];
+    }
+
+    const isSubset = nameStr.indexOf(':') != -1;
+
+    const { name, tag } = Aws.tileMetadata.TileSet.parse(nameStr);
+
+    const projections: Epsg[] =
+        projection == null ? Array.from(ProjectionTileMatrixSet.targetCodes()).map((c) => Epsg.get(c)) : [projection];
+    const names = name === '' ? TileSetNameValues().map((tsn) => (tag == null ? tsn : `${tsn}@${tag}`)) : [nameStr];
+
+    const promises: Promise<TileSet | null>[] = [];
+
+    for (const n of names) {
+        for (const p of projections) {
+            promises.push(loadTileSet(n, p));
+        }
+    }
+
+    const tileSets: TileSet[] = [];
+    for (const parent of await Promise.all(promises)) {
+        if (parent != null) {
+            tileSets.push(parent);
+            if (isSubset) {
+                parent.name = nameStr;
+            } else if (parent.imagery != null && parent.imagery.length > 1) {
+                for (const image of parent.imagery) {
+                    tileSets.push(individualTileSet(parent, image, parent.taggedName + ':' + image.imagery.name));
+                }
+            }
+        }
+    }
+
+    return tileSets.sort(compareByTitle);
 }

--- a/packages/lambda-xyz/src/tile.set.ts
+++ b/packages/lambda-xyz/src/tile.set.ts
@@ -6,6 +6,7 @@ import {
     TileMetadataSetRecord,
     TileMetadataTag,
     TileSetRuleImagery,
+    ProjectionTileMatrixSet,
 } from '@basemaps/shared';
 import { CogTiff } from '@cogeotiff/core';
 import { CogSourceAwsS3 } from '@cogeotiff/source-aws';
@@ -14,9 +15,11 @@ export class TileSet {
     name: string;
     tag: TileMetadataTag;
     projection: Epsg;
-    protected tileSet: TileMetadataSetRecord;
+    tileSet: TileMetadataSetRecord;
     imagery: TileSetRuleImagery[];
     sources: Map<string, CogTiff> = new Map();
+    titleOverride: string;
+    extentOverride: Bounds;
 
     /**
      * Return the location of a imagery `record`
@@ -54,11 +57,15 @@ export class TileSet {
     }
 
     get title(): string {
-        return this.tileSet.title ?? this.name;
+        return this.titleOverride ?? this.tileSet.title ?? this.name;
     }
 
     get description(): string {
         return this.tileSet.description ?? '';
+    }
+
+    get extent(): Bounds {
+        return this.extentOverride ?? ProjectionTileMatrixSet.get(this.projection.code).tms.extent;
     }
 
     async load(): Promise<boolean> {

--- a/packages/lambda/src/__test__/api.path.test.ts
+++ b/packages/lambda/src/__test__/api.path.test.ts
@@ -34,6 +34,14 @@ o.spec('api.path', () => {
             o(ans).equals(null);
         });
 
+        o('should return null if projection not supported', () => {
+            const ctx = makeContext('/v1/tiles/aerial/3793/1/2/3.png');
+
+            const ans = tileFromPath(ctx.action.rest);
+
+            o(ans).equals(null);
+        });
+
         o('should extract variables png', () => {
             const ctx = makeContext('/v1/tiles/aerial/global-mercator/1/2/3.png');
 

--- a/packages/shared/src/api.path.ts
+++ b/packages/shared/src/api.path.ts
@@ -1,6 +1,6 @@
-import { Epsg } from '@basemaps/geo';
+import { Epsg, Tile } from '@basemaps/geo';
 import { getImageFormat, ImageFormat } from '@basemaps/tiler';
-import { Tile } from '@basemaps/geo';
+import { ProjectionTileMatrixSet } from './proj/projection.tile.matrix.set';
 
 export interface ActionData {
     version: string;
@@ -29,9 +29,17 @@ export interface TileDataWmts {
     projection: Epsg | null;
 }
 
+function parseTargetEpsg(text: string): Epsg | null {
+    const projection = Epsg.parse(text);
+    if (projection == null || !Array.from(ProjectionTileMatrixSet.targetCodes()).includes(projection.code)) {
+        return null;
+    }
+    return projection;
+}
+
 function tileXyzFromPath(path: string[]): TileData | null {
     const name = path[0];
-    const projection = Epsg.parse(path[1]);
+    const projection = parseTargetEpsg(path[1]);
     if (projection == null) return null;
     const z = parseInt(path[2], 10);
     const x = parseInt(path[3], 10);
@@ -59,10 +67,10 @@ function tileWmtsFromPath(path: string[]): TileData | null {
     if (path.length > 3) return null;
     if (path[path.length - 1] != 'WMTSCapabilities.xml') return null;
 
-    const name = path[0];
+    const name = path.length == 1 ? '' : path[0];
     let projection = null;
     if (path.length == 3) {
-        projection = Epsg.parse(path[1]);
+        projection = parseTargetEpsg(path[1]);
         if (projection == null) return null;
     }
 

--- a/packages/shared/src/aws/__test__/tile.metadata.table.test.ts
+++ b/packages/shared/src/aws/__test__/tile.metadata.table.test.ts
@@ -6,6 +6,7 @@ import { Const } from '../../const';
 import { qkToNamedBounds } from '../../proj/__test__/test.util';
 import { TileMetadataTable } from '../tile.metadata';
 import { TileMetadataImageRule, TileMetadataImageryRecordV1, TileMetadataSetRecord } from '../tile.metadata.base';
+import { TileSetName } from '../../proj/tile.set.name';
 
 const { marshall } = AWS.DynamoDB.Converter;
 
@@ -114,7 +115,7 @@ o.spec('tile.metadata.table', () => {
             id: 'ts_aerial_3857',
             version: 0,
             imagery: genMap(rules.values()),
-            name: 'aerial',
+            name: TileSetName.aerial,
             projection: Epsg.Google.code,
         } as TileMetadataSetRecord;
 
@@ -160,7 +161,7 @@ o.spec('tile.metadata.table', () => {
                 id: 'ts_aerial_3857',
                 version: 0,
                 imagery: genMap(genRules(5)),
-                name: 'aerial',
+                name: TileSetName.aerial,
                 projection: Epsg.Google.code,
             });
         } catch (_err) {
@@ -209,7 +210,7 @@ o.spec('tile.metadata.table', () => {
             id: 'ts_aerial_3857',
             version: 0,
             imagery: genMap(genRules(202)),
-            name: 'aerial',
+            name: TileSetName.aerial,
             projection: Epsg.Google.code,
         } as TileMetadataSetRecord;
 

--- a/packages/shared/src/aws/__test__/tile.metadata.tileset.test.ts
+++ b/packages/shared/src/aws/__test__/tile.metadata.tileset.test.ts
@@ -2,6 +2,7 @@ import o from 'ospec';
 import { TileMetadataTileSet } from '../tile.metadata.tileset';
 import { Epsg } from '@basemaps/geo';
 import { TileMetadataSetRecord, TileMetadataTag } from '../tile.metadata.base';
+import { TileSetName } from '../../proj/tile.set.name';
 
 const promiseNull = async (): Promise<unknown> => null;
 async function throws(cb: () => Promise<any>, re: RegExp): Promise<void> {
@@ -93,9 +94,9 @@ o.spec('tile.metadata.tileset', () => {
 
     o.spec('parse', () => {
         o('should parse @ syntax', () => {
-            o(ts.parse('aerial@head')).deepEquals({ name: 'aerial', tag: TileMetadataTag.Head });
-            o(ts.parse('aerial@production')).deepEquals({ name: 'aerial', tag: TileMetadataTag.Production });
-            o(ts.parse('aerial@beta')).deepEquals({ name: 'aerial', tag: TileMetadataTag.Beta });
+            o(ts.parse('aerial@head')).deepEquals({ name: TileSetName.aerial, tag: TileMetadataTag.Head });
+            o(ts.parse('aerial@production')).deepEquals({ name: TileSetName.aerial, tag: TileMetadataTag.Production });
+            o(ts.parse('aerial@beta')).deepEquals({ name: TileSetName.aerial, tag: TileMetadataTag.Beta });
         });
 
         o('should throw with invalid tags', () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,6 +10,7 @@ export { VNodeParser } from './vdom.parse';
 export { CompositeError } from './composite.error';
 export { LoggerFatalError } from './logger.fatal.error';
 export * from './proj/projection.tile.matrix.set';
+export { TileSetName, TileSetNameValues } from './proj/tile.set.name';
 
 export * from './aws/tile.metadata.base';
 export * from './aws/tile.metadata';

--- a/packages/shared/src/proj/__test__/projection.test.ts
+++ b/packages/shared/src/proj/__test__/projection.test.ts
@@ -12,10 +12,10 @@ o.spec('Projection', () => {
         if (nztmProj == null) {
             throw new Error('Failed to init proj:2193');
         }
-        const output = nztmProj.toWsg84([1180000, 4758000]);
+        const output = nztmProj.toWgs84([1180000, 4758000]);
         o(round(output, 6)).deepEquals([167.454458, -47.197075]);
 
-        const reverse = nztmProj.fromWsg84(output);
+        const reverse = nztmProj.fromWgs84(output);
         o(round(reverse, 2)).deepEquals([1180000, 4758000]);
     });
 
@@ -37,6 +37,16 @@ o.spec('Projection', () => {
             [180, -66.51326044],
             [90, -66.51326044],
         ]);
+    });
+
+    o('boundsToWgs84', () => {
+        const source = Bounds.fromBbox([1766181, 5439092, 1780544, 5450093]);
+
+        o(round(nztmProj.boundsToWgs84(source).toBbox(), 4)).deepEquals([174.9814, -41.1825, 175.1493, -41.0804]);
+
+        const crossAM = Bounds.fromBbox([1766181, 5439092, 2580544, 5450093]);
+
+        o(round(nztmProj.boundsToWgs84(crossAM).toBbox(), 4)).deepEquals([174.9814, -41.1825, 184.563, -40.5171]);
     });
 
     o.spec('boundsToGeoJsonFeature', () => {

--- a/packages/shared/src/proj/__test__/projection.tile.matrix.set.test.ts
+++ b/packages/shared/src/proj/__test__/projection.tile.matrix.set.test.ts
@@ -221,4 +221,8 @@ o.spec('ProjectionTileMatrixSet', () => {
             o(totalRightIntersectionHeight).equals(bounds.height);
         });
     });
+
+    o('TargetCodes', () => {
+        o(Array.from(ProjectionTileMatrixSet.targetCodes())).deepEquals([3857, 2193]);
+    });
 });

--- a/packages/shared/src/proj/projection.tile.matrix.set.ts
+++ b/packages/shared/src/proj/projection.tile.matrix.set.ts
@@ -26,6 +26,10 @@ export class ProjectionTileMatrixSet {
         this.proj = Projection.get(tms.projection.code);
     }
 
+    static targetCodes(): IterableIterator<EpsgCode> {
+        return CodeMap.keys();
+    }
+
     /**
      * Get the ProjectionTileMatrixSet instance for a specified code,
      *
@@ -78,8 +82,8 @@ export class ProjectionTileMatrixSet {
         const ul = this.tms.tileToSource(tile);
         const lr = this.tms.tileToSource({ x: tile.x + 1, y: tile.y + 1, z: tile.z });
 
-        const [swLon, swLat] = this.proj.toWsg84([ul.x, lr.y]);
-        const [neLon, neLat] = this.proj.toWsg84([lr.x, ul.y]);
+        const [swLon, swLat] = this.proj.toWgs84([ul.x, lr.y]);
+        const [neLon, neLat] = this.proj.toWgs84([lr.x, ul.y]);
 
         return [swLon, swLat, neLon, neLat];
     }
@@ -89,7 +93,7 @@ export class ProjectionTileMatrixSet {
      */
     tileCenterToLatLon(tile: Tile): LatLon {
         const point = this.tms.tileToSource({ x: tile.x + 0.5, y: tile.y + 0.5, z: tile.z });
-        const [lon, lat] = this.proj.toWsg84([point.x, point.y]);
+        const [lon, lat] = this.proj.toWgs84([point.x, point.y]);
         return { lat, lon };
     }
 

--- a/packages/shared/src/proj/tile.set.name.ts
+++ b/packages/shared/src/proj/tile.set.name.ts
@@ -1,0 +1,7 @@
+export enum TileSetName {
+    aerial = 'aerial',
+}
+
+export function TileSetNameValues(): TileSetName[] {
+    return [TileSetName.aerial];
+}

--- a/packages/tiler/src/raster.ts
+++ b/packages/tiler/src/raster.ts
@@ -39,7 +39,7 @@ export enum ImageFormat {
     WEBP = 'webp',
 }
 
-export const ImageFormatOrder = [ImageFormat.PNG, ImageFormat.WEBP, ImageFormat.JPEG];
+export const ImageFormatOrder = [ImageFormat.JPEG, ImageFormat.WEBP, ImageFormat.PNG];
 
 /** Guess the image format based on the file extension */
 export function getImageFormat(ext: string): ImageFormat | null {


### PR DESCRIPTION
When the tile set name is not supplied create a WMTSCapabilities xml file with all supported Layers
including individual layers from composite tileSets.

When the projection is not supplied create a WMTSCapabilities xml file with layers for all supported
target projections.

Allow fetching sub imagery tiles by the parent imagery name plus the child imagery set name. For
example `/v1/tiles/aerial@beta:tasman_rural_2018-19_0-3m/2193/8/405/321.png`

Group projections for same imagery.

Set the `ows:BoundingBox` for each layer to the extent of the layer

Set the `ows:WGS84BoundingBox` also (after the `ows:BoundingBox`). Currently if the bounding box
crosses the anti-merdian just make the boundingbox the world extent. It may be possible to instead
create two bounding boxes on each side of the anti-merdian.
