### PR TITLE
fix(landing) Deploy mime type wrong

### DIFF
--- a/packages/landing/static/examples/index.html
+++ b/packages/landing/static/examples/index.html
@@ -2,21 +2,21 @@
 <html lang="en">
 
   <head>
-    <link rel="icon" type="image/png" sizes="32x32" href="../favicon-32x32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="../favicon-16x16.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <title>Basemaps Examples | Land Information New Zealand (LINZ)</title>
   </head>
 
   <body>
-    <h1>Examples of accessing basemaps from the browser</h1>
+    <h1>Examples of accessing basemaps from a browser</h1>
     <p id="noApiKey" style="display:none">
-      Please first visit <a href="/" >basemaps</a> to be automatically allocated an 90 day API key.
+      Please first visit <a href="/" >basemaps</a> to be automatically allocated a 90 day API key.
     </p>
     <ul>
-      <li><a href="examples/index.leaflet.xyz.3857.html">index.leaflet.xyz.3857.html</a></li>
-      <li><a href="examples/index.openlayers.attribution.wmts.3857.html">index.openlayers.attribution.wmts.3857.html</a></li>
-      <li><a href="examples/index.openlayers.wmts.3857.html">index.openlayers.wmts.3857.html</a></li>
-      <li><a href="examples/index.openlayers.xyz.3857.html">index.openlayers.xyz.3857.html</a></li>
+      <li><a href="/examples/index.leaflet.xyz.3857.html">index.leaflet.xyz.3857.html</a></li>
+      <li><a href="/examples/index.openlayers.attribution.wmts.3857.html">index.openlayers.attribution.wmts.3857.html</a></li>
+      <li><a href="/examples/index.openlayers.wmts.3857.html">index.openlayers.wmts.3857.html</a></li>
+      <li><a href="/examples/index.openlayers.xyz.3857.html">index.openlayers.xyz.3857.html</a></li>
     </ul>
     <p>
       Source code available at <a href="https://github.com/linz/basemaps">https://github.com/linz/basemaps</a>

--- a/packages/linzjs-geojson/src/multipolygon/convert.ts
+++ b/packages/linzjs-geojson/src/multipolygon/convert.ts
@@ -83,7 +83,7 @@ export function multiPolygonToWgs84(multipoly: MultiPolygon, toWgs84: ConvertCoo
                         }
                     }
                     if (lineCrosses) {
-                        // insert an point on the AM which approximates a straight line in
+                        // insert a point on the AM which approximates a straight line in
                         // source coordinates.
                         const frac = (180 - wPoint[0]) / (wPrev[0] - wPoint[0]);
                         const midPoint = toWgs84(pointAtFrac(frac, sPoint, sPrev));


### PR DESCRIPTION
When deploying changed files the logic to determine the mime-type was returning the wrong
type. Fixed by passing the file extension instead of whole path.

Also deploy `examples/index.html` as `examples` and `examples/` because Cloudfront doesn't handle `index.html`
files in sub directories.


