### PR TITLE
fix(landing): Don't use auto for svg height

### DIFF
--- a/packages/landing/static/index.css
+++ b/packages/landing/static/index.css
@@ -94,7 +94,7 @@ button {
 
 .nz-govt-logo svg {
     width: 200px;
-    height: auto;
+    height: 24px;
 }
 
 .lui-footer-x-sm.g-footer__standard {
@@ -144,7 +144,7 @@ button {
 
 .lui-header-logo .linz-logo-sm {
     width: 160px;
-    height: auto;
+    height: 40px;
 }
 
 .side-nav {


### PR DESCRIPTION
Breaks Safari

