### PR TITLE
feat(infra): move lambda into the same VPC as the ALB

### DIFF
--- a/packages/_infra/src/serve/index.ts
+++ b/packages/_infra/src/serve/index.ts
@@ -20,15 +20,16 @@ export class ServeStack extends cdk.Stack {
         super(scope, id, props);
 
         const config = getConfig();
+        const vpc = ec2.Vpc.fromLookup(this, 'AlbVpc', { tags: { default: 'true' } });
+
         /**
          * WARNING: changing this lambda name while attached to a alb will cause cloudformation to die
          * see: https://github.com/aws/aws-cdk/issues/8253
          */
-        const lambda = new LambdaTiler(this, 'LambdaTiler');
+        const lambda = new LambdaTiler(this, 'LambdaTiler', { vpc });
         const table = new TileMetadataTable(this, 'TileMetadata');
         table.table.grantReadData(lambda.lambda);
 
-        const vpc = ec2.Vpc.fromLookup(this, 'AlbVpc', { tags: { default: 'true' } });
         const lb = new elbv2.ApplicationLoadBalancer(this, 'LB', { vpc, internetFacing: false });
 
         const targetLambda = new targets.LambdaTarget(lambda.lambda);

--- a/packages/_infra/src/serve/lambda.tiler.ts
+++ b/packages/_infra/src/serve/lambda.tiler.ts
@@ -1,13 +1,17 @@
-import cdk = require('@aws-cdk/core');
-import lambda = require('@aws-cdk/aws-lambda');
-import s3 = require('@aws-cdk/aws-s3');
-
+import { IVpc } from '@aws-cdk/aws-ec2';
+import * as lambda from '@aws-cdk/aws-lambda';
 import { RetentionDays } from '@aws-cdk/aws-logs';
+import * as s3 from '@aws-cdk/aws-s3';
+import * as cdk from '@aws-cdk/core';
 import { Duration } from '@aws-cdk/core';
 import { Env } from '@basemaps/shared';
 import { getConfig } from '../config';
 
 const CODE_PATH = '../lambda-tiler/dist';
+
+export interface LambdaTilerProps {
+    vpc: IVpc;
+}
 /**
  * Create a API Key validation edge lambda
  */
@@ -15,7 +19,7 @@ export class LambdaTiler extends cdk.Construct {
     public lambda: lambda.Function;
     public version: lambda.Version;
 
-    public constructor(scope: cdk.Stack, id: string) {
+    public constructor(scope: cdk.Stack, id: string, props: LambdaTilerProps) {
         super(scope, id);
 
         const config = getConfig();
@@ -24,6 +28,7 @@ export class LambdaTiler extends cdk.Construct {
          * see: https://github.com/aws/aws-cdk/issues/8253
          */
         this.lambda = new lambda.Function(this, 'Tiler', {
+            vpc: props.vpc,
             runtime: lambda.Runtime.NODEJS_14_X,
             memorySize: 2048,
             timeout: Duration.seconds(60),


### PR DESCRIPTION
From some inital performance testing this greatly reduces the time for the lambda to serve a tile as it does not have to traverse multiple networks between LINZ, ALB and VPCs