### PR TITLE
fix(tiler): Use nearest smoothing when down sizing

### DIFF
--- a/packages/tiler-sharp/src/__test__/tile.creation.test.ts
+++ b/packages/tiler-sharp/src/__test__/tile.creation.test.ts
@@ -40,7 +40,7 @@ o.spec('TileCreation', () => {
 
         const topLeft = layer0.find((f) => f.source.x == 0 && f.source.y == 0);
         o(topLeft?.tiff.source.name).equals(tiff.source.name);
-        o(topLeft?.resize).deepEquals({ width: 32, height: 32 });
+        o(topLeft?.resize).deepEquals({ width: 32, height: 32, downsize: false });
         o(topLeft?.x).equals(64);
         o(topLeft?.y).equals(64);
     });

--- a/packages/tiler-sharp/src/index.ts
+++ b/packages/tiler-sharp/src/index.ts
@@ -7,7 +7,8 @@ function notEmpty<T>(value: T | null | undefined): value is T {
 }
 export type SharpOverlay = { input: string | Buffer } & Sharp.OverlayOptions;
 
-const SharpScaleOptions = { fit: Sharp.fit.cover };
+const SharpScaleOptionsDownsize = { fit: Sharp.fit.cover, kernel: Sharp.kernel.nearest };
+const SharpScaleOptionsUpsize = { fit: Sharp.fit.cover, kernel: Sharp.kernel.lanczos3 };
 
 export class TileMakerSharp implements TileMaker {
     static readonly MaxImageSize = 256 * 2 ** 15;
@@ -89,7 +90,11 @@ export class TileMakerSharp implements TileMaker {
         }
 
         if (composition.resize) {
-            sharp.resize(composition.resize.width, composition.resize.height, SharpScaleOptions);
+            sharp.resize(
+                composition.resize.width,
+                composition.resize.height,
+                composition.resize.downsize ? SharpScaleOptionsDownsize : SharpScaleOptionsUpsize,
+            );
         }
 
         if (composition.crop) {

--- a/packages/tiler/src/__test__/tiler.test.ts
+++ b/packages/tiler/src/__test__/tiler.test.ts
@@ -63,7 +63,7 @@ o.spec('tiler.test', () => {
             y: 0,
             x: 64,
             extract: { width: 512, height: 387 },
-            resize: { width: 256, height: 194 },
+            resize: { width: 256, height: 194, downsize: true },
             crop,
         });
 

--- a/packages/tiler/src/raster.ts
+++ b/packages/tiler/src/raster.ts
@@ -28,7 +28,7 @@ export interface Composition {
     /** Crop the initial bounds */
     extract?: Size;
     /** Resize the image */
-    resize?: Size;
+    resize?: Size & { downsize: boolean };
     /** Crop after the resize */
     crop?: Bounds;
 }

--- a/packages/tiler/src/tiler.ts
+++ b/packages/tiler/src/tiler.ts
@@ -110,7 +110,7 @@ export class Tiler {
         // Often COG tiles do not align to the same size as XYZ Tiles
         // This will scale the COG tile to the same size as a XYZ
         if (source.width != target.width || source.height != target.height) {
-            composition.resize = { width: target.width, height: target.height };
+            composition.resize = { width: target.width, height: target.height, downsize: source.width > target.width };
         }
 
         // If the output XYZ tile needs a piece of a COG tile, extract the speicific


### PR DESCRIPTION
Use lanczos3 when up sizing. This is a fix to reduce artefacts when rendering the topo-50 nztm
layer.

Allow supplying source order when creating CogJob; needed when ordering is important or a source
directory contains more than one imagery set as in the case of topo-50.

