### PR TITLE
ci: use organisation secrets

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -62,11 +62,11 @@ jobs:
         if: github.ref == 'refs/heads/master' && github.repository == 'linz/basemaps'
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_BASEMAPS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_BASEMAPS_SECRET_ACCESS_KEY }}
           aws-region: ap-southeast-2
           mask-account-id: true
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_NON_PROD }}
+          role-to-assume: ${{ secrets.AWS_BASEMAPS_ROLE_NON_PROD }}
 
       - name: (NonProd) Deploy 
         if: github.ref == 'refs/heads/master' && github.repository == 'linz/basemaps'
@@ -83,17 +83,17 @@ jobs:
         if: github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'release:')
         run: npx lerna publish from-git --yes
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN_LINZJS}}
 
       - name: (Prod) Configure AWS Credentials 
         if: github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'release:')
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_BASEMAPS_ACCESS_KEY }}
+          aws-secret-access-key: ${{ secrets.AWS_BASEMAPS_SECRET_ACCESS_KEY }}
           aws-region: ap-southeast-2
           mask-account-id: true
-          role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_PROD }}
+          role-to-assume: ${{ secrets.AWS_BASEMAPS_ROLE_PROD }}
 
       - name: (Prod) Deploy
         if: github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'release:')


### PR DESCRIPTION
Now that there are multiple repositories for basemaps share the secrets across both repositories
