### PR TITLE
fix(landing): correct broken wmts/xyz links in side bar

### DIFF
--- a/packages/landing/src/config.ts
+++ b/packages/landing/src/config.ts
@@ -2,8 +2,8 @@ import { getApiKey } from '@basemaps/shared/build/api';
 
 const currentApiKey: string = getApiKey();
 export const Config = {
-    get BaseUrl(): string | undefined {
-        return process.env.TILE_HOST;
+    get BaseUrl(): string {
+        return process.env.TILE_HOST ?? '';
     },
     get ApiKey(): string {
         return currentApiKey;

--- a/packages/landing/src/url.ts
+++ b/packages/landing/src/url.ts
@@ -81,10 +81,9 @@ export const WindowUrl = {
     },
 
     baseUrl(): string {
-        const baseUrl = Config.BaseUrl ?? baseWindowUrl();
-        if (baseUrl != '' && !baseUrl.startsWith('http')) {
-            throw new Error('BaseURL must start with http(s)://');
-        }
+        const baseUrl = Config.BaseUrl;
+        if (baseUrl == '') return baseWindowUrl();
+        if (!baseUrl.startsWith('http')) throw new Error('BaseURL must start with http(s)://');
         return baseUrl;
     },
 


### PR DESCRIPTION
by default process.env.TILE_HOST is set to "" not undefined


