### PR TITLE
chore: update license referred to in README to MIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Basemaps
 
 [![Build Status](https://github.com/linz/basemaps/workflows/Build/badge.svg)](https://github.com/linz/basemaps/actions)
-[![License](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](https://github.com/linz/basemaps/blob/master/LICENSE)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/linz/basemaps/blob/master/LICENSE)
 [![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/linz/basemaps.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/linz/basemaps/context:javascript)
 
 A digital basemap provides a consistent background detail necessary to orient location and add to aesthetic appeal. Basemaps can be made up of streets, parcels, boundaries (country, regional, and city boundaries), shaded relief of a digital elevation model, waterways, hydrography, aerial and satellite imagery. Basemaps can be used as desktop, website or mobile phone application components, or as a 3rd party layers within a GIS or desktop mapping application.
@@ -29,4 +29,4 @@ yarn run test
 
 ## License
 
-This system is licensed under the 3-clause BSD License, except where otherwise specified. See the [LICENSE](https://github.com/linz/basemaps/blob/master/LICENSE) file for more details.
+This system is licensed under the MIT License, except where otherwise specified. See the [LICENSE](https://github.com/linz/basemaps/blob/master/LICENSE) file for more details.


### PR DESCRIPTION
The README referred to BSD-3, while the LICENSE file is MIT. Updated badge and text to match the file.