### PR TITLE
build: ignore aws-cdk from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  ignore:
+    - dependency-name: '@aws-cdk/*'
+    - dependency-name: 'aws-cdk'
   open-pull-requests-limit: 10


### PR DESCRIPTION
Dependabot does not do a good job updating these dependencies as they all need to be bumped at the same time.
