### PR TITLE
fix/linzjs-s3fs: throw 404 CompositeError if read throws NoSuchKey

### DIFF
--- a/packages/linzjs-s3fs/src/__tests__/file.s3.test.ts
+++ b/packages/linzjs-s3fs/src/__tests__/file.s3.test.ts
@@ -1,0 +1,40 @@
+import { FsS3 } from '../file.s3';
+import o from 'ospec';
+import { S3 } from 'aws-sdk';
+
+o.spec('file.s3', () => {
+    o.spec('CompositeError', () => {
+        let err: any = null;
+        const mockS3 = {
+            getObject(): any {
+                return {
+                    async promise(): Promise<void> {
+                        throw err;
+                    },
+                };
+            },
+        } as S3;
+        const fs = new FsS3(mockS3);
+
+        o('bad statusCode', async () => {
+            err = {};
+            try {
+                await fs.read('s3://test-bucket/foo.txt');
+                o('Should have thrown error').equals('');
+            } catch (err) {
+                o(err.code).equals(500);
+            }
+        });
+
+        o('statusCode', async () => {
+            err = { statusCode: 404 };
+            try {
+                await fs.read('s3://test-bucket/foo.txt');
+                o('Should have thrown error').equals('');
+            } catch (err) {
+                o(err.code).equals(404);
+                o(err.reason.statusCode).equals(404);
+            }
+        });
+    });
+});

--- a/packages/linzjs-s3fs/src/file.s3.ts
+++ b/packages/linzjs-s3fs/src/file.s3.ts
@@ -4,9 +4,7 @@ import { CompositeError } from './composite.error';
 import { FileProcessor } from './file';
 
 function getCompositeError(e: AWSError, msg: string): CompositeError {
-    if (e == null) return new CompositeError(msg, 500, e);
-    if (e.code == 'NotFound') return new CompositeError(msg, 404, e);
-    if (e.code == 'AccessDenied') return new CompositeError(msg, 403, e);
+    if (typeof e?.statusCode === 'number') return new CompositeError(msg, e.statusCode, e);
     return new CompositeError(msg, 500, e);
 }
 


### PR DESCRIPTION
Previously only code of 'NotFound' was throwing 404; 'NoSuchKey' threw 500

Now uses the Aws `statusCode` instead of aws code as error type.
