### PR TITLE
fix: STAC files should comply to 1.0.0-beta.2 of the specification

### DIFF
--- a/packages/bathymetry/src/__test__/stac.test.ts
+++ b/packages/bathymetry/src/__test__/stac.test.ts
@@ -1,5 +1,5 @@
 import { GoogleTms } from '@basemaps/geo/build/tms/google';
-import { LogConfig, LogType, StacCollection } from '@basemaps/shared';
+import { LogConfig, LogType, StacCollection, StacBaseMapsExtension, StacVersion } from '@basemaps/shared';
 import { mockFileOperator } from '@basemaps/shared/build/file/__test__/file.operator.test.helper';
 import { round } from '@basemaps/test/build/rounding';
 import o from 'ospec';
@@ -42,8 +42,8 @@ o.spec('stac', () => {
         o(date >= now && date < now + 2000).equals(true);
 
         o(round(stac, 4)).deepEquals({
-            stac_version: '1.0.0',
-            stac_extensions: ['proj', 'linz'],
+            stac_version: StacVersion,
+            stac_extensions: ['projection', StacBaseMapsExtension],
             id: 'id123/13-22-33',
             collection: 'id123',
             type: 'Feature',
@@ -109,13 +109,13 @@ o.spec('stac', () => {
             const stac = await Stac.createCollection(bm, bounds, items, logger);
 
             o(round(stac, 4)).deepEquals({
-                stac_version: '1.0.0',
-                stac_extensions: ['proj'],
+                stac_version: StacVersion,
+                stac_extensions: ['projection'],
                 id: 'id123',
                 title: 'Gebco 2020.nc',
-                description: undefined,
+                description: 'No description',
                 extent: {
-                    spatial: { bbox: [-157.5, 74.0195, -135, 79.1713] },
+                    spatial: { bbox: [[-157.5, 74.0195, -135, 79.1713]] },
                     temporal: {
                         interval: [['2020-01-01T00:00:00Z', '2021-01-01T00:00:00Z']],
                     },
@@ -140,7 +140,7 @@ o.spec('stac', () => {
                 description: 'collection description',
                 providers: [{ name: 'source provider', roles: ['source'] }],
                 extent: {
-                    spatial: { bbox: [-180, 84, -178, 85] },
+                    spatial: { bbox: [[-180, 84, -178, 85]] },
                     temporal: { interval: [['2020-01-01T00:00:00Z', '2020-10-12T01:02:03Z']] },
                 },
             } as StacCollection;
@@ -156,13 +156,13 @@ o.spec('stac', () => {
             o(/^\d+\.\d+\.\d+$/.test(gitHubLink.version)).equals(true);
 
             o(round(stac, 4)).deepEquals({
-                stac_version: '1.0.0',
-                stac_extensions: ['proj'],
+                stac_version: StacVersion,
+                stac_extensions: ['projection'],
                 id: 'id123',
                 title: 'fancy title',
                 description: 'collection description',
                 extent: {
-                    spatial: { bbox: [-179.0332, 84.9205, -178.9893, 84.9244] },
+                    spatial: { bbox: [[-179.0332, 84.9205, -178.9893, 84.9244]] },
                     temporal: { interval: [['2020-01-01T00:00:00Z', '2020-10-12T01:02:03Z']] },
                 },
                 license: 'CC-BY-4.0',

--- a/packages/cli/src/cog/stac.ts
+++ b/packages/cli/src/cog/stac.ts
@@ -28,8 +28,7 @@ export interface CogSummaries {
 }
 
 export const CogStacKeywords = ['Imagery', 'New Zealand'];
-export const CogStacItemExtensions = ['proj'];
-export const CogStacExtensions = ['proj', 'linz'];
+export const CogStacItemExtensions = ['projection'];
 
 /** STAC compliant structure for storing Job instructions */
 export type CogStac = StacCollection<CogSummaries>;

--- a/packages/landing/scripts/util.js
+++ b/packages/landing/scripts/util.js
@@ -1,0 +1,29 @@
+const { join } = require('path');
+const fs = require('fs').promises;
+
+/**
+ * call `callback` for every file in `topDir`. Sub directories a traversed unless callback returns false.
+
+ * @param topDir top directory to scan
+ * @param callback async function that is called with (subPath, isDir) and returns true if dir
+ * should be traversed.
+ */
+exports.recurseDirectory = async (topDir, callback) => {
+    const recurse = async (subDir) => {
+        const path = subDir === '' ? topDir : join(topDir, subDir);
+        const files = await fs.readdir(path);
+        for (const file of files) {
+            const subPath = subDir === '' ? file : join(subDir, file);
+            const stat = await fs.stat(join(topDir, subPath));
+            if (stat.isDirectory()) {
+                if (await callback(subPath, true)) {
+                    await recurse(subPath);
+                }
+            } else {
+                await callback(subPath, false);
+            }
+        }
+    };
+
+    await recurse('');
+};

--- a/packages/landing/static/json-schema/stac-basemaps-extension/1.0/schema.json
+++ b/packages/landing/static/json-schema/stac-basemaps-extension/1.0/schema.json
@@ -1,0 +1,128 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://basemaps.linz.govt.nz/json-schema/stac-basemaps-extension/1.0/schema.json#",
+  "title": "LINZ Basemaps Extension",
+  "description": "STAC LINZ Basemaps extension to a SATC item and STAC collection.",
+  "oneOf": [
+    {
+      "allOf": [
+        {
+          "$ref": "https://schemas.stacspec.org/v1.0.0-beta.2/item-spec/json-schema/item.json"
+        },
+        {
+          "$ref": "#/definitions/common"
+        },
+        {
+          "$ref": "#/definitions/item"
+        }
+      ]
+    },
+    {
+      "allOf": [
+        {
+          "$ref": "https://schemas.stacspec.org/v1.0.0-beta.2/collection-spec/json-schema/collection.json"
+        },
+        {
+          "$ref": "#/definitions/common"
+        },
+        {
+          "$ref": "#/definitions/collection"
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "common": {
+      "type": "object",
+      "required": [
+        "stac_extensions"
+      ],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "enum": [
+              "https://basemaps.linz.govt.nz/json-schema/stac-basemaps-extension/1.0/schema.json"
+            ]
+          }
+        }
+      }
+    },
+    "item": {
+      "type": "object",
+      "properties": {
+        "properties": {
+          "type": "object",
+          "properties": {
+            "linz:gdal:version": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "collection": {
+      "type": "object",
+      "properties": {
+        "summaries": {
+          "type": "object",
+          "properties": {
+            "proj:epsg": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            },
+            "linz:output": {
+              "type": "array",
+              "contains": {
+                "properties": {
+                  "resampling": {
+                    "type": "object",
+                    "properties": {
+                      "warp": {
+                        "type": "string"
+                      },
+                      "overview": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "quality": {
+                    "type": "number"
+                  },
+                  "cutlineBlend": {
+                    "type": "number"
+                  },
+                  "addAlpha": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "linz:generated": {
+              "type": "array",
+              "contains": {
+                "properties": {
+                  "package": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "string"
+                  },
+                  "hash": {
+                    "type": "string"
+                  },
+                  "datetime": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/shared/src/stac/index.ts
+++ b/packages/shared/src/stac/index.ts
@@ -1,5 +1,7 @@
-export const StacVersion = '1.0.0';
+export const StacVersion = '1.0.0-beta.2';
 export const StacLicense = 'CC-BY-4.0';
+export const StacBaseMapsExtension =
+    'https://basemaps.linz.govt.nz/json-schema/stac-basemaps-extension/1.0/schema.json';
 
 export interface StacLink {
     rel: string;
@@ -19,7 +21,7 @@ export interface StacAsset {
 export interface StacProvider {
     name: string;
     roles: string[];
-    url: string;
+    url?: string;
 }
 
 export interface StacObject {
@@ -35,13 +37,13 @@ export interface StacObject {
 
 export interface StacCollection<S = Record<string, any>> extends StacObject {
     title: string;
-    description?: string;
+    description: string;
 
     license: string;
 
     extent: {
         spatial: {
-            bbox: [number, number, number, number];
+            bbox: [number, number, number, number][];
         };
         temporal?: {
             interval: [string, string][];


### PR DESCRIPTION
* Add linz basemaps schema.json
* Fix `extent/spatial/bbox` to `number[][]`
* `description` is always required
* Set `stac_version` to `1.0.0-beta.2`
* Don't use `projection` extension for `collection.json`
