### PR TITLE
build: remove github pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,2 +1,0 @@
-Fixes: #
-_Add new line for each issue that was fixed_


### PR DESCRIPTION
Since we do not use github issues it makes no sense to show the fixed issues


