### PR TITLE
feat(cli): Configure TileSet metedata DB from config file

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -44,7 +44,8 @@
     "@rushstack/ts-command-line": "^4.3.13",
     "ansi-colors": "^4.1.1",
     "p-limit": "^3.0.1",
-    "pretty-json-log": "^0.3.1"
+    "pretty-json-log": "^0.3.1",
+    "zod": "^1.10.1"
   },
   "devDependencies": {
     "@types/geojson": "^7946.0.7",

--- a/packages/cli/src/cli/basemaps/README.md
+++ b/packages/cli/src/cli/basemaps/README.md
@@ -59,11 +59,49 @@ v0  	2020-04-29T00:32:46.514Z                	production
 ...
 ```
 
+## Export
+
+The metadata database can be exported to a JSON file for a specific name and projection that match the state of a tag. Its format is simplified for easier updating by hand any changes that are needed. Defaults can be supplied via `--defaults` which further simplifies the output; defaults are included in the output.
+
+```sh
+# Create config for current state of production tag for aerial/3857
+./basemaps export -n aerial -p 3857 -t production --defaults path/to/defaults-config.json -o path/to/imagery-config.json
+```
+
+### Defaults config
+
+A Defaults config format is an array of values for `priority`, `minZoom` and `maxZoom`. A default is applied if the image name contains the text in the `nameContains` field or there is no `nameContains` field.
+
+```json
+[
+  {
+    "nameContains": "_urban_",
+    "priority": 3000, "minZoom": 14
+  },
+  {
+    "nameContains": "_rural_",
+    "priority": 2000, "minZoom": 13
+  },
+  {
+    "priority": 1000, "minZoom": 0, "maxZoom": 32
+  }
+]
+```
+
+## Import
+
+The metadata database can be reconfigured using a config file like the one created from export (above). Only the changes needed to reconcile the metadata database to match the config file for a given tag will be made. It will also invalidate the relevant paths in cloudfront.
+
+```sh
+# Reconcile config with the current state of production tag
+./basemaps import -t production -c path/to/imagery-config.json --commit
+```
+
 ## Tag
 
 To change the version a tag is using
 
-```
+```sh
 # Update tag production to v3
 
 ./basemaps tag -n aerial -p 3857 -t production -v 3 --commit
@@ -73,7 +111,7 @@ To change the version a tag is using
 
 The update command can be used to configure the rendering of a tile set, each time the `--commit` is used a new version is created and the `head` tag is updated to point at it.
 
-```
+```sh
 # Make gebco priority 2
 ./basemaps update -n aerial -p 3857 -i im_01DYE4EGR92TNMV16AHXSR45JH --priority 2 --commit
 

--- a/packages/cli/src/cli/basemaps/__test__/test.update.test.ts
+++ b/packages/cli/src/cli/basemaps/__test__/test.update.test.ts
@@ -1,6 +1,7 @@
+import { Aws, LogConfig, TileMetadataImageRule, TileMetadataSetRecord } from '@basemaps/shared';
 import o from 'ospec';
-import { TileSetUpdateAction, parseRgba } from '../action.tileset.update';
-import { TileMetadataSetRecord, LogConfig, Aws, TileMetadataImageRule } from '@basemaps/shared';
+import { TileSetUpdateAction } from '../action.tileset.update';
+import { parseRgba } from '../tileset.util';
 
 function fakeTileSet(): TileMetadataSetRecord {
     Aws.tileMetadata.Imagery.imagery.set('im_0', { name: '0', id: 'im_0' } as any);
@@ -170,11 +171,14 @@ o.spec('TileSetUpdateAction', () => {
         });
 
         o('should support smaller hex strings', () => {
-            o(parseRgba('0x')).deepEquals({ r: 0, g: 0, b: 0, alpha: 0 });
-            o(parseRgba('0xff')).deepEquals({ r: 255, g: 0, b: 0, alpha: 0 });
-            o(parseRgba('0xffff')).deepEquals({ r: 255, g: 255, b: 0, alpha: 0 });
             o(parseRgba('0xffffff')).deepEquals({ r: 255, g: 255, b: 255, alpha: 0 });
             o(parseRgba('0xffffffff')).deepEquals({ r: 255, g: 255, b: 255, alpha: 255 });
+        });
+
+        o('should throw if hex string invalid', () => {
+            o(() => parseRgba('0x')).throws(Error);
+            o(() => parseRgba('0xff')).throws(Error);
+            o(() => parseRgba('0xffff')).throws(Error);
         });
 
         o('should support all hex', () => {

--- a/packages/cli/src/cli/basemaps/__test__/tileset.config.test.ts
+++ b/packages/cli/src/cli/basemaps/__test__/tileset.config.test.ts
@@ -1,0 +1,226 @@
+import o from 'ospec';
+import { addDefaults, assertTileSetConfig, ImageryDefaultConfig, removeDefaults } from '../tileset.config';
+
+o.spec('imagery.config', () => {
+    const image1 = {
+        id: 'abc123',
+        name: 'tileset_1_2019-2020_0.05m',
+        priority: 2000,
+        minZoom: 13,
+        maxZoom: 32,
+    };
+
+    const tileset3857 = {
+        name: 'aerial',
+        projection: 3857,
+        background: '000000ff',
+        imagery: [image1],
+    };
+
+    o.spec('addDefaults', () => {
+        o('no defaults', () => {
+            o(
+                addDefaults([], {
+                    id: '01ED81CFNWK9R75S0277SW972N',
+                    name: 'auckland_urban_2015-16_0-075m',
+                }),
+            ).deepEquals({
+                id: '01ED81CFNWK9R75S0277SW972N',
+                name: 'auckland_urban_2015-16_0-075m',
+                priority: 1000,
+                minZoom: 0,
+                maxZoom: 32,
+            });
+        });
+
+        o('invalid result', () => {
+            try {
+                addDefaults([{ minZoom: 12 }], {
+                    id: '01ED81CFNWK9R75S0277SW972N',
+                    name: 'auckland_urban_2015-16_0-075m',
+                    maxZoom: 10,
+                });
+                o('should throw').equals('did not throw');
+            } catch (err) {
+                const err0 = err.errors[0];
+                o(err0.code).equals('custom_error');
+                o(err0.path).deepEquals(['minZoom']);
+                o(err0.message).equals('minZoom may no be greater than maxZoom');
+            }
+        });
+
+        o('no condition', () => {
+            const defaults: ImageryDefaultConfig[] = [
+                {
+                    priority: 3000,
+                    minZoom: 14,
+                    maxZoom: 32,
+                },
+            ];
+            o(
+                addDefaults(defaults, {
+                    id: '01ED81CFNWK9R75S0277SW972N',
+                    name: 'auckland_urban_2015-16_0-075m',
+                }),
+            ).deepEquals({
+                id: '01ED81CFNWK9R75S0277SW972N',
+                name: 'auckland_urban_2015-16_0-075m',
+                priority: 3000,
+                minZoom: 14,
+                maxZoom: 32,
+            });
+        });
+
+        o('nameContains', () => {
+            const defaults: ImageryDefaultConfig[] = [
+                { nameContains: '_rural_', priority: 2000, minZoom: 11 },
+                { nameContains: '_urban_', minZoom: 12 },
+                {
+                    minZoom: 1,
+                    maxZoom: 30,
+                },
+            ];
+            o(
+                addDefaults(defaults, {
+                    id: '01ED81CFNWK9R75S0277SW972N',
+                    name: 'auckland_urban_2015-16_0-075m',
+                }),
+            ).deepEquals({
+                id: '01ED81CFNWK9R75S0277SW972N',
+                name: 'auckland_urban_2015-16_0-075m',
+                priority: 1000,
+                minZoom: 12,
+                maxZoom: 30,
+            });
+        });
+    });
+
+    o.spec('removeDefaults', () => {
+        o('no defaults', () => {
+            o(
+                removeDefaults([], {
+                    id: '01ED81CFNWK9R75S0277SW972N',
+                    name: 'auckland_urban_2015-16_0-075m',
+                    priority: 1000,
+                    minZoom: 0,
+                    maxZoom: 32,
+                }),
+            ).deepEquals({
+                id: '01ED81CFNWK9R75S0277SW972N',
+                name: 'auckland_urban_2015-16_0-075m',
+                priority: 1000,
+                minZoom: 0,
+                maxZoom: 32,
+            });
+        });
+
+        o('no condition', () => {
+            const defaults: ImageryDefaultConfig[] = [
+                {
+                    priority: 3000,
+                    minZoom: 14,
+                    maxZoom: 32,
+                },
+            ];
+            o(
+                removeDefaults(defaults, {
+                    id: '01ED81CFNWK9R75S0277SW972N',
+                    name: 'auckland_urban_2015-16_0-075m',
+                    priority: 3000,
+                    minZoom: 14,
+                    maxZoom: 32,
+                }),
+            ).deepEquals({
+                id: '01ED81CFNWK9R75S0277SW972N',
+                name: 'auckland_urban_2015-16_0-075m',
+            });
+        });
+
+        o('nameContains', () => {
+            const defaults: ImageryDefaultConfig[] = [
+                { nameContains: '_rural_', priority: 2000, minZoom: 11 },
+                { nameContains: '_urban_', minZoom: 12 },
+                {
+                    minZoom: 1,
+                    maxZoom: 30,
+                },
+            ];
+            o(
+                removeDefaults(defaults, {
+                    id: '01ED81CFNWK9R75S0277SW972N',
+                    name: 'auckland_urban_2015-16_0-075m',
+                    priority: 1000,
+                    minZoom: 12,
+                    maxZoom: 30,
+                }),
+            ).deepEquals({
+                id: '01ED81CFNWK9R75S0277SW972N',
+                name: 'auckland_urban_2015-16_0-075m',
+                priority: 1000,
+            });
+        });
+    });
+
+    o.spec('assertValid', () => {
+        o('empty', () => {
+            const x = { name: 'aerial', projection: 3857, background: '11223344', imagery: [] } as unknown;
+            assertTileSetConfig(x);
+
+            o(x.imagery).deepEquals([]);
+        });
+
+        o('full', () => {
+            const x = { ...tileset3857 } as unknown;
+            assertTileSetConfig(x);
+        });
+
+        o('invalid schema', () => {
+            try {
+                assertTileSetConfig({ name: [] });
+                o('no throw').equals('throw');
+            } catch (err) {
+                o(err.errors[0].code).equals('invalid_type');
+            }
+        });
+
+        o('invalid priority', () => {
+            const badTileset = { ...tileset3857, imagery: [{ ...image1, priority: -2 }] };
+            try {
+                assertTileSetConfig(badTileset);
+                o('no throw').equals('throw');
+            } catch (err) {
+                const err0 = err.errors[0];
+                o(err0.code).equals('custom_error');
+                o(err0.path).deepEquals(['imagery', 0, 'priority']);
+                o(err0.message).equals('must be between -1 and 10000');
+            }
+        });
+
+        o('invalid zoom', () => {
+            const badTileset = { ...tileset3857, imagery: [{ ...image1, minZoom: 5, maxZoom: -1 }] };
+            try {
+                assertTileSetConfig(badTileset);
+                o('no throw').equals('throw');
+            } catch (err) {
+                o(err.errors[0].message).equals('must be between 0 and 32');
+                const err1 = err.errors[1];
+                o(err1.code).equals('custom_error');
+                o(err1.path).deepEquals(['imagery', 0, 'minZoom']);
+                o(err1.message).equals('minZoom may no be greater than maxZoom');
+            }
+        });
+
+        o('invalid background', () => {
+            const badTileset = { ...tileset3857, background: '112233yy' };
+            try {
+                assertTileSetConfig(badTileset);
+                o('no throw').equals('throw');
+            } catch (err) {
+                const err0 = err.errors[0];
+                o(err0.code).equals('custom_error');
+                o(err0.path).deepEquals(['background']);
+                o(err0.message).equals('Invalid hex color');
+            }
+        });
+    });
+});

--- a/packages/cli/src/cli/basemaps/__test__/tileset.updater.test.ts
+++ b/packages/cli/src/cli/basemaps/__test__/tileset.updater.test.ts
@@ -1,0 +1,182 @@
+import { Epsg, EpsgCode } from '@basemaps/geo';
+import { Aws, TileMetadataImageRule, TileMetadataNamedTag, TileMetadataTag } from '@basemaps/shared';
+import o from 'ospec';
+import { ProjectionConfig } from '../tileset.config';
+import { TileSetUpdater } from '../tileset.updater';
+import { parseRgba } from '../tileset.util';
+
+o.spec('tileset.updater', () => {
+    o.spec('new', () => {
+        o('bad config', () => {
+            try {
+                new TileSetUpdater({}, TileMetadataNamedTag.Head);
+                o('did not throw').equals('throw');
+            } catch (err) {
+                o(err.errors.length).notEquals(0);
+            }
+        });
+    });
+
+    o.spec('reconcile', () => {
+        const origTileMetadata = Aws.tileMetadata;
+        const background = 'e1e2e3e4';
+        const tileSet1 = {
+            id: 'abc123',
+            name: 'tileset_1_2019-2020_0.05m',
+            priority: 2000,
+            minZoom: 13,
+            maxZoom: 32,
+        };
+        const config: ProjectionConfig = {
+            name: 'aerial',
+            projection: EpsgCode.Google,
+            background: background,
+            imagery: [tileSet1],
+        };
+
+        const metadata = {
+            batchGet: () => new Map(),
+        } as any;
+
+        const rec1: TileMetadataImageRule = {
+            imgId: 'im_abc123',
+            ruleId: 'ir_abc1231',
+            priority: 2000,
+            minZoom: 13,
+            maxZoom: 32,
+        };
+
+        const origRecords = {
+            head: {
+                id: 'ts_abc123_head',
+                v: 2,
+                version: 20,
+                background: parseRgba(background),
+                projection: EpsgCode.Google,
+                rules: [rec1],
+            },
+            production: {
+                id: 'ts_abc123_production',
+                v: 2,
+                version: 20,
+                background: parseRgba(background),
+                projection: EpsgCode.Google,
+                rules: [rec1],
+            },
+        };
+
+        let records = { ...origRecords };
+
+        const TileSet = {
+            get: (name: string, proj: Epsg, tag: TileMetadataTag): any => {
+                if (name !== 'aerial' || proj !== Epsg.Google) {
+                    throw new Error('invalid args!');
+                }
+                return (records as any)[tag];
+            },
+        };
+
+        o.before(() => {
+            Aws.tileMetadata = metadata;
+        });
+
+        o.after(() => {
+            Aws.tileMetadata = origTileMetadata;
+        });
+
+        o.afterEach(() => {
+            records = { ...origRecords };
+        });
+
+        o('no change', async () => {
+            metadata.TileSet = { ...TileSet };
+            const updater = new TileSetUpdater(config, TileMetadataNamedTag.Production);
+
+            const changes = await updater.reconcile(false);
+            o(changes).deepEquals({ changes: null, imagery: changes.imagery });
+            o(changes.imagery.size).equals(0);
+        });
+
+        o('tagging production not head', async () => {
+            records.head.version = 24;
+            records.head.rules[0] = { ...rec1, minZoom: 12 };
+            records.production.rules[0] = { ...rec1, minZoom: 14 };
+
+            const tag = o.spy();
+            const create = o.spy((rec: any): any => ({ ...rec, id: 'new_id', version: 25 }));
+            metadata.TileSet = { ...TileSet, create, tag };
+            const updater = new TileSetUpdater(config, TileMetadataNamedTag.Production);
+
+            const changes = await updater.reconcile(true);
+
+            o(create.callCount).equals(1);
+            o(tag.callCount).equals(1);
+
+            o(tag.args).deepEquals(['aerial', Epsg.Google, TileMetadataNamedTag.Production, 25]);
+
+            o(changes.changes!.after.rules).deepEquals([
+                {
+                    imgId: 'im_abc123',
+                    ruleId: 'ir_abc1231',
+                    priority: 2000,
+                    minZoom: 13,
+                    maxZoom: 32,
+                },
+            ]);
+        });
+
+        o('tagging production is head', async () => {
+            records.head.version = 24;
+            records.head.rules[0] = { ...rec1, minZoom: 14 };
+            records.production.version = 24;
+            records.production.rules[0] = { ...rec1, minZoom: 14 };
+
+            const tag = o.spy();
+            const create = o.spy((rec: any): any => ({ ...rec, id: 'new_id', version: 25 }));
+            metadata.TileSet = { ...TileSet, create, tag };
+            const updater = new TileSetUpdater(config, TileMetadataNamedTag.Production);
+
+            const changes = await updater.reconcile(true);
+
+            o(create.callCount).equals(1);
+            o(tag.callCount).equals(1);
+
+            o(tag.args).deepEquals(['aerial', Epsg.Google, TileMetadataNamedTag.Production, 25]);
+
+            o(changes.changes!.after.rules).deepEquals([
+                {
+                    imgId: 'im_abc123',
+                    ruleId: 'ir_abc1231',
+                    priority: 2000,
+                    minZoom: 13,
+                    maxZoom: 32,
+                },
+            ]);
+        });
+
+        o('tag new pr', async () => {
+            records.head.version = 24;
+            records.head.rules[0] = { ...rec1, minZoom: 14 };
+
+            const tag = o.spy();
+            const create = o.spy((rec: any): any => ({ ...rec, id: 'new_id', version: 25 }));
+            metadata.TileSet = { ...TileSet, create, tag, initialRecord: origTileMetadata.TileSet.initialRecord };
+            const updater = new TileSetUpdater(config, 'pr-123');
+
+            const changes = await updater.reconcile(true);
+
+            o(create.callCount).equals(1);
+            o(tag.callCount).equals(0);
+
+            o(changes.changes!.after.rules).deepEquals([
+                {
+                    imgId: 'im_abc123',
+                    ruleId: 'ir_abc1231',
+                    priority: 2000,
+                    minZoom: 13,
+                    maxZoom: 32,
+                },
+            ]);
+        });
+    });
+});

--- a/packages/cli/src/cli/basemaps/action.export.ts
+++ b/packages/cli/src/cli/basemaps/action.export.ts
@@ -1,0 +1,122 @@
+import { Epsg } from '@basemaps/geo';
+import {
+    Aws,
+    DefaultBackground,
+    LogConfig,
+    parseMetadataTag,
+    RecordPrefix,
+    TileMetadataTable,
+    TileMetadataTag,
+} from '@basemaps/shared';
+import { CommandLineStringParameter } from '@rushstack/ts-command-line';
+import { promises as fs } from 'fs';
+import { TileSetBaseAction } from './tileset.action';
+import {
+    compareNamePriority,
+    FullImageryConfig,
+    ImageryDefaultConfig,
+    ProjectionConfig,
+    removeDefaults,
+} from './tileset.config';
+import { defineTagParameter, primeImageryCache, rgbaToHex } from './tileset.util';
+
+/**
+ * Convert all the tilesets in the TileMetadataTable to a TileSetConfig. The Head and Production
+ * rules tags are converted to one record. If a production rule differs from the head then the rule
+ * is marked as non-production.
+
+ * @param table
+ */
+async function tilesetToConfig(
+    name: string,
+    projection: Epsg,
+    tag: TileMetadataTag,
+    defaults: ImageryDefaultConfig[] = [],
+): Promise<ProjectionConfig> {
+    const item = await Aws.tileMetadata.TileSet.get(name, projection, tag);
+
+    const imageryMap = await primeImageryCache(new Set(item.rules.map((r) => r.imgId)));
+
+    const imagery = item.rules
+        .map(
+            (rule): FullImageryConfig => {
+                const image = imageryMap.get(rule.imgId);
+                if (image == null) {
+                    throw new Error(`Can't find imagery record "${rule.imgId}" for Tileset "${item.id}"`);
+                }
+                return {
+                    id: TileMetadataTable.unprefix(RecordPrefix.Imagery, rule.imgId),
+                    name: image.name,
+                    priority: rule.priority,
+                    minZoom: rule.minZoom,
+                    maxZoom: rule.maxZoom,
+                };
+            },
+        )
+        .sort(compareNamePriority)
+        .map((r) => removeDefaults(defaults, r));
+
+    return {
+        name,
+        projection: projection.code,
+        background: rgbaToHex(item.background ?? DefaultBackground),
+        defaults,
+        imagery,
+    };
+}
+
+export class ExportAction extends TileSetBaseAction {
+    private output: CommandLineStringParameter;
+    private defaults: CommandLineStringParameter;
+    private tag: CommandLineStringParameter;
+
+    public constructor() {
+        super({
+            actionName: 'export',
+            summary: 'Export imagery and tileset rules',
+            documentation: '',
+        });
+    }
+
+    protected onDefineParameters(): void {
+        super.onDefineParameters();
+        this.output = this.defineStringParameter({
+            argumentName: 'JSON_FILE',
+            parameterLongName: '--output',
+            parameterShortName: '-o',
+            description: 'File to output to',
+            required: true,
+        });
+        this.defaults = this.defineStringParameter({
+            argumentName: 'JSON_FILE',
+            parameterLongName: '--defaults',
+            description:
+                'Config File containing rule defaults. This is added to the output and used to minimize the rule fields.',
+            required: false,
+        });
+        defineTagParameter(this);
+    }
+
+    protected async onExecute(): Promise<void> {
+        const outFile = this.output.value!;
+
+        const tileSet = this.tileSet.value!;
+        const projection = Epsg.get(this.projection.value!);
+        const tagInput = this.tag.value!;
+
+        const tag = parseMetadataTag(tagInput);
+        if (tag == null) {
+            LogConfig.get().fatal({ tag }, 'Invalid tag name');
+            console.log(this.renderHelpText());
+            return;
+        }
+
+        const defaults = this.defaults.value
+            ? JSON.parse((await fs.readFile(this.defaults.value)).toString())
+            : undefined;
+
+        const output = JSON.stringify(await tilesetToConfig(tileSet, projection, tag, defaults), undefined, 2);
+
+        await fs.writeFile(outFile, output, { flag: 'wx' });
+    }
+}

