### PR TITLE
fix(shared): Don't error if tile ext missing

### DIFF
--- a/packages/lambda/src/__test__/api.path.test.ts
+++ b/packages/lambda/src/__test__/api.path.test.ts
@@ -34,6 +34,14 @@ o.spec('api.path', () => {
             o(ans).equals(null);
         });
 
+        o('should allow missing extension', () => {
+            const ctx = makeContext('/v1/tiles/aerial/EPSG:3857/12/4009/2602');
+
+            const ans = tileFromPath(ctx.action.rest);
+
+            o(ans).equals(null);
+        });
+
         o('should return null if projection not supported', () => {
             const ctx = makeContext('/v1/tiles/aerial/3793/1/2/3.png');
 

--- a/packages/shared/src/api.path.ts
+++ b/packages/shared/src/api.path.ts
@@ -48,7 +48,7 @@ function tileXyzFromPath(path: string[]): TileData | null {
 
     if (isNaN(x) || isNaN(y) || isNaN(z)) return null;
 
-    const ext = getImageFormat(extStr);
+    const ext = extStr ? getImageFormat(extStr) : null;
     if (ext == null) return null;
 
     return { type: TileType.Image, name, projection, x, y, z, ext };


### PR DESCRIPTION
This path `/v1/tiles/aerial/EPSG:3857/12/4009/2602` was throwing an error


