### PR TITLE
fix(lambda-tiler): bundle farmhash correctly

### DIFF
--- a/packages/lambda-tiler/bundle.sh
+++ b/packages/lambda-tiler/bundle.sh
@@ -7,4 +7,4 @@ cd dist
 cp ../package.json .
 cp -r ../static .
 # @see https://sharp.pixelplumbing.com/en/stable/install/#aws-lambda
-npm install --arch=x64 --platform=linux sharp
+npm install --arch=x64 --platform=linux sharp farmhash

--- a/packages/lambda-tiler/package.json
+++ b/packages/lambda-tiler/package.json
@@ -24,6 +24,7 @@
     "@cogeotiff/source-aws": "^4.3.0",
     "@cotar/core": "3.0.0",
     "@linzjs/geojson": "^6.0.0",
+    "farmhash": "^3.2.1",
     "path-to-regexp": "^6.1.0",
     "pixelmatch": "^5.1.0",
     "sharp": "^0.28.1"
@@ -34,7 +35,8 @@
     "external": [
       "aws-sdk",
       "pino-pretty",
-      "sharp"
+      "sharp",
+      "farmhash"
     ]
   },
   "scripts": {

--- a/scripts/bundle.js
+++ b/scripts/bundle.js
@@ -71,7 +71,12 @@ function bundleJs(basePath, cfg, outfile) {
         joinPath(basePath, cfg.entry),
     ];
 
-    cp.spawnSync('npx', buildCmd);
+    const res = cp.spawnSync('npx', buildCmd);
+    if (res.status > 0) {
+        console.log('BuildCommandFailed', buildCmd);
+        console.log(res.stderr.toString().trim());
+        process.exit(1);
+    }
 
     const fileData = fs.readFileSync(outfile).toString();
     console.log('Bundled', (fileData.length / 1024).toFixed(2), 'KB');


### PR DESCRIPTION
`farmhash` is a c lib and needs to be bundled as a c lib 