### PR TITLE
feat(lambda-api-tracker): remove www. from referer tracking

### DIFF
--- a/packages/lambda-api-tracker/src/__test__/xyz.request.test.ts
+++ b/packages/lambda-api-tracker/src/__test__/xyz.request.test.ts
@@ -92,6 +92,13 @@ o.spec('xyz-request', () => {
             o(getUrlHost('http://localhost:12344/bar/baz')).equals('localhost');
         });
 
+        o('should normalize www.foo.com and foo.com ', () => {
+            o(getUrlHost('https://www.foo.com/')).equals('foo.com');
+            o(getUrlHost('https://bar.foo.com/')).equals('bar.foo.com');
+            o(getUrlHost('https://www3.foo.com/')).equals('www3.foo.com');
+            o(getUrlHost('https://foo.com/')).equals('foo.com');
+        });
+
         o('should not die with badly formatted urls', () => {
             o(getUrlHost('foo/bar')).equals('foo/bar');
             o(getUrlHost('some weird text')).equals('some weird text');

--- a/packages/lambda-api-tracker/src/index.ts
+++ b/packages/lambda-api-tracker/src/index.ts
@@ -6,8 +6,10 @@ import { ValidateRequest } from './validate';
 export function getUrlHost(ref: string | undefined): string | undefined {
     if (ref == null) return ref;
     try {
-        const url = new URL(ref);
-        if (url.hostname) return url.hostname;
+        const { hostname } = new URL(ref);
+        if (hostname == null) return ref;
+        if (hostname.startsWith('www.')) return hostname.slice(4);
+        return hostname;
     } catch (e) {
         // Ignore
     }


### PR DESCRIPTION
A lot of sites will use foo.com or www.foo.com interchangeably

