### PR TITLE
fix(lambda-tiler): regression in invalid url parsing causing 500 Error

### DIFF
--- a/packages/shared/src/__test__/api.path.test.ts
+++ b/packages/shared/src/__test__/api.path.test.ts
@@ -1,0 +1,43 @@
+import { Epsg } from '@basemaps/geo';
+import { ImageFormat } from '@basemaps/tiler';
+import o from 'ospec';
+import { tileAttributionFromPath, TileType, tileWmtsFromPath, tileXyzFromPath } from '../api.path';
+
+o.spec('api.path', () => {
+    o('tileXyzFromPath', () => {
+        o(tileXyzFromPath(['aerial', 'EPSG:3857', '10', '3456', '5432.webp'])).deepEquals({
+            type: TileType.Image,
+            name: 'aerial',
+            projection: Epsg.Google,
+            x: 3456,
+            y: 5432,
+            z: 10,
+            ext: ImageFormat.WEBP,
+        });
+        o(tileXyzFromPath([])).equals(null);
+        o(tileXyzFromPath(['aerial', 'EPSG:3857', '10', '3456'])).equals(null);
+    });
+
+    o('tileWmtsFromPath', () => {
+        o(tileWmtsFromPath(['aerial', 'EPSG:3857', 'WMTSCapabilities.xml'])).deepEquals({
+            type: TileType.WMTS,
+            name: 'aerial',
+            projection: Epsg.Google,
+        });
+        o(tileWmtsFromPath([])).deepEquals({
+            type: TileType.WMTS,
+            name: '',
+            projection: null,
+        });
+    });
+
+    o('tileAttributionFromPath', () => {
+        o(tileAttributionFromPath(['aerial', 'EPSG:3857', 'attribution.json'])).deepEquals({
+            type: TileType.Attribution,
+            name: 'aerial',
+            projection: Epsg.Google,
+        });
+        o(tileAttributionFromPath([])).equals(null);
+        o(tileAttributionFromPath(['aerial', 'attribution.json'])).equals(null);
+    });
+});

--- a/packages/shared/src/api.path.ts
+++ b/packages/shared/src/api.path.ts
@@ -50,6 +50,7 @@ function parseTargetEpsg(text: string): Epsg | null {
 }
 
 export function tileXyzFromPath(path: string[]): TileDataXyz | null {
+    if (path.length < 5) return null;
     const name = path[0];
     const projection = parseTargetEpsg(path[1]);
     if (projection == null) return null;
@@ -88,7 +89,7 @@ export function tileAttributionFromPath(path: string[]): TileDataAttribution | n
 export function tileWmtsFromPath(path: string[]): TileDataWmts | null {
     if (path.length > 3) return null;
 
-    const name = path.length == 1 ? '' : path[0];
+    const name = path.length < 2 ? '' : path[0];
     let projection = null;
     if (path.length == 3) {
         projection = parseTargetEpsg(path[1]);


### PR DESCRIPTION
`tileXyzFromPath` was not checking that the number of parts to the url was at least 5 causing index
lookups past the end of the array.

