### PR TITLE
build: improve build times

### DIFF
--- a/packages/cli/src/gdal/gdal.command.ts
+++ b/packages/cli/src/gdal/gdal.command.ts
@@ -24,6 +24,14 @@ export function normalizeAwsEnv(env: Record<string, string | undefined>): Record
     return env;
 }
 
+export interface GdalCredentials {
+    needsRefresh(): boolean;
+    refreshPromise(): Promise<void>;
+    accessKeyId: string;
+    secretAccessKey: string;
+    sessionToken: string;
+}
+
 export abstract class GdalCommand {
     parser?: GdalProgressParser;
     protected child: ChildProcessWithoutNullStreams;
@@ -31,13 +39,13 @@ export abstract class GdalCommand {
     protected startTime: number;
 
     /** AWS Access  */
-    protected credentials?: AWS.Credentials;
+    protected credentials?: GdalCredentials;
 
     mount?(mount: string): void;
     env?(): Promise<Record<string, string | undefined>>;
 
     /** Pass AWS credentials into the container */
-    setCredentials(credentials?: AWS.Credentials): void {
+    setCredentials(credentials?: GdalCredentials): void {
         this.credentials = credentials;
     }
 

--- a/packages/linzjs-s3fs/src/__tests__/file.s3.test.ts
+++ b/packages/linzjs-s3fs/src/__tests__/file.s3.test.ts
@@ -1,6 +1,6 @@
 import { FsS3 } from '../file.s3';
 import o from 'ospec';
-import { S3 } from 'aws-sdk';
+import S3 from 'aws-sdk/clients/s3';
 import { createSandbox } from 'sinon';
 import { S3Fs } from '..';
 

--- a/packages/linzjs-s3fs/src/file.s3.ts
+++ b/packages/linzjs-s3fs/src/file.s3.ts
@@ -1,4 +1,5 @@
-import type { S3, AWSError } from 'aws-sdk';
+import S3 from 'aws-sdk/clients/s3';
+import { AWSError } from 'aws-sdk/lib/error';
 import { Readable, Stream } from 'stream';
 import { CompositeError } from './composite.error';
 import { FileProcessor } from './file';

--- a/packages/linzjs-s3fs/src/index.ts
+++ b/packages/linzjs-s3fs/src/index.ts
@@ -1,4 +1,4 @@
-import { S3 } from 'aws-sdk';
+import S3 from 'aws-sdk/clients/s3';
 import { Readable } from 'stream';
 import { CompositeError } from './composite.error';
 import { FileProcessor } from './file';

--- a/packages/shared/src/aws/__test__/tile.metadata.table.test.ts
+++ b/packages/shared/src/aws/__test__/tile.metadata.table.test.ts
@@ -1,6 +1,6 @@
 import { Bounds, Epsg } from '@basemaps/geo';
 import { round } from '@basemaps/test/build/rounding';
-import * as AWS from 'aws-sdk';
+import DynamoDB from 'aws-sdk/clients/dynamodb';
 import o from 'ospec';
 import { Const } from '../../const';
 import { TileSetName } from '../../proj/tile.set.name';
@@ -8,7 +8,7 @@ import { qkToNamedBounds } from '../../proj/__test__/test.util';
 import { TileMetadataTable } from '../tile.metadata';
 import { TileMetadataImageRule, TileMetadataImageryRecord, TileMetadataSetRecord } from '../tile.metadata.base';
 
-const { marshall } = AWS.DynamoDB.Converter;
+const { marshall } = DynamoDB.Converter;
 
 o.spec('tile.metadata.table', () => {
     const { now } = Date;

--- a/packages/shared/src/aws/api.key.table.ts
+++ b/packages/shared/src/aws/api.key.table.ts
@@ -1,6 +1,6 @@
-import * as AWS from 'aws-sdk';
 import { BaseDynamoTable } from './aws.dynamo.table';
 import { Const } from '../const';
+import DynamoDB from 'aws-sdk/clients/dynamodb';
 
 /**
  * The database format for the ApiKey Table
@@ -23,10 +23,10 @@ export interface ApiKeyTableRecord extends BaseDynamoTable {
 }
 
 export class ApiKeyTable {
-    private dynamo: AWS.DynamoDB;
+    private dynamo: DynamoDB;
 
     public constructor() {
-        this.dynamo = new AWS.DynamoDB({});
+        this.dynamo = new DynamoDB({});
     }
 
     /**
@@ -46,7 +46,7 @@ export class ApiKeyTable {
             return null;
         }
 
-        return AWS.DynamoDB.Converter.unmarshall(res.Item) as ApiKeyTableRecord;
+        return DynamoDB.Converter.unmarshall(res.Item) as ApiKeyTableRecord;
     }
 
     public async create(apiKey: string): Promise<string> {

--- a/packages/shared/src/aws/credentials.ts
+++ b/packages/shared/src/aws/credentials.ts
@@ -2,6 +2,7 @@ import { ObjectCache } from './object.cache';
 import { hostname } from 'os';
 import { Env } from '../const';
 import { ChainableTemporaryCredentials } from 'aws-sdk/lib/credentials/chainable_temporary_credentials';
+import AWS from 'aws-sdk/lib/core';
 import S3 from 'aws-sdk/clients/s3';
 
 export interface StsAssumeRoleConfig {
@@ -18,7 +19,7 @@ const AwsRoleDurationSeconds = Env.getNumber(Env.AwsRoleDurationHours, 8) * OneH
  */
 class CredentialObjectCache extends ObjectCache<ChainableTemporaryCredentials, StsAssumeRoleConfig> {
     create(opts: StsAssumeRoleConfig): ChainableTemporaryCredentials {
-        return new ChainableTemporaryCredentials({
+        return new AWS.ChainableTemporaryCredentials({
             params: {
                 RoleArn: opts.roleArn,
                 ExternalId: opts.externalId,
@@ -26,7 +27,7 @@ class CredentialObjectCache extends ObjectCache<ChainableTemporaryCredentials, S
                 DurationSeconds: AwsRoleDurationSeconds,
             },
             // TODO can we fix this
-            // masterCredentials: config.credentials as Credentials,
+            // masterCredentials: AWS.config.credentials as Credentials,
         });
     }
 }

--- a/packages/shared/src/aws/index.ts
+++ b/packages/shared/src/aws/index.ts
@@ -9,26 +9,26 @@
  */
 process.env['AWS_NODEJS_CONNECTION_REUSE_ENABLED'] = '1';
 
-import * as AWS from 'aws-sdk';
+import S3 from 'aws-sdk/clients/s3';
 
 import { ApiKeyTable } from './api.key.table';
 import { TileMetadataTable } from './tile.metadata';
 import { S3Cache, CredentialsCache, StsAssumeRoleConfig } from './credentials';
+import { ChainableTemporaryCredentials } from 'aws-sdk/lib/credentials/chainable_temporary_credentials';
 
-const s3 = new AWS.S3();
+const s3 = new S3();
 export const Aws = {
-    sdk: AWS,
     credentials: {
         /**
          * Get a s3 that is bound to a specific role
          */
-        getS3ForRole(opts?: StsAssumeRoleConfig): AWS.S3 {
+        getS3ForRole(opts?: StsAssumeRoleConfig): S3 {
             if (opts == null) {
                 return s3;
             }
             return S3Cache.getOrMake(opts.roleArn, opts);
         },
-        getCredentialsForRole(roleArn: string, externalId?: string): AWS.ChainableTemporaryCredentials {
+        getCredentialsForRole(roleArn: string, externalId?: string): ChainableTemporaryCredentials {
             return CredentialsCache.getOrMake(roleArn, { roleArn, externalId });
         },
     },

--- a/packages/shared/src/aws/tile.metadata.base.ts
+++ b/packages/shared/src/aws/tile.metadata.base.ts
@@ -1,5 +1,5 @@
-import { BoundingBox, EpsgCode, WmtsProvider } from '@basemaps/geo';
-import { DynamoDB } from 'aws-sdk';
+import { EpsgCode, WmtsProvider, BoundingBox } from '@basemaps/geo';
+import DynamoDB from 'aws-sdk/clients/dynamodb';
 import { Const } from '../const';
 import { BaseDynamoTable } from './aws.dynamo.table';
 

--- a/packages/shared/src/file/index.ts
+++ b/packages/shared/src/file/index.ts
@@ -5,7 +5,7 @@ import { promisify } from 'util';
 import { createGzip, gunzip } from 'zlib';
 import { S3Fs, isConfigS3Role, FileConfigS3, FileProcessor } from '@linzjs/s3fs';
 import { Aws } from '../aws';
-import type { S3 } from 'aws-sdk';
+import type S3 from 'aws-sdk/clients/s3';
 
 function getS3(s3Cfg: string | FileConfigS3): S3 {
     if (isConfigS3Role(s3Cfg)) {


### PR DESCRIPTION
Using `import * as AWS from 'aws-sdk'` Imports a ton of types which are generally not needed which greatly inflate the typescript compile time.

By using `import S3 from 'aws-sdk/clients/s3'` this seems to drop builds by 2-3 seconds per project