--- a/packages/cli/src/cli/basemaps/action.tileset.history.ts
+++ b/packages/cli/src/cli/basemaps/action.tileset.history.ts
@@ -1,6 +1,13 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { Epsg } from '@basemaps/geo';
-import { Aws, LogConfig, TileMetadataImageryRecord, TileMetadataSetRecord, TileMetadataTag } from '@basemaps/shared';
+import {
+    Aws,
+    LogConfig,
+    TileMetadataImageryRecord,
+    TileMetadataNamedTag,
+    TileMetadataSetRecord,
+    TileMetadataTag,
+} from '@basemaps/shared';
 import { CliTable } from '../cli.table';
 import { TileSetBaseAction } from './tileset.action';
 import { printTileSet, showDiff } from './tileset.util';
@@ -21,7 +28,7 @@ export class TileSetHistoryAction extends TileSetBaseAction {
         const projection = Epsg.get(this.projection.value ?? -1);
         const allTags: Map<TileMetadataTag, TileMetadataSetRecord> = new Map();
         await Promise.all(
-            Object.values(TileMetadataTag).map(async (tag) => {
+            Object.values(TileMetadataNamedTag).map(async (tag) => {
                 try {
                     const value = await Aws.tileMetadata.TileSet.get(tileSet, projection, tag);
                     allTags.set(tag, value);
@@ -38,7 +45,7 @@ export class TileSetHistoryAction extends TileSetBaseAction {
 
         const allTags = await this.getAllTags();
 
-        const tsData = allTags.get(TileMetadataTag.Head);
+        const tsData = allTags.get(TileMetadataNamedTag.Head);
         if (tsData == null) throw new Error('Unable to find tag: head');
 
         printTileSet(tsData, false);
@@ -52,7 +59,7 @@ export class TileSetHistoryAction extends TileSetBaseAction {
         }
 
         function getTagsForVersion(version: number): string {
-            return Object.values(TileMetadataTag)
+            return Object.values(TileMetadataNamedTag)
                 .filter((c) => allTags.get(c)?.version == version)
                 .join(', ');
         }

--- a/packages/cli/src/cli/basemaps/action.tileset.info.ts
+++ b/packages/cli/src/cli/basemaps/action.tileset.info.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { Epsg } from '@basemaps/geo';
-import { Aws, LogConfig, TileMetadataTag } from '@basemaps/shared';
+import { Aws, LogConfig, TileMetadataNamedTag } from '@basemaps/shared';
 import { CommandLineIntegerParameter, CommandLineStringParameter } from '@rushstack/ts-command-line';
 import * as c from 'ansi-colors';
 import { TileSetBaseAction } from './tileset.action';
@@ -65,7 +65,7 @@ export class TileSetInfoAction extends TileSetBaseAction {
         const tsData = await Aws.tileMetadata.TileSet.get(
             tileSet,
             projection,
-            this.version.value! ?? TileMetadataTag.Head,
+            this.version.value! ?? TileMetadataNamedTag.Head,
         );
 
         if (tsData == null) {

--- a/packages/cli/src/cli/basemaps/index.ts
+++ b/packages/cli/src/cli/basemaps/index.ts
@@ -3,7 +3,8 @@ import 'source-map-support/register';
 import { BaseCommandLine } from '../base.cli';
 import { TileSetUpdateAction } from './action.tileset.update';
 import { TileSetInfoAction } from './action.tileset.info';
-import { ImageryImportAction } from './action.imagery.import';
+import { ImportAction } from './action.import';
+import { ExportAction } from './action.export';
 import { TileSetUpdateTagAction } from './action.tileset.tag';
 import { TileSetHistoryAction } from './action.tileset.history';
 import { PrettyTransform } from 'pretty-json-log';
@@ -17,7 +18,8 @@ export class BasemapsCommandLine extends BaseCommandLine {
         });
         this.addAction(new TileSetInfoAction());
         this.addAction(new TileSetUpdateAction());
-        this.addAction(new ImageryImportAction());
+        this.addAction(new ImportAction());
+        this.addAction(new ExportAction());
         this.addAction(new TileSetUpdateTagAction());
         this.addAction(new TileSetHistoryAction());
 

--- a/packages/cli/src/cli/basemaps/tileset.config.ts
+++ b/packages/cli/src/cli/basemaps/tileset.config.ts
@@ -1,0 +1,154 @@
+import { EpsgCode } from '@basemaps/geo';
+import * as z from 'zod';
+import { parseRgba } from './tileset.util';
+
+export const ImageryConfigDefaults = {
+    priority: 1000,
+    minZoom: 0,
+    maxZoom: 32,
+};
+
+const zZoom = z.number().refine((val) => val >= ImageryConfigDefaults.minZoom && val <= ImageryConfigDefaults.maxZoom, {
+    message: `must be between ${ImageryConfigDefaults.minZoom} and ${ImageryConfigDefaults.maxZoom}`,
+});
+
+const zImageryRule = z
+    .object({
+        priority: z
+            .number()
+            .refine((val) => val >= -1 && val <= 10000, { message: 'must be between -1 and 10000' })
+            .optional(),
+        minZoom: zZoom.optional(),
+        maxZoom: zZoom.optional(),
+    })
+    .refine(
+        ({ minZoom, maxZoom }) =>
+            (minZoom ?? ImageryConfigDefaults.minZoom) <= (maxZoom ?? ImageryConfigDefaults.maxZoom),
+        {
+            message: 'minZoom may no be greater than maxZoom',
+            path: ['minZoom'],
+        },
+    );
+
+export type ImageryRule = z.infer<typeof zImageryRule>;
+
+const zImageryConfig = zImageryRule.extend({
+    id: z.string(),
+    name: z.string(),
+});
+
+const validateColor = (val: string): boolean => {
+    try {
+        parseRgba(val);
+        return true;
+    } catch (err) {
+        return false;
+    }
+};
+
+const zBackground = z.string().refine(validateColor, { message: 'Invalid hex color' });
+
+const zImageryDefaultConfig = zImageryRule.extend({
+    nameContains: z.string().optional(),
+});
+
+const zProjectionConfig = z.object({
+    name: z.string(),
+    projection: z.nativeEnum(EpsgCode),
+    title: z.string().optional(),
+    description: z.string().optional(),
+    background: zBackground,
+    defaults: z.array(zImageryDefaultConfig).optional(),
+    imagery: z.array(zImageryConfig),
+});
+
+/**
+ * The Configuration of one Imagery set
+ */
+export type ImageryConfig = z.infer<typeof zImageryConfig>;
+
+/**
+ *  The Configuration for all the imagery in a TileSet
+ */
+export type ProjectionConfig = z.infer<typeof zProjectionConfig>;
+
+export function assertTileSetConfig(json: any): asserts json is ProjectionConfig {
+    zProjectionConfig.parse(json);
+}
+
+export interface FullImageryConfig {
+    id: string;
+    name: string;
+    priority: number;
+    minZoom: number;
+    maxZoom: number;
+}
+
+export type ImageryDefaultConfig = z.infer<typeof zImageryDefaultConfig>;
+
+const defaultFields: Array<keyof ImageryRule> = ['priority', 'minZoom', 'maxZoom'];
+
+/**
+ * Use defaults to ensure all attributes are present for an imagery config rule.
+
+ * @param defaults an array of defaults to apply if the default `nameContains` matches the rule or
+ * no `nameContains` field is present. Applied in array order.
+
+ * @param rule the rule which may have missing fields
+ */
+export function addDefaults(defaults: ImageryDefaultConfig[], rule: ImageryConfig): FullImageryConfig {
+    const ans = { ...rule } as FullImageryConfig;
+
+    for (const def of defaults) {
+        if (def.nameContains != null) {
+            if (rule.name.indexOf(def.nameContains) == -1) continue;
+        }
+        for (const field of defaultFields) {
+            const value = def[field];
+            if (value != null) {
+                ans[field] ??= value;
+            }
+        }
+    }
+
+    ans.priority ??= ImageryConfigDefaults.priority;
+    ans.minZoom ??= ImageryConfigDefaults.minZoom;
+    ans.maxZoom ??= ImageryConfigDefaults.maxZoom;
+
+    zImageryConfig.parse(ans);
+    return ans as FullImageryConfig;
+}
+
+/**
+ * Use defaults to remove any derivable attributes in the rule. (see `addDefaults`)
+
+ * @param defaults
+ * @param rule
+ */
+export function removeDefaults(defaults: ImageryDefaultConfig[], rule: FullImageryConfig): ImageryConfig {
+    const removeFields = new Map<string, boolean>();
+    for (const def of defaults) {
+        if (def.nameContains != null && rule.name.indexOf(def.nameContains) == -1) continue;
+
+        for (const field of defaultFields) {
+            if (field in def) {
+                if (removeFields.has(field)) continue;
+
+                removeFields.set(field, def[field] == rule[field]);
+            }
+        }
+    }
+    const config: ImageryConfig = { id: rule.id, name: rule.name };
+
+    for (const field of defaultFields) {
+        if (!removeFields.get(field)) {
+            config[field] = rule[field];
+        }
+    }
+    return config;
+}
+
+export function compareNamePriority(a: FullImageryConfig, b: FullImageryConfig): number {
+    if (a.name === b.name) return b.priority - a.priority;
+    return a.name.localeCompare(b.name);
+}

--- a/packages/cli/src/cli/basemaps/tileset.updater.ts
+++ b/packages/cli/src/cli/basemaps/tileset.updater.ts
@@ -1,0 +1,274 @@
+import { Epsg } from '@basemaps/geo';
+import {
+    Aws,
+    DefaultBackground,
+    LogConfig,
+    RecordPrefix,
+    TileMetadataImageRule,
+    TileMetadataImageryRecord,
+    TileMetadataNamedTag,
+    TileMetadataSetRecord,
+    TileMetadataTable,
+    TileMetadataTag,
+} from '@basemaps/shared';
+import { deepStrictEqual } from 'assert';
+import { promises as fs } from 'fs';
+import { ulid } from 'ulid';
+import { addDefaults, assertTileSetConfig, FullImageryConfig, ProjectionConfig } from './tileset.config';
+import { invalidateXYZCache, parseRgba, primeImageryCache, rgbaToHex, showDiff } from './tileset.util';
+
+export interface TagChanges {
+    name: string;
+    projection: Epsg;
+    before: TileMetadataSetRecord;
+    after: TileMetadataSetRecord;
+}
+
+/**
+ * All the changes made by applying the TileSetConfig
+ */
+export interface TilesetChanges {
+    changes: TagChanges | null;
+    /** A mapping from an id to an imagery record */
+    imagery: Map<string, TileMetadataImageryRecord>;
+}
+
+function objectsDiffer(a: any, b: any): boolean {
+    try {
+        deepStrictEqual(a, b);
+        return false;
+    } catch (err) {}
+    return true;
+}
+
+interface ImgPriority {
+    imgId: string;
+    priority: number;
+}
+
+function compareImgIdPriority(a: ImgPriority, b: ImgPriority): number {
+    if (a.imgId === b.imgId) return b.priority - a.priority;
+    return a.imgId < b.imgId ? 1 : -1;
+}
+
+function compareIdPriority<T extends { id: string; priority: number }>(a: T, b: T): number {
+    if (a.id === b.id) return b.priority - a.priority;
+    return a.id < b.id ? 1 : -1;
+}
+
+function rulesToMap<T extends ImgPriority>(rules: T[]): Map<string, T[]> {
+    const ans = new Map<string, T[]>();
+    for (const rule of rules) {
+        const entry = ans.get(rule.imgId);
+        if (entry == null) {
+            ans.set(rule.imgId, [rule]);
+        } else {
+            entry.push(rule);
+        }
+    }
+    return ans;
+}
+
+/**
+ * Search for an existing matching rule (using imgId, priority). If not found; remove and return the first one.
+ */
+function findRule<T extends ImgPriority>(map: Map<string, T[]>, id: string, priority: number): T | null {
+    const rules = map.get(TileMetadataTable.prefix(RecordPrefix.Imagery, id));
+    if (rules == null) return null;
+    for (let i = 0; i < rules.length; ++i) {
+        if (rules[i].priority === priority) {
+            return rules.splice(i, 1)[0];
+        }
+    }
+    return rules.shift() ?? null;
+}
+
+async function showUpdateTag(
+    tag: TileMetadataTag,
+    changes: TagChanges,
+    imagery: Map<string, TileMetadataImageryRecord>,
+    isCommit: boolean,
+): Promise<string> {
+    let output = `\nChanges for ${tag} ${changes.name}/${changes.projection.toEpsgString()}:\n`;
+    const backgroundBefore = rgbaToHex(changes.before.background ?? DefaultBackground);
+    const backgroundAfter = rgbaToHex(changes.after.background ?? DefaultBackground);
+    if (backgroundBefore !== backgroundAfter) {
+        output += `\nBackground changed from '${backgroundBefore}' to '${backgroundAfter}'\n`;
+    }
+
+    output += showDiff(changes.after, changes.before, imagery);
+    await invalidateXYZCache(changes.name, changes.projection, tag, isCommit);
+    return output;
+}
+
+/**
+ * Update the Head and Production config (and tags) to match the config file, Invalidate cloudfront
+ *
+ * @param filename the config file to apply
+ * @param tag the tag to assign to the changes
+ * @param isCommit commit changes or just dry run
+ */
+export async function updateConfig(filename: string, tag: TileMetadataTag, isCommit = false): Promise<void> {
+    const configUpdater = new TileSetUpdater((await fs.readFile(filename)).toString(), tag);
+    const { changes, imagery } = await configUpdater.reconcile(isCommit);
+
+    if (changes == null) {
+        LogConfig.get().info('No Changes');
+    } else {
+        const output = await showUpdateTag(tag, changes, imagery, isCommit);
+        console.log(output);
+
+        if (isCommit) {
+            LogConfig.get().info('Changes committed');
+        } else {
+            LogConfig.get().warn('DryRun:Done');
+        }
+    }
+}
+
+export class TileSetUpdater {
+    config: ProjectionConfig;
+    tag: TileMetadataTag;
+    imagery: FullImageryConfig[];
+    projection: Epsg;
+    /**
+     * Class to apply an TileSetConfig source to the tile metadata db
+
+     * @param config a string or TileSetConfig to use
+     */
+    constructor(config: unknown, tag: TileMetadataTag) {
+        if (typeof config === 'string') {
+            config = JSON.parse(config);
+        }
+        assertTileSetConfig(config);
+        this.config = config;
+        this.tag = tag;
+        const defaults = this.config.defaults ?? [];
+        this.imagery = this.config.imagery.map((r) => addDefaults(defaults, r)).sort(compareIdPriority);
+        this.projection = Epsg.get(config.projection);
+    }
+
+    /**
+     * Reconcile the differences between the config and the tile metadata DB and tag the new version if changed.
+
+     * @param isCommit if true apply the differences to bring the DB in to line with the config file
+     */
+    async reconcile(isCommit = false): Promise<TilesetChanges> {
+        const imgIds = new Set<string>();
+
+        const { name } = this.config;
+
+        let beforeTs = await this.loadTS(this.tag);
+        const newTag = beforeTs.id === '';
+        const headTs = this.tag === TileMetadataNamedTag.Head ? beforeTs : await this.loadTS(TileMetadataNamedTag.Head);
+
+        if (newTag) {
+            beforeTs = headTs;
+        }
+
+        const tagAtHead = headTs.version == beforeTs.version;
+
+        // Only commit the changes if changing head
+        const changes = await this.reconcileTileSet(imgIds, beforeTs, tagAtHead ? isCommit : false);
+        if (changes != null) {
+            if (isCommit && this.tag !== TileMetadataNamedTag.Head) {
+                let version = changes.after.version;
+                if (!tagAtHead) {
+                    // tag has changed but not commited yet; commit now against head
+                    const changes = await this.reconcileTileSet(imgIds, headTs, true);
+                    if (changes == null) {
+                        // changes already applied to head; just tag it
+                        version = headTs.version;
+                    } else {
+                        // tag the new head
+                        version = changes.after.version;
+                    }
+                }
+                if (!newTag) {
+                    await Aws.tileMetadata.TileSet.tag(name, this.projection, this.tag, version);
+                }
+            }
+        }
+
+        return { changes, imagery: await primeImageryCache(imgIds) };
+    }
+
+    /**
+     * Reconcile a tileset with the config.
+
+     * @param imgIds a set of imgIds to add to. These will be loaded later
+     * @param beforeTs the current state of the TileSet
+     * @param isProdTag is this for the production or head Tag
+     * @param isCommit make the actual changes
+     */
+    private async reconcileTileSet(
+        imgIds: Set<string>,
+        beforeTs: TileMetadataSetRecord,
+        isCommit = false,
+    ): Promise<TagChanges | null> {
+        for (const rule of beforeTs.rules) {
+            imgIds.add(TileMetadataTable.prefix(RecordPrefix.Imagery, rule.imgId));
+        }
+
+        const backgroundAfter = this.config.background;
+        const backgroundBefore = beforeTs.background && rgbaToHex(beforeTs.background);
+
+        const ruleMap = rulesToMap(beforeTs.rules);
+
+        const afterRules: TileMetadataImageRule[] = [];
+        // build the new rules
+        for (const ts of this.imagery) {
+            const imgId = TileMetadataTable.prefix(RecordPrefix.Imagery, ts.id);
+            // blank imgId means not yet created. priority of -1 means remove
+            if (imgId != '' && ts.priority != -1) {
+                const rule = findRule(ruleMap, ts.id, ts.priority);
+                const ruleId = rule == null ? TileMetadataTable.prefix(RecordPrefix.ImageryRule, ulid()) : rule.ruleId;
+                afterRules.push({
+                    imgId,
+                    ruleId,
+                    priority: ts.priority,
+                    minZoom: ts.minZoom,
+                    maxZoom: ts.maxZoom,
+                });
+            }
+
+            imgIds.add(imgId);
+        }
+
+        // look for changes
+        beforeTs.rules.sort(compareImgIdPriority);
+        afterRules.sort(compareImgIdPriority);
+
+        if (objectsDiffer(beforeTs.rules, afterRules) || backgroundAfter !== backgroundBefore) {
+            let after: TileMetadataSetRecord = {
+                ...beforeTs,
+                background: parseRgba(backgroundAfter),
+                rules: afterRules,
+            };
+            if (isCommit) {
+                after = await Aws.tileMetadata.TileSet.create(after);
+            }
+            after.rules = afterRules;
+            return {
+                name: beforeTs.name,
+                projection: Epsg.get(beforeTs.projection),
+                before: beforeTs,
+                after,
+            };
+        }
+        return null;
+    }
+
+    private async loadTS(tag: TileMetadataTag): Promise<TileMetadataSetRecord> {
+        const { config, projection } = this;
+        const tsData = await Aws.tileMetadata.TileSet.get(config.name, projection, tag);
+        if (tsData != null) return tsData;
+        return Aws.tileMetadata.TileSet.initialRecord(
+            config.name,
+            projection.code,
+            [],
+            config.title,
+            config.description,
+        );
+    }
+}

--- a/packages/cli/src/cli/basemaps/tileset.util.ts
+++ b/packages/cli/src/cli/basemaps/tileset.util.ts
@@ -3,12 +3,57 @@ import {
     Aws,
     TileMetadataImageRule,
     TileMetadataImageryRecord,
+    TileMetadataNamedTag,
     TileMetadataSetRecord,
     TileMetadataTag,
 } from '@basemaps/shared';
 import * as c from 'ansi-colors';
 import { CliTable } from '../cli.table';
 import { invalidateCache } from '../util';
+
+/**
+ * Parse a string as hex, return 0 on failure
+ * @param str string to parse
+ */
+function parseHex(str: string): number {
+    if (str == '') return 0;
+    const val = parseInt(str, 16);
+    if (isNaN(val)) {
+        throw new Error('Invalid hex byte: ' + str);
+    }
+    return val;
+}
+
+/**
+ * Parse a hexstring into RGBA
+ *
+ * Defaults to 0 if missing values
+ * @param str string to parse
+ */
+export function parseRgba(str: string): { r: number; g: number; b: number; alpha: number } {
+    if (str.startsWith('0x')) str = str.slice(2);
+    else if (str.startsWith('#')) str = str.slice(1);
+    if (str.length != 6 && str.length != 8) {
+        throw new Error('Invalid hex color: ' + str);
+    }
+    return {
+        r: parseHex(str.substr(0, 2)),
+        g: parseHex(str.substr(2, 2)),
+        b: parseHex(str.substr(4, 2)),
+        alpha: parseHex(str.substr(6, 2)),
+    };
+}
+
+/**
+ * Convert a number to a two digit hex string. numbers < 16 are padded with '0'
+ */
+function numberToHexString(n: number): string {
+    const ans = n.toString(16);
+    return ans.length == 1 ? '0' + ans : ans;
+}
+export function rgbaToHex(c: { r: number; g: number; b: number; alpha: number }): string {
+    return numberToHexString(c.r) + numberToHexString(c.g) + numberToHexString(c.b) + numberToHexString(c.alpha);
+}
 
 interface TileSetRuleImagery {
     rule: TileMetadataImageRule;
@@ -59,35 +104,39 @@ export async function printTileSet(tsData: TileMetadataSetRecord, printImagery =
 }
 
 export function showDiff(
-    tsA: TileMetadataSetRecord,
-    tsB: TileMetadataSetRecord,
+    tsA: TileMetadataSetRecord | null,
+    tsB: TileMetadataSetRecord | null,
     imageSet: Map<string, TileMetadataImageryRecord>,
 ): string {
     let output = '';
-    for (const tsAImg of tsA.rules) {
-        const tsBImg = tsB.rules.find((rule) => rule.ruleId == tsAImg.ruleId);
-        const imagery = imageSet.get(tsAImg.imgId)!;
-        const lineA = TileSetTable.line({ rule: tsAImg, imagery });
+    if (tsA != null) {
+        for (const tsAImg of tsA.rules) {
+            const tsBImg = tsB?.rules.find((rule) => rule.ruleId == tsAImg.ruleId);
+            const imagery = imageSet.get(tsAImg.imgId)!;
+            const lineA = TileSetTable.line({ rule: tsAImg, imagery });
 
-        if (tsBImg == null) {
-            output += c.green('\t+' + lineA) + '\n';
-            continue;
-        }
+            if (tsBImg == null) {
+                output += c.green('\t+' + lineA) + '\n';
+                continue;
+            }
 
-        const lineB = TileSetTable.line({ rule: tsBImg, imagery });
-        if (lineA !== lineB) {
-            output += c.green('\t+' + lineA) + '\n';
-            output += c.red('\t-' + lineB) + '\n';
+            const lineB = TileSetTable.line({ rule: tsBImg, imagery });
+            if (lineA !== lineB) {
+                output += c.green('\t+' + lineA) + '\n';
+                output += c.red('\t-' + lineB) + '\n';
+            }
         }
     }
 
-    for (const tsBImg of tsB.rules) {
-        const tsAImg = tsA.rules.find((rule) => rule.ruleId == tsBImg.ruleId);
-        const imagery = imageSet.get(tsBImg.imgId)!;
+    if (tsB != null) {
+        for (const tsBImg of tsB.rules) {
+            const tsAImg = tsA?.rules.find((rule) => rule.ruleId == tsBImg.ruleId);
+            const imagery = imageSet.get(tsBImg.imgId)!;
 
-        if (tsAImg == null) {
-            const lineA = TileSetTable.line({ rule: tsBImg, imagery });
-            output += c.red('\t-' + lineA) + '\n';
+            if (tsAImg == null) {
+                const lineA = TileSetTable.line({ rule: tsBImg, imagery });
+                output += c.red('\t-' + lineA) + '\n';
+            }
         }
     }
     return output;
@@ -102,8 +151,29 @@ export function invalidateXYZCache(
     tag: TileMetadataTag,
     commit = false,
 ): Promise<void> {
-    const nameStr = tag == TileMetadataTag.Production ? name : `${name}@${tag}`;
+    const nameStr = tag == TileMetadataNamedTag.Production ? name : `${name}@${tag}`;
     const path = `/v1/tiles/${nameStr}/${projection.toEpsgString()}/*`;
 
     return invalidateCache(path, commit);
+}
+
+/**
+ * Prime the imagery cache so we are not doing lots of single gets
+ * @param {Set<string>} imageIds
+ */
+export async function primeImageryCache(imageIds: Set<string>): Promise<Map<string, TileMetadataImageryRecord>> {
+    const allImagery = await Aws.tileMetadata.batchGet<TileMetadataImageryRecord>(imageIds);
+    for (const img of allImagery.values()) Aws.tileMetadata.Imagery.imagery.set(img.id, img);
+    return allImagery;
+}
+
+export function defineTagParameter(self: any): void {
+    const validTags = Object.values(TileMetadataNamedTag).filter((f) => f != TileMetadataNamedTag.Head);
+    self.tag = self.defineStringParameter({
+        argumentName: 'TAG',
+        parameterLongName: '--tag',
+        parameterShortName: '-t',
+        description: `tag name  (options: ${validTags.join(', ')} or pr-<pr_number>)`,
+        required: false,
+    });
 }

--- a/packages/cli/src/cli/cogify/__test__/action.batch.test.ts
+++ b/packages/cli/src/cli/cogify/__test__/action.batch.test.ts
@@ -55,28 +55,35 @@ o.spec('action.batch', () => {
             const create = o.spy();
             Aws.tileMetadata = {
                 put,
-                TileSet: { create },
+                TileSet: { create, initialRecord: tileMetadata.TileSet.initialRecord },
             } as any;
 
             await createMetadataFromJob(job);
-
-            const { createdAt } = create.args[0];
 
             o(put.args[0].projection).equals(3857);
 
             o(create.args).deepEquals([
                 {
                     id: '',
+                    createdAt: create.args[0].createdAt,
+                    updatedAt: 0,
+                    version: 0,
+                    revisions: 0,
+                    v: 2,
                     name: 'abc123',
+                    projection: 3857,
+                    background: { r: 0, g: 0, b: 0, alpha: 0 },
+                    rules: [
+                        {
+                            imgId: 'im_abc123',
+                            ruleId: 'im_abc123',
+                            minZoom: 0,
+                            maxZoom: 32,
+                            priority: 1000,
+                        },
+                    ],
                     title: 'job title',
                     description: 'job description',
-                    projection: 3857,
-                    version: 0,
-                    createdAt,
-                    updatedAt: createdAt,
-                    imagery: {
-                        ['im_abc123']: { id: 'im_abc123', minZoom: 0, maxZoom: 32, priority: 10 },
-                    },
                 },
             ]);
         });

--- a/packages/cli/src/cli/cogify/action.batch.ts
+++ b/packages/cli/src/cli/cogify/action.batch.ts
@@ -8,7 +8,6 @@ import {
     LogType,
     RecordPrefix,
     TileMetadataImageryRecord,
-    TileMetadataSetRecordV1,
     TileMetadataTable,
 } from '@basemaps/shared';
 import { CommandLineAction, CommandLineFlagParameter, CommandLineStringParameter } from '@rushstack/ts-command-line';
@@ -62,19 +61,13 @@ export function createImageryRecordFromJob(job: CogJob): TileMetadataImageryReco
 export async function createMetadataFromJob(job: CogJob): Promise<void> {
     const img = createImageryRecordFromJob(job);
     await Aws.tileMetadata.put(img);
-    const createdAt = Date.now();
-    const tileMetadata: TileMetadataSetRecordV1 = {
-        id: '',
-        // TODO this name is not super nice, ideally we should use the simplified image name
-        name: job.id,
-        title: job.title,
-        description: job.description,
-        projection: job.output.epsg,
-        version: 0,
-        createdAt,
-        updatedAt: createdAt,
-        imagery: { [img.id]: { id: img.id, minZoom: 0, maxZoom: 32, priority: 10 } },
-    };
+    const tileMetadata = Aws.tileMetadata.TileSet.initialRecord(
+        job.id,
+        job.output.epsg,
+        [{ imgId: img.id, ruleId: img.id, minZoom: 0, maxZoom: 32, priority: 1000 }],
+        job.title,
+        job.description,
+    );
     await Aws.tileMetadata.TileSet.create(tileMetadata);
 }
 

--- a/packages/cli/src/cli/provider/action.provider.history.ts
+++ b/packages/cli/src/cli/provider/action.provider.history.ts
@@ -1,4 +1,4 @@
-import { Aws, TileMetadataProviderRecord, TileMetadataTag } from '@basemaps/shared';
+import { Aws, TileMetadataNamedTag, TileMetadataProviderRecord, TileMetadataTag } from '@basemaps/shared';
 import { CommandLineAction } from '@rushstack/ts-command-line';
 import { CliTable } from '../cli.table';
 import { printProvider } from './provider.util';
@@ -20,7 +20,7 @@ export class ProviderHistoryAction extends CommandLineAction {
     async getAllTags(): Promise<Map<TileMetadataTag, TileMetadataProviderRecord>> {
         const allTags: Map<TileMetadataTag, TileMetadataProviderRecord> = new Map();
         await Promise.all(
-            Object.values(TileMetadataTag).map(async (tag) => {
+            Object.values(TileMetadataNamedTag).map(async (tag) => {
                 const value = await Aws.tileMetadata.Provider.get(tag);
                 if (value != null) allTags.set(tag, value);
             }),
@@ -32,7 +32,7 @@ export class ProviderHistoryAction extends CommandLineAction {
     protected async onExecute(): Promise<void> {
         const allTags = await this.getAllTags();
 
-        const data = allTags.get(TileMetadataTag.Head);
+        const data = allTags.get(TileMetadataNamedTag.Head);
         if (data == null) throw new Error('Unable to find tag: head');
 
         printProvider(data);
@@ -46,7 +46,7 @@ export class ProviderHistoryAction extends CommandLineAction {
         }
 
         function getTagsForVersion(version: number): string {
-            return Object.values(TileMetadataTag)
+            return Object.values(TileMetadataNamedTag)
                 .filter((c) => allTags.get(c)?.version == version)
                 .join(', ');
         }

--- a/packages/cli/src/cli/provider/action.provider.info.ts
+++ b/packages/cli/src/cli/provider/action.provider.info.ts
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { Aws, TileMetadataTag } from '@basemaps/shared';
+import { Aws, TileMetadataNamedTag } from '@basemaps/shared';
 import { CommandLineAction, CommandLineIntegerParameter } from '@rushstack/ts-command-line';
-import { printProvider } from './provider.util';
 import * as c from 'ansi-colors';
+import { printProvider } from './provider.util';
 
 export class ProviderInfoAction extends CommandLineAction {
     private version: CommandLineIntegerParameter;
@@ -26,7 +26,7 @@ export class ProviderInfoAction extends CommandLineAction {
     }
 
     protected async onExecute(): Promise<void> {
-        const tsData = await Aws.tileMetadata.Provider.get(this.version.value! ?? TileMetadataTag.Head);
+        const tsData = await Aws.tileMetadata.Provider.get(this.version.value! ?? TileMetadataNamedTag.Head);
         if (tsData == null) {
             console.log(c.red('Provider info Not Found '));
         } else {

--- a/packages/cli/src/cli/provider/action.provider.tag.ts
+++ b/packages/cli/src/cli/provider/action.provider.tag.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { Aws, LogConfig, TileMetadataTag, parseMetadataTag } from '@basemaps/shared';
+import { Aws, LogConfig, TileMetadataNamedTag, parseMetadataTag } from '@basemaps/shared';
 import {
     CommandLineAction,
     CommandLineFlagParameter,
@@ -40,7 +40,7 @@ export class ProviderUpdateTagAction extends CommandLineAction {
 
         if (this.commit.value) {
             await Aws.tileMetadata.Provider.tag(tag, version);
-            if (tag === TileMetadataTag.Production) {
+            if (tag === TileMetadataNamedTag.Production) {
                 // TODO only invalidate WMTSCapabilities.xml paths
                 await invalidateCache(`/v1/tiles/*`, this.commit.value);
             }

--- a/packages/cli/src/cli/provider/action.provider.update.ts
+++ b/packages/cli/src/cli/provider/action.provider.update.ts
@@ -1,9 +1,9 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { Aws, LogConfig, TileMetadataTag, TileMetadataProviderRecord } from '@basemaps/shared';
+import { Aws, LogConfig, TileMetadataNamedTag, TileMetadataProviderRecord } from '@basemaps/shared';
 import { CommandLineAction, CommandLineFlagParameter, CommandLineStringParameter } from '@rushstack/ts-command-line';
-import { readFileSync } from 'fs';
-import { printProvider, BlankProvider, validateProvider } from './provider.util';
 import * as c from 'ansi-colors';
+import { readFileSync } from 'fs';
+import { BlankProvider, printProvider, validateProvider } from './provider.util';
 
 export class ProviderUpdateAction extends CommandLineAction {
     commit: CommandLineFlagParameter;
@@ -34,7 +34,7 @@ export class ProviderUpdateAction extends CommandLineAction {
     }
 
     protected async onExecute(): Promise<void> {
-        const before = (await Aws.tileMetadata.Provider.get(TileMetadataTag.Head)) || BlankProvider;
+        const before = (await Aws.tileMetadata.Provider.get(TileMetadataNamedTag.Head)) || BlankProvider;
 
         console.log(c.red('\nBefore'));
         printProvider(before);

--- a/packages/cli/src/cli/tag.action.ts
+++ b/packages/cli/src/cli/tag.action.ts
@@ -1,4 +1,4 @@
-import { TileMetadataTag } from '@basemaps/shared';
+import { defineTagParameter } from './basemaps/tileset.util';
 
 export const TagAction = {
     onDefineParameters(self: any): void {
@@ -10,14 +10,7 @@ export const TagAction = {
             required: false,
         });
 
-        const validTags = Object.values(TileMetadataTag).filter((f) => f != TileMetadataTag.Head);
-        self.tag = self.defineStringParameter({
-            argumentName: 'TAG',
-            parameterLongName: '--tag',
-            parameterShortName: '-t',
-            description: `tag name  (options: ${validTags.join(', ')})`,
-            required: false,
-        });
+        defineTagParameter(self);
 
         self.commit = self.defineFlagParameter({
             parameterLongName: '--commit',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -3,3 +3,4 @@ export { GdalCogBuilder } from './gdal/gdal.cog';
 export { GdalCogBuilderOptions } from './gdal/gdal.config';
 export { CogJobFactory } from './cog/job.factory';
 export { Gdal } from './gdal/gdal';
+export * from './cli/basemaps/tileset.updater';

--- a/packages/lambda-tiler/src/routes/attribution.ts
+++ b/packages/lambda-tiler/src/routes/attribution.ts
@@ -15,7 +15,7 @@ import {
     StacLicense,
     StacVersion,
     tileAttributionFromPath,
-    TileMetadataTag,
+    TileMetadataNamedTag,
     titleizeImageryName,
 } from '@basemaps/shared';
 import { BBox, MultiPolygon, multiPolygonToWgs84, Pair, union, Wgs84 } from '@linzjs/geojson';
@@ -100,7 +100,7 @@ async function tileSetAttribution(tileSet: TileSet): Promise<AttributionStac | n
         }
     }
 
-    const host = await Aws.tileMetadata.Provider.get(TileMetadataTag.Production);
+    const host = await Aws.tileMetadata.Provider.get(TileMetadataNamedTag.Production);
     if (host == null) return null;
 
     for (const rule of tileSet.tileSet.rules) {

--- a/packages/lambda-tiler/src/tile.set.ts
+++ b/packages/lambda-tiler/src/tile.set.ts
@@ -3,6 +3,7 @@ import {
     Aws,
     ProjectionTileMatrixSet,
     TileMetadataImageryRecord,
+    TileMetadataNamedTag,
     TileMetadataSetRecord,
     TileMetadataTag,
     TileResizeKernel,
@@ -38,7 +39,7 @@ export class TileSet {
     constructor(nameStr: string, projection: Epsg) {
         const { name, tag } = Aws.tileMetadata.TileSet.parse(nameStr);
         this.name = name;
-        this.tag = tag ?? TileMetadataTag.Production;
+        this.tag = tag ?? TileMetadataNamedTag.Production;
         this.projection = projection;
     }
 
@@ -51,7 +52,7 @@ export class TileSet {
     }
 
     get taggedName(): string {
-        if (this.tag == TileMetadataTag.Production) return this.name;
+        if (this.tag == TileMetadataNamedTag.Production) return this.name;
         return `${this.name}@${this.tag}`;
     }
 

--- a/packages/shared/src/aws/__test__/tile.metadata.imagery.test.ts
+++ b/packages/shared/src/aws/__test__/tile.metadata.imagery.test.ts
@@ -1,4 +1,6 @@
 import o from 'ospec';
+import { BaseDynamoTable } from '../aws.dynamo.table';
+import { TileMetadataTable } from '../tile.metadata';
 import { TileMetadataImageryRecord } from '../tile.metadata.base';
 import { compareImageSets } from '../tile.metadata.imagery';
 
@@ -25,5 +27,17 @@ o.spec('TileMetadataImagery', () => {
             imagery.sort(compareImageSets);
             o(imagery.map(getIds)).deepEquals(['b', 'c', 'a']);
         });
+    });
+
+    o('recordIsImagery', () => {
+        const table = new TileMetadataTable();
+
+        const item: BaseDynamoTable = { id: 'im_foo', name: 'abc' } as any;
+
+        o(table.Imagery.recordIsImagery(item)).equals(true);
+        o(table.Imagery.recordIsImagery({ id: 'ts_foo' } as any)).equals(false);
+        if (table.Imagery.recordIsImagery(item)) {
+            o(item.name).equals('abc'); // tests compiler
+        }
     });
 });

--- a/packages/shared/src/aws/__test__/tile.metadata.provider.test.ts
+++ b/packages/shared/src/aws/__test__/tile.metadata.provider.test.ts
@@ -1,5 +1,5 @@
 import o from 'ospec';
-import { TileMetadataTag, TileMetadataProviderRecord } from '../tile.metadata.base';
+import { TileMetadataNamedTag, TileMetadataProviderRecord } from '../tile.metadata.base';
 import { TileMetadataProvider } from '../tile.metadata.provider';
 
 o.spec('tile.metadata.provider', () => {
@@ -15,7 +15,7 @@ o.spec('tile.metadata.provider', () => {
         const rec1 = {} as TileMetadataProviderRecord;
         const recGet = o.spy(() => rec1);
         metadata.get = recGet;
-        const ans = await pv.get(TileMetadataTag.Production);
+        const ans = await pv.get(TileMetadataNamedTag.Production);
         o(ans).equals(rec1);
 
         o(recGet.args as any).deepEquals(['pv_main_production']);
@@ -24,7 +24,7 @@ o.spec('tile.metadata.provider', () => {
     o('tag', async () => {
         const v1 = { id: 'pv_main_v000001' } as TileMetadataProviderRecord;
         metadata.get = (): TileMetadataProviderRecord => v1;
-        const rec = await pv.tag(TileMetadataTag.Beta, 1);
+        const rec = await pv.tag(TileMetadataNamedTag.Beta, 1);
 
         o(rec).equals(v1);
 
@@ -39,9 +39,8 @@ o.spec('tile.metadata.provider', () => {
         });
 
         o('should create tag ids', () => {
-            o(pv.id(TileMetadataTag.Production)).equals('pv_main_production');
-            o(pv.id(TileMetadataTag.Head)).equals('pv_main_head');
-            o(pv.id(TileMetadataTag.Beta)).equals('pv_main_beta');
+            o(pv.id(TileMetadataNamedTag.Production)).equals('pv_main_production');
+            o(pv.id(TileMetadataNamedTag.Head)).equals('pv_main_head');
         });
     });
 });

--- a/packages/shared/src/aws/__test__/tile.metadata.test.ts
+++ b/packages/shared/src/aws/__test__/tile.metadata.test.ts
@@ -1,0 +1,48 @@
+import { DynamoDB } from 'aws-sdk';
+import o from 'ospec';
+import { Const } from '../../const';
+import { TileMetadataTable } from '../tile.metadata';
+
+o.spec('tile.metadata', () => {
+    o('asyncIterator', async () => {
+        const recs: any[] = [
+            { id: 'im_rec1', name: 'rec1' },
+            { id: 'ts_rec2', name: 'rec2' },
+            { id: 'ts_rec3', name: 'rec3' },
+        ];
+        const dynamo = {
+            scan(opts: any): any {
+                return {
+                    async promise(): Promise<any> {
+                        if (opts.TableName !== Const.TileMetadata.TableName) {
+                            throw new Error('Wrong table name: ' + opts.TableName);
+                        }
+                        let sample = recs.slice(0);
+                        let lastKey: any = null;
+                        if (opts.ExclusiveStartKey === undefined) {
+                            sample = recs.slice(0, 1);
+                            lastKey = 'ts_rec2';
+                        } else if (opts.ExclusiveStartKey === 'ts_rec2') {
+                            sample = recs.slice(1);
+                        }
+                        return {
+                            Items: sample.map((r) => DynamoDB.Converter.marshall(r)),
+                            LastEvaluatedKey: lastKey,
+                        };
+                    },
+                };
+            },
+        } as DynamoDB;
+
+        const table = new TileMetadataTable();
+        table.dynamo = dynamo;
+
+        const ans = [];
+
+        for await (const item of table) {
+            ans.push(item);
+        }
+
+        o(ans).deepEquals(recs);
+    });
+});

--- a/packages/shared/src/aws/__test__/tile.metadata.tileset.test.ts
+++ b/packages/shared/src/aws/__test__/tile.metadata.tileset.test.ts
@@ -1,8 +1,10 @@
-import o from 'ospec';
-import { TileMetadataTileSet } from '../tile.metadata.tileset';
 import { Epsg } from '@basemaps/geo';
-import { TileMetadataSetRecord, TileMetadataTag } from '../tile.metadata.base';
+import o from 'ospec';
 import { TileSetName } from '../../proj/tile.set.name';
+import { BaseDynamoTable } from '../aws.dynamo.table';
+import { TileMetadataTable } from '../tile.metadata';
+import { TileMetadataNamedTag, TileMetadataSetRecord } from '../tile.metadata.base';
+import { TileMetadataTileSet } from '../tile.metadata.tileset';
 
 const promiseNull = async (): Promise<unknown> => null;
 async function throws(cb: () => Promise<any>, re: RegExp): Promise<void> {
@@ -32,10 +34,9 @@ o.spec('tile.metadata.tileset', () => {
 
             o(metadata.get.callCount).equals(1);
             o(metadata.get.args[0]).equals('ts_test_3857_head');
-            o(metadata.put.callCount).equals(3);
+            o(metadata.put.callCount).equals(2);
             o(metadata.put.calls[0].args[0].id).equals('ts_test_3857_v000000');
-            o(metadata.put.calls[1].args[0].id).equals('ts_test_3857_production');
-            o(metadata.put.calls[2].args[0].id).equals('ts_test_3857_head');
+            o(metadata.put.calls[1].args[0].id).equals('ts_test_3857_head');
         });
 
         o('should migrate records on creation', async () => {
@@ -77,16 +78,16 @@ o.spec('tile.metadata.tileset', () => {
 
     o.spec('tag', () => {
         o('should fail if version does not exist', async () => {
-            await throws(() => ts.tag('test', Epsg.Google, TileMetadataTag.Production, 5), /ts_test_3857_v000005/);
+            await throws(() => ts.tag('test', Epsg.Google, TileMetadataNamedTag.Production, 5), /ts_test_3857_v000005/);
         });
 
         o('should fail if tagging head', async () => {
-            await throws(() => ts.tag('test', Epsg.Google, TileMetadataTag.Head, 5), /Cannot overwrite head tag/);
+            await throws(() => ts.tag('test', Epsg.Google, TileMetadataNamedTag.Head, 5), /Cannot overwrite head tag/);
         });
 
         o('should create tags', async () => {
             metadata.get = o.spy(() => Promise.resolve({ revisions: 5 }));
-            const res = await ts.tag('test', Epsg.Google, TileMetadataTag.Production, 5);
+            const res = await ts.tag('test', Epsg.Google, TileMetadataNamedTag.Production, 5);
             o(res.id).equals('ts_test_3857_production');
             o(res.v).equals(2);
             o(Array.isArray(res.rules)).equals(true);
@@ -104,17 +105,20 @@ o.spec('tile.metadata.tileset', () => {
         });
 
         o('should create tag ids', () => {
-            o(ts.id('test', Epsg.Google, TileMetadataTag.Production)).equals('ts_test_3857_production');
-            o(ts.id('test', Epsg.Google, TileMetadataTag.Head)).equals('ts_test_3857_head');
-            o(ts.id('test', Epsg.Google, TileMetadataTag.Beta)).equals('ts_test_3857_beta');
+            o(ts.id('test', Epsg.Google, TileMetadataNamedTag.Production)).equals('ts_test_3857_production');
+            o(ts.id('test', Epsg.Google, TileMetadataNamedTag.Head)).equals('ts_test_3857_head');
+            o(ts.id('test', Epsg.Google, TileMetadataNamedTag.Beta)).equals('ts_test_3857_beta');
         });
     });
 
     o.spec('parse', () => {
         o('should parse @ syntax', () => {
-            o(ts.parse('aerial@head')).deepEquals({ name: TileSetName.aerial, tag: TileMetadataTag.Head });
-            o(ts.parse('aerial@production')).deepEquals({ name: TileSetName.aerial, tag: TileMetadataTag.Production });
-            o(ts.parse('aerial@beta')).deepEquals({ name: TileSetName.aerial, tag: TileMetadataTag.Beta });
+            o(ts.parse('aerial@head')).deepEquals({ name: TileSetName.aerial, tag: TileMetadataNamedTag.Head });
+            o(ts.parse('aerial@production')).deepEquals({
+                name: TileSetName.aerial,
+                tag: TileMetadataNamedTag.Production,
+            });
+            o(ts.parse('aerial@beta')).deepEquals({ name: TileSetName.aerial, tag: TileMetadataNamedTag.Beta });
         });
 
         o('should throw with invalid tags', () => {
@@ -126,5 +130,17 @@ o.spec('tile.metadata.tileset', () => {
             o(ts.parse('AeRiaL@BETA')).deepEquals({ name: 'AeRiaL@BETA' });
             o(ts.parse('AeRiaL@HEAD')).deepEquals({ name: 'AeRiaL@HEAD' });
         });
+    });
+
+    o('recordIsImagery', () => {
+        const table = new TileMetadataTable();
+
+        const item: BaseDynamoTable = { id: 'ts_foo', name: 'abc' } as any;
+
+        o(table.TileSet.recordIsTileset(item)).equals(true);
+        o(table.TileSet.recordIsTileset({ id: 'im_foo' } as any)).equals(false);
+        if (table.Imagery.recordIsImagery(item)) {
+            o(item.name).equals('abc'); // tests compiler
+        }
     });
 });

--- a/packages/shared/src/aws/tile.metadata.imagery.ts
+++ b/packages/shared/src/aws/tile.metadata.imagery.ts
@@ -1,4 +1,10 @@
-import { TileMetadataImageryRecord, TileMetadataSetRecord, TileMetadataTableBase } from './tile.metadata.base';
+import { BaseDynamoTable } from './aws.dynamo.table';
+import {
+    RecordPrefix,
+    TileMetadataImageryRecord,
+    TileMetadataSetRecord,
+    TileMetadataTableBase,
+} from './tile.metadata.base';
 
 /**
  * Imagery sort must be stable, otherwise the ordering of imagery sets will vary between tile
@@ -25,6 +31,15 @@ export class TileMetadataImagery {
     metadata: TileMetadataTableBase;
     constructor(metadata: TileMetadataTableBase) {
         this.metadata = metadata;
+    }
+
+    /**
+     * Is `rec` an Imagery record
+
+     * @param rec record to infer is a TileMetadataImageryRecord
+     */
+    public recordIsImagery(rec: BaseDynamoTable): rec is TileMetadataImageryRecord {
+        return rec.id.startsWith(RecordPrefix.Imagery);
     }
 
     public async get(imgId: string): Promise<TileMetadataImageryRecord> {

--- a/packages/shared/src/aws/tile.metadata.tileset.ts
+++ b/packages/shared/src/aws/tile.metadata.tileset.ts
@@ -1,8 +1,11 @@
-import { Epsg } from '@basemaps/geo';
+import { Epsg, EpsgCode } from '@basemaps/geo';
+import { BaseDynamoTable } from './aws.dynamo.table';
 import {
+    DefaultBackground,
     parseMetadataTag,
     RecordPrefix,
     TaggedTileMetadata,
+    TileMetadataImageRuleV2,
     TileMetadataImageryRecord,
     TileMetadataSetRecord,
     TileMetadataSetRecordBase,
@@ -44,6 +47,45 @@ export class TileMetadataTileSet extends TaggedTileMetadata<TileMetadataSetRecor
             });
         }
         return output;
+    }
+
+    initialRecord(
+        name: string,
+        projection: EpsgCode,
+        rules: TileMetadataImageRuleV2[] = [],
+        title?: string,
+        description?: string,
+    ): TileMetadataSetRecord {
+        const rec: TileMetadataSetRecord = {
+            id: '',
+            createdAt: Date.now(),
+            updatedAt: 0,
+            version: 0,
+            revisions: 0,
+            v: 2,
+            name,
+            projection: projection,
+            background: DefaultBackground,
+            rules,
+        };
+
+        if (title != null) {
+            rec.title = title;
+        }
+        if (description != null) {
+            rec.description = description;
+        }
+
+        return rec;
+    }
+
+    /**
+     * Is `rec` a TileSet record
+
+     * @param rec record to infer is a TileMetadataSetRecord
+     */
+    recordIsTileset(rec: BaseDynamoTable): rec is TileMetadataSetRecord {
+        return rec.id.startsWith(RecordPrefix.TileSet);
     }
 
     /**

--- a/packages/shared/src/aws/tile.metadata.ts
+++ b/packages/shared/src/aws/tile.metadata.ts
@@ -1,7 +1,8 @@
-import { TileMetadataTableBase } from './tile.metadata.base';
+import { Const } from '../const';
+import { TileMetadataRecord, TileMetadataTableBase } from './tile.metadata.base';
 import { TileMetadataImagery } from './tile.metadata.imagery';
-import { TileMetadataTileSet } from './tile.metadata.tileset';
 import { TileMetadataProvider } from './tile.metadata.provider';
+import { TileMetadataTileSet } from './tile.metadata.tileset';
 
 export class TileMetadataTable extends TileMetadataTableBase {
     TileSet: TileMetadataTileSet;
@@ -13,5 +14,13 @@ export class TileMetadataTable extends TileMetadataTableBase {
         this.TileSet = new TileMetadataTileSet(this);
         this.Imagery = new TileMetadataImagery(this);
         this.Provider = new TileMetadataProvider(this);
+    }
+
+    /**
+     * Iterate over all records in the TileMetadataTable
+     */
+    async *[Symbol.asyncIterator](): AsyncGenerator<TileMetadataRecord, null, void> {
+        yield* this.scan(Const.TileMetadata.TableName);
+        return null;
     }
 }


### PR DESCRIPTION
Adds import, export commands to basemaps tool

Supports both Head and Production config and full DB contents config.

