### PR TITLE
fix: default to basemaps.linz.govt.nz rather than tiles.basemaps.linz.govt.nz

### DIFF
--- a/packages/_infra/src/config.ts
+++ b/packages/_infra/src/config.ts
@@ -22,7 +22,7 @@ export const BaseMapsProdConfig: BaseMapsConfig = {
     Route53Zone: 'prod.basemaps.awsint.linz.govt.nz.',
     AlbPublicDns: 'int.tiles.basemaps.linz.govt.nz',
     CloudFrontDns: ['tiles.basemaps.linz.govt.nz', 'basemaps.linz.govt.nz'],
-    PublicUrlBase: 'https://tiles.basemaps.linz.govt.nz',
+    PublicUrlBase: 'https://basemaps.linz.govt.nz',
 };
 
 export const BaseMapsDevConfig: BaseMapsConfig = {
@@ -30,7 +30,7 @@ export const BaseMapsDevConfig: BaseMapsConfig = {
     Route53Zone: 'nonprod.basemaps.awsint.linz.govt.nz',
     AlbPublicDns: 'dev.int.tiles.basemaps.linz.govt.nz',
     CloudFrontDns: ['tiles.dev.basemaps.linz.govt.nz', 'dev.basemaps.linz.govt.nz'],
-    PublicUrlBase: 'https://tiles.dev.basemaps.linz.govt.nz',
+    PublicUrlBase: 'https://dev.basemaps.linz.govt.nz',
 };
 
 export function getConfig(): BaseMapsConfig {

--- a/packages/landing/static/examples/index.maplibre.compare.3857.html
+++ b/packages/landing/static/examples/index.maplibre.compare.3857.html
@@ -61,7 +61,7 @@
 
             // vector layers
             const styleUrl =
-                'https://tiles.basemaps.linz.govt.nz/v1/tiles/topographic/EPSG:3857/style/topolike.json?api=' + apiKey;
+                'https://basemaps.linz.govt.nz/v1/tiles/topographic/EPSG:3857/style/topolike.json?api=' + apiKey;
 
             // Raster layers
             const url = 'https://basemaps.linz.govt.nz/v1/tiles/aerial/EPSG:3857/{z}/{x}/{y}.webp?api=' + apiKey;

--- a/packages/landing/static/examples/index.maplibre.opacity.3857.html
+++ b/packages/landing/static/examples/index.maplibre.opacity.3857.html
@@ -83,7 +83,7 @@
 
             // vector layers
             const styleUrl =
-                'https://tiles.basemaps.linz.govt.nz/v1/tiles/topographic/EPSG:3857/style/topolike.json?api=' + apiKey;
+                'https://basemaps.linz.govt.nz/v1/tiles/topographic/EPSG:3857/style/topolike.json?api=' + apiKey;
 
             // Raster layers
             const url = 'https://basemaps.linz.govt.nz/v1/tiles/aerial/EPSG:3857/{z}/{x}/{y}.webp?api=' + apiKey;

--- a/packages/landing/static/examples/index.maplibre.vector.3857.html
+++ b/packages/landing/static/examples/index.maplibre.vector.3857.html
@@ -36,7 +36,7 @@
 
             // vector layers
             const style =
-                'https://tiles.basemaps.linz.govt.nz/v1/tiles/topographic/EPSG:3857/style/topolike.json?api=' + apiKey;
+                'https://basemaps.linz.govt.nz/v1/tiles/topographic/EPSG:3857/style/topolike.json?api=' + apiKey;
             var map = new maplibregl.Map({
                 container: 'map', // container id
                 style: style, // style URL


### PR DESCRIPTION
This fixes a inconsistency where some things are pointing to `tiles.` and some are not