### PR TITLE
feat(attribution): remove `@basemaps/shared` dependency to make it smaller to install

### DIFF
--- a/packages/attribution/package.json
+++ b/packages/attribution/package.json
@@ -26,7 +26,7 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/shared": "^4.19.0",
+    "@basemaps/geo": "^4.19.0",
     "@linzjs/geojson": "^4.19.0",
     "ol": "^6.4.2"
   },

--- a/packages/attribution/src/attribution.ts
+++ b/packages/attribution/src/attribution.ts
@@ -1,4 +1,4 @@
-import { AttributionCollection, AttributionStac } from '@basemaps/shared/build/attribution';
+import { AttributionCollection, AttributionStac } from '@basemaps/geo';
 import { BBox } from '@linzjs/geojson';
 import { Wgs84 } from '@linzjs/geojson/build/wgs84';
 import { Extent } from 'ol/extent';

--- a/packages/bathymetry/src/__test__/stac.test.ts
+++ b/packages/bathymetry/src/__test__/stac.test.ts
@@ -1,5 +1,6 @@
 import { GoogleTms } from '@basemaps/geo/build/tms/google';
-import { LogConfig, LogType, StacCollection, StacBaseMapsExtension, StacVersion, StacLicense } from '@basemaps/shared';
+import { StacCollection } from '@basemaps/geo';
+import { LogConfig, LogType } from '@basemaps/shared';
 import { mockFileOperator } from '@basemaps/shared/build/file/__test__/file.operator.test.helper';
 import { round } from '@basemaps/test/build/rounding';
 import o from 'ospec';
