### PR TITLE
fix(landing): correct the WMTS url for arcgis users

### DIFF
--- a/packages/landing/src/__test__/hash.test.ts
+++ b/packages/landing/src/__test__/hash.test.ts
@@ -4,12 +4,12 @@ import { Epsg } from '@basemaps/geo';
 import { Config } from '../config';
 
 declare const global: {
-    window?: { location: { protocol: string; hostname: string } };
+    window?: { location: { origin: string } };
 };
 
 o.spec('WindowUrl', () => {
     o.beforeEach(() => {
-        global.window = { location: { protocol: 'https:', hostname: 'basemaps.linz.govt.nz' } };
+        global.window = { location: { origin: 'https://basemaps.linz.govt.nz' } };
     });
     o.afterEach(() => {
         delete global.window;

--- a/packages/landing/src/url.ts
+++ b/packages/landing/src/url.ts
@@ -21,12 +21,6 @@ export const enum MapOptionType {
     Attribution = 'attribution',
 }
 
-export function baseWindowUrl(): string {
-    const baseUrl = `${window.location.protocol}//${window.location.hostname}`;
-    if (window.location.port == null) return baseUrl;
-    return baseUrl + ':' + window.location.port;
-}
-
 export const WindowUrl = {
     ImageFormat: 'png',
 
@@ -82,7 +76,7 @@ export const WindowUrl = {
 
     baseUrl(): string {
         const baseUrl = Config.BaseUrl;
-        if (baseUrl === '') return baseWindowUrl();
+        if (baseUrl === '') return window.location.origin;
         if (!baseUrl.startsWith('http')) throw new Error('BaseURL must start with http(s)://');
         return baseUrl;
     },


### PR DESCRIPTION
`window.location.port == null` was failing and then causing the `:` to be added into the url even when the default port `:443` was being used.

`window.location.origin` handles the scheme, port and domain joining for us and fixes the problem