### PR TITLE
fix: Remove dashes from CC-BY-4.0 license text

### DIFF
--- a/packages/bathymetry/src/__test__/stac.test.ts
+++ b/packages/bathymetry/src/__test__/stac.test.ts
@@ -1,5 +1,5 @@
 import { GoogleTms } from '@basemaps/geo/build/tms/google';
-import { LogConfig, LogType, StacCollection, StacBaseMapsExtension, StacVersion } from '@basemaps/shared';
+import { LogConfig, LogType, StacCollection, StacBaseMapsExtension, StacVersion, StacLicense } from '@basemaps/shared';
 import { mockFileOperator } from '@basemaps/shared/build/file/__test__/file.operator.test.helper';
 import { round } from '@basemaps/test/build/rounding';
 import o from 'ospec';
@@ -113,7 +113,7 @@ o.spec('stac', () => {
                         interval: [['2020-01-01T00:00:00Z', '2021-01-01T00:00:00Z']],
                     },
                 },
-                license: 'CC-BY-4.0',
+                license: StacLicense,
                 links: stac.links,
                 providers: [
                     {
@@ -158,7 +158,7 @@ o.spec('stac', () => {
                     spatial: { bbox: [[-179.0332, 84.9205, -178.9893, 84.9244]] },
                     temporal: { interval: [['2020-01-01T00:00:00Z', '2020-10-12T01:02:03Z']] },
                 },
-                license: 'CC-BY-4.0',
+                license: StacLicense,
                 links: [
                     {
                         rel: 'self',

--- a/packages/cli/src/cog/__test__/cog.stac.job.test.ts
+++ b/packages/cli/src/cog/__test__/cog.stac.job.test.ts
@@ -1,5 +1,5 @@
 import { Bounds, EpsgCode } from '@basemaps/geo';
-import { ProjectionTileMatrixSet, StacBaseMapsExtension, StacVersion } from '@basemaps/shared';
+import { ProjectionTileMatrixSet, StacBaseMapsExtension, StacLicense, StacVersion } from '@basemaps/shared';
 import { mockFileOperator } from '@basemaps/shared/build/file/__test__/file.operator.test.helper';
 import { round } from '@basemaps/test/build/rounding';
 import { Ring } from '@linzjs/geojson';
@@ -186,7 +186,7 @@ o.spec('CogJob', () => {
                     spatial: { bbox: [[169.3341, -51.8754, -146.1432, -32.8952]] },
                     temporal: { interval: [['2010-01-01T00:00:00Z', '2011-01-01T00:00:00Z']] },
                 },
-                license: 'CC-BY-4.0',
+                license: StacLicense,
                 keywords: ['Imagery', 'New Zealand'],
                 providers: [],
                 summaries: {

--- a/packages/lambda-tiler/src/routes/__test__/attribution.test.ts
+++ b/packages/lambda-tiler/src/routes/__test__/attribution.test.ts
@@ -257,7 +257,7 @@ o.spec('attribution', () => {
                 collections: [
                     {
                         stac_version: '1.0.0-beta.2',
-                        license: 'CC-BY-4.0',
+                        license: 'CC BY 4.0',
                         id: 'ir_ir_1',
                         providers: [{ name: 'p1' }],
                         title: 'image one',
@@ -277,7 +277,7 @@ o.spec('attribution', () => {
                     },
                     {
                         stac_version: '1.0.0-beta.2',
-                        license: 'CC-BY-4.0',
+                        license: StacLicense,
                         id: 'ir_ir_2',
                         providers: [
                             {
@@ -303,7 +303,7 @@ o.spec('attribution', () => {
                     },
                     {
                         stac_version: '1.0.0-beta.2',
-                        license: 'CC-BY-4.0',
+                        license: StacLicense,
                         id: 'ir_ir_3',
                         providers: [
                             {
@@ -329,7 +329,7 @@ o.spec('attribution', () => {
                     },
                     {
                         stac_version: '1.0.0-beta.2',
-                        license: 'CC-BY-4.0',
+                        license: StacLicense,
                         id: 'ir_ir_4',
                         providers: [{ name: 'p1' }],
                         title: 'image one',

--- a/packages/shared/src/stac/index.ts
+++ b/packages/shared/src/stac/index.ts
@@ -1,5 +1,5 @@
 export const StacVersion = '1.0.0-beta.2';
-export const StacLicense = 'CC-BY-4.0';
+export const StacLicense = 'CC BY 4.0';
 export const StacBaseMapsExtension =
     'https://basemaps.linz.govt.nz/json-schema/stac-basemaps-extension/1.0/schema.json';
 


### PR DESCRIPTION
Now reads "CC BY 4.0"

