### PR TITLE
fix(cli): use the same url pattern as WMTS to invalidate cache

### DIFF
--- a/packages/cli/src/cli/basemaps/tileset.util.ts
+++ b/packages/cli/src/cli/basemaps/tileset.util.ts
@@ -87,7 +87,7 @@ export function invalidateXYZCache(
     commit = false,
 ): Promise<void> {
     const nameStr = tag == TileMetadataTag.Production ? name : `${name}@${tag}`;
-    const path = `/v1/tiles/${nameStr}/${projection}/*`;
+    const path = `/v1/tiles/${nameStr}/${projection.toEpsgString()}/*`;
 
     return invalidateCache(path, commit);
 }


### PR DESCRIPTION
See #1034

Was invalidating, say, `/v1/tiles/topo50/2193/*`; now is `/v1/tiles/topo50/EPSG:2193`

