### PR TITLE
fix(lambda-tiler): health endpoint cannot open static files.

### DIFF
--- a/packages/lambda-tiler/src/routes/health.ts
+++ b/packages/lambda-tiler/src/routes/health.ts
@@ -8,18 +8,9 @@ import { ImageFormat } from '@basemaps/tiler';
 import { tile } from './tile';
 
 export function getExpectedTileName(projection: Epsg, tile: Tile, format: ImageFormat): string {
-    if (__filename === 'index.js') {
-        // Bundle static files are at the same directory with index.js
-        return path.join(__dirname, `static/expected_tile_${projection.code}_${tile.x}_${tile.y}_z${tile.z}.${format}`);
-    } else {
-        // To get test file locally
-        return path.join(
-            __dirname,
-            '..',
-            '..',
-            `static/expected_tile_${projection.code}_${tile.x}_${tile.y}_z${tile.z}.${format}`,
-        );
-    }
+    // Bundle static files are at the same directory with index.js
+    const dir = __filename === 'index.js' ? __dirname : path.join(__dirname, '..', '..');
+    return path.join(dir, `static/expected_tile_${projection.code}_${tile.x}_${tile.y}_z${tile.z}.${format}`);
 }
 
 interface TestTile {

--- a/packages/lambda-tiler/src/routes/health.ts
+++ b/packages/lambda-tiler/src/routes/health.ts
@@ -8,12 +8,18 @@ import { ImageFormat } from '@basemaps/tiler';
 import { tile } from './tile';
 
 export function getExpectedTileName(projection: Epsg, tile: Tile, format: ImageFormat): string {
-    return path.join(
-        __dirname,
-        '..',
-        '..',
-        `static/expected_tile_${projection.code}_${tile.x}_${tile.y}_z${tile.z}.${format}`,
-    );
+    if (__filename === 'index.js') {
+        // Bundle static files are at the same directory with index.js
+        return path.join(__dirname, `static/expected_tile_${projection.code}_${tile.x}_${tile.y}_z${tile.z}.${format}`);
+    } else {
+        // To get test file locally
+        return path.join(
+            __dirname,
+            '..',
+            '..',
+            `static/expected_tile_${projection.code}_${tile.x}_${tile.y}_z${tile.z}.${format}`,
+        );
+    }
 }
 
 interface TestTile {


### PR DESCRIPTION
Fixes: #
Static files are located at the same directory after bundle, which causes the following error.

`    "err": {
        "type": "Error",
        "message": "ENOENT: no such file or directory, open '/static/expected_tile_3857_252_156_z8.png'",
        "stack": "Error: ENOENT: no such file or directory, open '/static/expected_tile_3857_252_156_z8.png'",
        "errno": -2,
        "code": "ENOENT",
        "syscall": "open",
        "path": "/static/expected_tile_3857_252_156_z8.png"
    },`