### PR TITLE
fix(attribution): disable lat/lng bounds checking until bad bounds are fixed.

### DIFF
--- a/packages/attribution/src/__tests__/attr.test.ts
+++ b/packages/attribution/src/__tests__/attr.test.ts
@@ -176,21 +176,22 @@ o.spec('Attribution', () => {
         links: [],
     };
 
-    o('should assert bounds', () => {
-        const stacCopy = JSON.parse(JSON.stringify(stac)) as AttributionStac;
+    // TODO some attribution is outside of lat/lng bounds BM-113
+    // o('should assert bounds', () => {
+    //     const stacCopy = JSON.parse(JSON.stringify(stac)) as AttributionStac;
 
-        const firstPoly = (stacCopy.features[0].geometry as GeoJSON.MultiPolygon).coordinates[0][0][0];
+    //     const firstPoly = (stacCopy.features[0].geometry as GeoJSON.MultiPolygon).coordinates[0][0][0];
 
-        firstPoly[0] = 190;
-        o(() => Attribution.fromStac(stacCopy)).throws(Error);
+    //     firstPoly[0] = 190;
+    //     o(() => Attribution.fromStac(stacCopy)).throws(Error);
 
-        firstPoly[0] = 170;
-        const ab = Attribution.fromStac(stacCopy);
-        o(ab.attributions[0].boundaries.length).equals(6);
+    //     firstPoly[0] = 170;
+    //     const ab = Attribution.fromStac(stacCopy);
+    //     o(ab.attributions[0].boundaries.length).equals(6);
 
-        firstPoly[1] = 91;
-        o(() => Attribution.fromStac(stacCopy)).throws(Error);
-    });
+    //     firstPoly[1] = 91;
+    //     o(() => Attribution.fromStac(stacCopy)).throws(Error);
+    // });
 
     o('should find correct matches', () => {
         const ab = Attribution.fromStac(stac);

--- a/packages/attribution/src/attribution.ts
+++ b/packages/attribution/src/attribution.ts
@@ -65,8 +65,9 @@ function assertRing(ring: number[][][]): asserts ring is Ring[] {
     for (const outer of ring) {
         for (const inner of outer) {
             if (inner.length !== 2) throw new Error('Invalid ring wrong length');
-            if (inner[0] < -180 || inner[0] > 180) throw new Error('Invalid ring outside of bounds');
-            if (inner[1] < -90 || inner[1] > 90) throw new Error('Invalid ring outside of bounds');
+            // TODO some attribution is outside of lat/lng bounds BM-113
+            // if (inner[0] < -180 || inner[0] > 180) throw new Error('Invalid ring outside of bounds');
+            // if (inner[1] < -90 || inner[1] > 90) throw new Error('Invalid ring outside of bounds');
         }
     }
 }


### PR DESCRIPTION
See BM-113 for more information