@@ -41,8 +42,8 @@ o.spec('stac', () => {
         o(date >= now && date < now + 2000).equals(true);
 
         o(round(stac, 4)).deepEquals({
-            stac_version: StacVersion,
-            stac_extensions: ['projection', StacBaseMapsExtension],
+            stac_version: Stac.Version,
+            stac_extensions: ['projection', Stac.BaseMapsExtension],
             id: 'id123/13-22-33',
             collection: 'id123',
             type: 'Feature',
@@ -102,7 +103,7 @@ o.spec('stac', () => {
             const stac = await Stac.createCollection(bm, bounds, items, logger);
 
             o(round(stac, 4)).deepEquals({
-                stac_version: StacVersion,
+                stac_version: Stac.Version,
                 stac_extensions: ['projection'],
                 id: 'id123',
                 title: 'Gebco 2020.nc',
@@ -113,7 +114,7 @@ o.spec('stac', () => {
                         interval: [['2020-01-01T00:00:00Z', '2021-01-01T00:00:00Z']],
                     },
                 },
-                license: StacLicense,
+                license: Stac.License,
                 links: stac.links,
                 providers: [
                     {
@@ -146,10 +147,10 @@ o.spec('stac', () => {
             const gitHubLink = stac.links[2];
             o(gitHubLink.href.startsWith('https://github.com/linz/basemaps.git')).equals(true);
             o(gitHubLink.rel).equals('derived_from');
-            o(/^\d+\.\d+\.\d+$/.test(gitHubLink.version)).equals(true);
+            o(/^\d+\.\d+\.\d+$/.test(gitHubLink.version as any)).equals(true);
 
             o(round(stac, 4)).deepEquals({
-                stac_version: StacVersion,
+                stac_version: Stac.Version,
                 stac_extensions: ['projection'],
                 id: 'id123',
                 title: 'fancy title',
@@ -158,7 +159,7 @@ o.spec('stac', () => {
                     spatial: { bbox: [[-179.0332, 84.9205, -178.9893, 84.9244]] },
                     temporal: { interval: [['2020-01-01T00:00:00Z', '2020-10-12T01:02:03Z']] },
                 },
-                license: StacLicense,
+                license: Stac.License,
                 links: [
                     {
                         rel: 'self',

--- a/packages/bathymetry/src/stac.ts
+++ b/packages/bathymetry/src/stac.ts
@@ -1,16 +1,18 @@
-import { Bounds, Tile, TileMatrixSet } from '@basemaps/geo';
+import {
+    Bounds,
+    Tile,
+    TileMatrixSet,
+    Stac as StacStatic,
+    StacItem,
+    StacCollection,
+    StacLink,
+    StacProvider,
+} from '@basemaps/geo';
 import {
     extractYearRangeFromName,
     FileOperator,
     LogType,
     ProjectionTileMatrixSet,
-    StacBaseMapsExtension,
-    StacCollection,
-    StacItem,
-    StacLicense,
-    StacLink,
-    StacProvider,
-    StacVersion,
     titleizeImageryName,
 } from '@basemaps/shared';
 import * as cp from 'child_process';
@@ -39,8 +41,8 @@ async function createItem(bm: BathyMaker, tile: Tile): Promise<StacItem> {
 
     const created = new Date().toISOString();
     return {
-        stac_version: StacVersion,
-        stac_extensions: ['projection', StacBaseMapsExtension],
+        stac_version: StacStatic.Version,
+        stac_extensions: ['projection', StacStatic.BaseMapsExtension],
         id: bm.config.id + '/' + tileId,
         collection: bm.config.id,
         type: 'Feature',
@@ -137,7 +139,7 @@ async function createCollection(
     }
 
     return {
-        stac_version: StacVersion,
+        stac_version: StacStatic.Version,
         stac_extensions: ['projection'],
         id: bm.config.id,
         title,
@@ -148,7 +150,7 @@ async function createCollection(
             },
             temporal: { interval },
         },
-        license: StacLicense,
+        license: StacStatic.License,
         links,
         providers,
         keywords: ['Bathymetry'],
@@ -156,4 +158,4 @@ async function createCollection(
     };
 }
 
-export const Stac = { createItem, createCollection };
+export const Stac = { createItem, createCollection, ...StacStatic };

--- a/packages/cli/src/cog/__test__/cog.stac.job.test.ts
+++ b/packages/cli/src/cog/__test__/cog.stac.job.test.ts
@@ -1,5 +1,5 @@
-import { Bounds, EpsgCode } from '@basemaps/geo';
-import { ProjectionTileMatrixSet, StacBaseMapsExtension, StacLicense, StacVersion } from '@basemaps/shared';
+import { Bounds, EpsgCode, Stac } from '@basemaps/geo';
+import { ProjectionTileMatrixSet } from '@basemaps/shared';
 import { mockFileOperator } from '@basemaps/shared/build/file/__test__/file.operator.test.helper';
 import { round } from '@basemaps/test/build/rounding';
 import { Ring } from '@linzjs/geojson';
@@ -180,13 +180,13 @@ o.spec('CogJob', () => {
                 id: 'jobid1',
                 title: 'Auckland rural 2010-2012 0.50m',
                 description: 'No description',
-                stac_version: StacVersion,
-                stac_extensions: [StacBaseMapsExtension],
+                stac_version: Stac.Version,
+                stac_extensions: [Stac.BaseMapsExtension],
                 extent: {
                     spatial: { bbox: [[169.3341, -51.8754, -146.1432, -32.8952]] },
                     temporal: { interval: [['2010-01-01T00:00:00Z', '2011-01-01T00:00:00Z']] },
                 },
-                license: StacLicense,
+                license: Stac.License,
                 keywords: ['Imagery', 'New Zealand'],
                 providers: [],
                 summaries: {
@@ -273,7 +273,7 @@ o.spec('CogJob', () => {
                 bbox: [0, 0, 0, 0],
                 id: 'jobid1/0-0-0',
                 collection: 'jobid1',
-                stac_version: StacVersion,
+                stac_version: Stac.Version,
                 stac_extensions: ['projection'],
                 links: [
                     { href: jobPath + '/0-0-0.json', rel: 'self' },

--- a/packages/cli/src/cog/cog.stac.job.ts
+++ b/packages/cli/src/cog/cog.stac.job.ts
@@ -1,16 +1,10 @@
-import { Bounds, Epsg } from '@basemaps/geo';
+import { Bounds, Epsg, Stac, StacCollection, StacLink, StacProvider } from '@basemaps/geo';
 import {
     extractYearRangeFromName,
     FileConfig,
     FileConfigPath,
     FileOperator,
     ProjectionTileMatrixSet,
-    StacBaseMapsExtension,
-    StacCollection,
-    StacLicense,
-    StacLink,
-    StacProvider,
-    StacVersion,
     titleizeImageryName,
 } from '@basemaps/shared';
 import { MultiPolygon, toFeatureCollection, toFeatureMultiPolygon } from '@linzjs/geojson';
@@ -169,7 +163,7 @@ export class CogStacJob implements CogJob {
             }
         }
         const keywords = sourceStac.keywords ?? CogStacKeywords.slice();
-        const license = sourceStac.license ?? StacLicense;
+        const license = sourceStac.license ?? Stac.License;
         const title = sourceStac.title ?? titleizeImageryName(imageryName);
 
         if (description == null) {
@@ -236,8 +230,8 @@ export class CogStacJob implements CogJob {
             id,
             title,
             description,
-            stac_version: StacVersion,
-            stac_extensions: [StacBaseMapsExtension],
+            stac_version: Stac.Version,
+            stac_extensions: [Stac.BaseMapsExtension],
 
             extent: {
                 spatial: { bbox },
@@ -289,7 +283,7 @@ export class CogStacJob implements CogJob {
                 ...f,
                 id: job.id + '/' + name,
                 collection: job.id,
-                stac_version: StacVersion,
+                stac_version: Stac.Version,
                 stac_extensions: CogStacItemExtensions,
                 properties: {
                     ...f.properties,

--- a/packages/cli/src/cog/stac.ts
+++ b/packages/cli/src/cog/stac.ts
@@ -1,5 +1,4 @@
-import { EpsgCode } from '@basemaps/geo';
-import { StacCollection, StacItem } from '@basemaps/shared';
+import { EpsgCode, StacCollection, StacItem } from '@basemaps/geo';
 import { CogGdalSettings } from './types';
 
 export interface CogGenerated {

--- a/packages/geo/README.md
+++ b/packages/geo/README.md
@@ -24,3 +24,41 @@ const p: Point = { x: 5, y: 5 };
 const s: Size = { width: 200, height: 500 };
 const box: BoundingBox = { ...p, ...s };
 ```
+
+## QuadKey utilities
+
+```typescript
+import {QuadKey} from '@basemaps/geo';
+
+
+QuadKey.children('3') // ['30', '31', '32', '33']
+
+QuadKey.fromTile({ x: 3, y: 2, z: 2 } // '31'
+```
+
+## Tile Matrix Sets
+
+
+```typescript
+import {GoogleTms} from '@basemaps/geo/build/tms/google'
+
+
+/** Convert tile offsets into pixel coordinates */
+GoogleTms.tileToPixels(1, 1) // { x: 256, y: 256 }
+
+/** Convert a tile into the upper left point in Google  */
+GoogleTms.tileToSource({ x: 0, y: 0, z: 0 }) // { x: -20037508.3427892, y: 20037508.3427892 }
+```
+
+
+## Epsg Helpers
+
+```typescript
+import {Epsg} from '@basemaps/geo'
+
+
+Epsg.Google.toEpsgCode() // `EPSG:3857`
+Epsg.Google.toUrn() // `urn:ogc:def:crs:EPSG:3857`
+Epsg.parse('3857') // Epsg.Google
+Epsg.get(3857) // Epsg.Google
+```

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -22,5 +22,8 @@
   },
   "files": [
     "build/"
-  ]
+  ],
+  "devDependencies": {
+    "@types/geojson": "^7946.0.7"
+  }
 }

--- a/packages/geo/src/index.ts
+++ b/packages/geo/src/index.ts
@@ -3,4 +3,7 @@ export { Epsg, EpsgCode } from './epsg';
 export { QuadKey } from './quad.key';
 export { Tile, TileMatrixSet } from './tile.matrix.set';
 export { WmtsLayer, WmtsProvider } from './wmts/wmts';
-export * from './tms/tile.matrix.set.type';
+export { TileMatrixSetType, TileMatrixSetTypeMatrix } from './tms/tile.matrix.set.type';
+
+export * from './stac';
+export { AttributionCollection, AttributionItem, AttributionStac } from './stac/stac.attribution';

--- a/packages/geo/src/stac/index.ts
+++ b/packages/geo/src/stac/index.ts
@@ -1,13 +1,16 @@
-export const StacVersion = '1.0.0-beta.2';
-export const StacLicense = 'CC BY 4.0';
-export const StacBaseMapsExtension =
-    'https://basemaps.linz.govt.nz/json-schema/stac-basemaps-extension/1.0/schema.json';
+import type * as GeoJSON from 'geojson';
+
+export const Stac = {
+    Version: '1.0.0-beta.2',
+    License: 'CC BY 4.0',
+    BaseMapsExtension: 'https://basemaps.linz.govt.nz/json-schema/stac-basemaps-extension/1.0/schema.json',
+} as const;
 
 export interface StacLink {
     rel: string;
     href: string;
     type?: string;
-    [other: string]: any;
+    [other: string]: unknown;
 }
 
 export interface StacAsset {
@@ -49,7 +52,7 @@ export interface StacCatalog extends StacObject {
     description: string;
 }
 
-export interface StacCollection<S = Record<string, any>> extends StacCatalog {
+export interface StacCollection<S = Record<string, unknown>> extends StacCatalog {
     license: string;
 
     extent: StacExtent;

--- a/packages/geo/src/stac/stac.attribution.ts
+++ b/packages/geo/src/stac/stac.attribution.ts
@@ -1,4 +1,4 @@
-import { StacCatalog, StacCollection, StacItem } from './stac';
+import { StacCatalog, StacCollection, StacItem } from './index';
 
 /**
  * A Single File STAC compliant collection with zoom and priority for calculating attribution of an extent

--- a/packages/lambda-tiler/src/routes/__test__/attribution.test.ts
+++ b/packages/lambda-tiler/src/routes/__test__/attribution.test.ts
@@ -1,11 +1,10 @@
-import { Epsg, EpsgCode } from '@basemaps/geo';
+import { Epsg, EpsgCode, Stac } from '@basemaps/geo';
 import { GoogleTms } from '@basemaps/geo/build/tms/google';
 import { HttpHeader } from '@basemaps/lambda';
 import {
     Aws,
     NamedBounds,
     ProjectionTileMatrixSet,
-    StacLicense,
     TileMetadataImageRuleV2,
     TileMetadataImageryRecord,
     TileMetadataProviderRecord,
@@ -104,7 +103,7 @@ o.spec('attribution', () => {
                 },
                 title: 'image one',
                 description: 'image one description',
-                license: StacLicense,
+                license: Stac.License,
                 providers: [
                     {
                         name: 'p1',
@@ -277,7 +276,7 @@ o.spec('attribution', () => {
                     },
                     {
                         stac_version: '1.0.0-beta.2',
-                        license: StacLicense,
+                        license: Stac.License,
                         id: 'ir_ir_2',
                         providers: [
                             {
@@ -303,7 +302,7 @@ o.spec('attribution', () => {
                     },
                     {
                         stac_version: '1.0.0-beta.2',
-                        license: StacLicense,
+                        license: Stac.License,
                         id: 'ir_ir_3',
                         providers: [
                             {
@@ -329,7 +328,7 @@ o.spec('attribution', () => {
                     },
                     {
                         stac_version: '1.0.0-beta.2',
-                        license: StacLicense,
+                        license: Stac.License,
                         id: 'ir_ir_4',
                         providers: [{ name: 'p1' }],
                         title: 'image one',

--- a/packages/landing/src/ol.attribution.ts
+++ b/packages/landing/src/ol.attribution.ts
@@ -1,6 +1,5 @@
+import { AttributionCollection, Stac } from '@basemaps/geo';
 import { Attribution } from '@basemaps/attribution';
-import { AttributionCollection } from '@basemaps/shared/build/attribution';
-import { StacLicense } from '@basemaps/shared/build/stac';
 import { View } from 'ol';
 import { Extent } from 'ol/extent';
 import OlMap from 'ol/Map';
@@ -8,7 +7,7 @@ import MapEventType from 'ol/MapEventType';
 import Source from 'ol/source/Source';
 import { MapOptions, MapOptionType, WindowUrl } from './url';
 
-const Copyright = `© ${StacLicense} LINZ`;
+const Copyright = `© ${Stac.License} LINZ`;
 
 function sameExtent(a: Extent, b: Extent): boolean {
     if (a.length != b.length) return false;
@@ -27,7 +26,7 @@ export class OlAttribution {
     config: MapOptions;
 
     /** handle for scheduleRender setTimeout */
-    private _scheduled: any;
+    private _scheduled: number | NodeJS.Timeout | undefined;
     /** handle for scheduleRender requestAnimationFrame */
     private _raf = 0;
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,10 +18,6 @@ export * from './aws/tile.metadata.base';
 export * from './aws/tile.metadata';
 export * from './aws/tile.metadata.tileset';
 
-export * from './stac/index';
-
-export * from './attribution';
-
 export * from './file';
 
 export * from './util';


### PR DESCRIPTION
`@basemaps/shared` is getting to be quite a large library with lots of dependencies, lets only import it if we really need it.

as `@basemaps/attribution` is a library others may install, reduce the number of dependencies needed
