### PR TITLE
fix(lambda-tiler): only export the tile matrix set once per epsg code

### DIFF
--- a/packages/lambda-tiler/src/__test__/wmts.capability.test.ts
+++ b/packages/lambda-tiler/src/__test__/wmts.capability.test.ts
@@ -230,6 +230,16 @@ o.spec('WmtsCapabilities', () => {
         ts[2].tileSet.title = 'aerial_dunedin_urban';
         const nodes = new WmtsCapabilities('basemaps.test', Provider, ts, tileMatrixSetMap).toVNode();
 
+        const allMatrixes = tags(nodes, 'TileMatrixSet');
+
+        o(allMatrixes[0].children[0].textContent).equals('EPSG:2193');
+        o(allMatrixes[1].children[0].textContent).equals('EPSG:2193');
+        o(allMatrixes[2].children[0].textContent).equals('EPSG:3857');
+
+        o(allMatrixes[3].find('ows:Identifier')?.textContent).equals('EPSG:2193');
+        o(allMatrixes[4].find('ows:Identifier')?.textContent).equals('EPSG:3857');
+        o(allMatrixes.length).equals(5);
+
         const layers = tags(nodes, 'Layer');
         o(layers.length).equals(3);
 


### PR DESCRIPTION
This was creating a TileMatrixSet definition per use which was causing the file size to explode when multiple layers were used as each layer would export a copy of each TileMatrixSet they used.

