### PR TITLE
feat(s3fs): expose standard error codes for not found and forbidden

### DIFF
--- a/packages/linzjs-s3fs/src/__tests__/file.local.test.ts
+++ b/packages/linzjs-s3fs/src/__tests__/file.local.test.ts
@@ -1,0 +1,66 @@
+import o from 'ospec';
+import { FsLocal } from '../file.local';
+import { CompositeError } from '../composite.error';
+
+o.spec('FileLocal', () => {
+    const localFs = new FsLocal();
+    o('Should capture not found errors:list', async () => {
+        try {
+            await localFs.list('/foo/bar/baz');
+            throw new Error('Failed to throw');
+        } catch (e) {
+            o(CompositeError.isCompositeError(e)).equals(true);
+            o(e.code).equals(404);
+        }
+    });
+
+    o('Should capture not found errors:write', async () => {
+        try {
+            await localFs.write('/foo/bar/baz', Buffer.from('foobar'), false);
+            throw new Error('Failed to throw');
+        } catch (e) {
+            o(CompositeError.isCompositeError(e)).equals(true);
+            o(e.code).equals(404);
+        }
+    });
+
+    o('Should capture not found errors:read', async () => {
+        try {
+            await localFs.read('/foo/bar/baz');
+            throw new Error('Failed to throw');
+        } catch (e) {
+            o(CompositeError.isCompositeError(e)).equals(true);
+            o(e.code).equals(404);
+        }
+    });
+
+    o('Should capture permission errors:list', async () => {
+        try {
+            await localFs.list('/root/test');
+            throw new Error('Failed to throw');
+        } catch (e) {
+            o(CompositeError.isCompositeError(e)).equals(true);
+            o(e.code).equals(403);
+        }
+    });
+
+    o('Should capture permission errors:write', async () => {
+        try {
+            await localFs.write('/root/test', Buffer.from('foobar'), false);
+            throw new Error('Failed to throw');
+        } catch (e) {
+            o(CompositeError.isCompositeError(e)).equals(true);
+            o(e.code).equals(403);
+        }
+    });
+
+    o('Should capture permission errors:read', async () => {
+        try {
+            await localFs.read('/root/test');
+            throw new Error('Failed to throw');
+        } catch (e) {
+            o(CompositeError.isCompositeError(e)).equals(true);
+            o(e.code).equals(403);
+        }
+    });
+});

--- a/packages/linzjs-s3fs/src/composite.error.ts
+++ b/packages/linzjs-s3fs/src/composite.error.ts
@@ -1,10 +1,25 @@
+export const enum ErrorCodes {
+    PermissionDenied = 403,
+    NotFound = 404,
+    InternalError = 500,
+}
+
 /**
  * Utility error to wrap other errors to make them more understandable
  */
 export class CompositeError extends Error {
+    name = 'CompositeError';
+    code: ErrorCodes;
     reason: Error;
-    constructor(msg: string, reason: Error) {
+
+    constructor(msg: string, code: ErrorCodes, reason: Error) {
         super(msg);
+        this.code = code;
         this.reason = reason;
+    }
+
+    static isCompositeError(e: unknown): e is CompositeError {
+        if (typeof e != 'object' || e == null) return false;
+        return (e as CompositeError).name == 'CompositeError';
     }
 }

--- a/packages/linzjs-s3fs/src/file.local.ts
+++ b/packages/linzjs-s3fs/src/file.local.ts
@@ -2,40 +2,57 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Readable } from 'stream';
 import { FileProcessor } from './file';
+import { CompositeError } from './composite.error';
 
