### PR TITLE
fix(lambda-xyz): Stop health and ping response being cached

### DIFF
--- a/packages/lambda-xyz/src/__test__/index.test.ts
+++ b/packages/lambda-xyz/src/__test__/index.test.ts
@@ -39,6 +39,7 @@ o.spec('LambdaXyz index', () => {
 
             o(response.status).equals(200);
             o(response.statusDescription).equals('ok');
+            o(response.header('cache-control')).equals('no-store');
             o(JSON.parse(response.body)).deepEquals({
                 version: '1.2.3',
                 hash: 'abc456',
@@ -50,11 +51,13 @@ o.spec('LambdaXyz index', () => {
         const res = await handleRequest(req('/health'));
         o(res.status).equals(200);
         o(res.statusDescription).equals('ok');
+        o(res.header('cache-control')).equals('no-store');
     });
 
     o('should respond to /ping', async () => {
         const res = await handleRequest(req('/ping'));
         o(res.status).equals(200);
         o(res.statusDescription).equals('ok');
+        o(res.header('cache-control')).equals('no-store');
     });
 });

--- a/packages/lambda-xyz/src/routes/api.ts
+++ b/packages/lambda-xyz/src/routes/api.ts
@@ -1,15 +1,19 @@
-import { LambdaHttpResponse } from '@basemaps/lambda';
+import { LambdaHttpResponse, HttpHeader } from '@basemaps/lambda';
+
+const OkResponse = new LambdaHttpResponse(200, 'ok');
+OkResponse.header(HttpHeader.CacheControl, 'no-store');
 
 export async function Health(): Promise<LambdaHttpResponse> {
-    return new LambdaHttpResponse(200, 'ok');
+    return OkResponse;
 }
 
 export async function Ping(): Promise<LambdaHttpResponse> {
-    return new LambdaHttpResponse(200, 'ok');
+    return OkResponse;
 }
 
 export async function Version(): Promise<LambdaHttpResponse> {
     const response = new LambdaHttpResponse(200, 'ok');
+    response.header(HttpHeader.CacheControl, 'no-store');
     response.json({ version: process.env.GIT_VERSION, hash: process.env.GIT_HASH });
     return response;
 }


### PR DESCRIPTION
Cloudfront was caching these requests