-export const FileOperatorLocal: FileProcessor = {
+export type FsError = { code: string } & Error;
+function getCompositeError(e: FsError, msg: string): CompositeError {
+    if (e.code == 'ENOENT') return new CompositeError(msg, 404, e);
+    if (e.code == 'EACCES') return new CompositeError(msg, 403, e);
+    return new CompositeError(msg, 500, e);
+}
+
+export class FsLocal implements FileProcessor {
     async list(filePath: string): Promise<string[]> {
-        const files = await fs.promises.readdir(filePath);
-        return files.map((f: string): string => path.join(filePath, f));
-    },
+        try {
+            const files = await fs.promises.readdir(filePath);
+            return files.map((f: string): string => path.join(filePath, f));
+        } catch (e) {
+            throw getCompositeError(e, `Failed to list: ${filePath}`);
+        }
+    }
 
     async read(filePath: string): Promise<Buffer> {
-        return fs.promises.readFile(filePath);
-    },
+        try {
+            return await fs.promises.readFile(filePath);
+        } catch (e) {
+            throw getCompositeError(e, `Failed to read: ${filePath}`);
+        }
+    }
 
     async exists(filePath: string): Promise<boolean> {
-        return await new Promise((resolve) => {
-            fs.exists(filePath, resolve);
-        });
-    },
+        return await new Promise((resolve) => fs.exists(filePath, resolve));
+    }
 
-    async write(filePath: string, buf: Buffer | Readable): Promise<void> {
+    async write(filePath: string, buf: Buffer | Readable, makeFolder = true): Promise<void> {
         const folderPath = path.dirname(filePath);
-        await fs.promises.mkdir(folderPath, { recursive: true });
-
-        if (Buffer.isBuffer(buf)) {
-            await fs.promises.writeFile(filePath, buf);
-        } else {
-            const st = fs.createWriteStream(filePath);
-            await new Promise((resolve, reject) => {
-                st.on('finish', resolve);
-                st.on('error', reject);
-                buf.pipe(st);
-            });
+        if (makeFolder) await fs.promises.mkdir(folderPath, { recursive: true });
+        try {
+            if (Buffer.isBuffer(buf)) {
+                await fs.promises.writeFile(filePath, buf);
+            } else {
+                const st = fs.createWriteStream(filePath);
+                await new Promise((resolve, reject) => {
+                    st.on('finish', resolve);
+                    st.on('error', reject);
+                    buf.pipe(st);
+                });
+            }
+        } catch (e) {
+            throw getCompositeError(e, `Failed to write: ${filePath}`);
         }
-    },
+    }
 
     readStream(filePath: string): fs.ReadStream {
         return fs.createReadStream(filePath);
-    },
-};
+    }
+}

--- a/packages/linzjs-s3fs/src/index.ts
+++ b/packages/linzjs-s3fs/src/index.ts
@@ -2,11 +2,14 @@ import { S3 } from 'aws-sdk';
 import { Readable } from 'stream';
 import { FileProcessor } from './file';
 import { FileConfig, FileConfigS3 } from './file.config';
-import { FileOperatorLocal } from './file.local';
-import { FileProcessorS3 } from './file.s3';
+import { FsLocal } from './file.local';
+import { FsS3 } from './file.s3';
 
 export * from './file.config';
 export * from './file';
+export { CompositeError } from './composite.error';
+
+const localFs = new FsLocal();
 
 export class S3Fs {
     getS3: (cfg: FileConfigS3 | string) => S3;
@@ -45,8 +48,8 @@ export class S3Fs {
     }
 
     /** Is this FileProcessor a s3 instance */
-    isS3Processor(fo: FileProcessor): fo is FileProcessorS3 {
-        return fo instanceof FileProcessorS3;
+    isS3Processor(fo: FileProcessor): fo is FsS3 {
+        return fo instanceof FsS3;
     }
 
     /** Is this a s3 URI */
@@ -59,13 +62,13 @@ export class S3Fs {
     create(cfg: string | FileConfig): FileProcessor {
         if (typeof cfg == 'string') {
             if (this.isS3(cfg)) {
-                return new FileProcessorS3(this.getS3(cfg));
+                return new FsS3(this.getS3(cfg));
             }
-            return FileOperatorLocal;
+            return localFs;
         }
         if (cfg.type == 's3') {
-            return new FileProcessorS3(this.getS3(cfg));
+            return new FsS3(this.getS3(cfg));
         }
-        return FileOperatorLocal;
+        return localFs;
     }
 }


### PR DESCRIPTION
use 403 and 404 for errors across s3 and local instead of fs:EACESS or fs:ENOENT and s3:NotFound


