### PR TITLE
fix(config): do not cache tile sets forever as they can be updated

### DIFF
--- a/packages/config/src/dynamo/dynamo.config.ts
+++ b/packages/config/src/dynamo/dynamo.config.ts
@@ -7,6 +7,7 @@ import { ConfigProvider } from '../config/provider';
 import { ConfigLayer, ConfigTileSet, ConfigTileSetRaster, ConfigTileSetVector, TileSetType } from '../config/tile.set';
 import { ConfigVectorStyle } from '../config/vector.style';
 import { ConfigDynamoCached } from './dynamo.config.cached';
+import { ConfigDynamoBase } from './dynamo.config.base';
 
 export class ConfigDynamo {
     Prefix = ConfigPrefix;
@@ -76,7 +77,7 @@ export class ConfigDynamoImagery extends ConfigDynamoCached<ConfigImagery> {
     }
 }
 
-export class ConfigDynamoTileSet extends ConfigDynamoCached<ConfigTileSet> {
+export class ConfigDynamoTileSet extends ConfigDynamoBase<ConfigTileSet> {
     isRaster(x: ConfigTileSet | null | undefined): x is ConfigTileSetRaster {
         if (x == null) return false;
         return x.type == null || x.type === TileSetType.Raster;

--- a/packages/lambda-tiler/src/cli/serve.ts
+++ b/packages/lambda-tiler/src/cli/serve.ts
@@ -110,7 +110,7 @@ async function useLocal(): Promise<void> {
         const requestId = ulid.ulid();
         const logger = LogConfig.get().child({ id: requestId });
 
-        const tileSets = await Promise.all([...TileSets.cache.values()]);
+        const tileSets = await Promise.all([...TileSets.cache.values()].map((c) => c.value));
         const xml = WmtsCapabilities.toXml(
             Env.get(Env.PublicUrlBase) ?? '',
             Provider,

--- a/packages/lambda-tiler/src/tile.set.cache.ts
+++ b/packages/lambda-tiler/src/tile.set.cache.ts
@@ -6,7 +6,13 @@ import { TileSetRaster } from './tile.set.raster';
 import { TileSetVector } from './tile.set.vector';
 
 export class TileSetCache {
-    cache: Map<string, Promise<TileSet | null>> = new Map();
+    /** Duration to cache tile sets for */
+    CacheTime = 30_000;
+
+    /** Cache the fetch requests */
+    cache: Map<string, { time: number; value: Promise<TileSet | null> }> = new Map();
+    /** Cache initialized tile sets */
+    tileSets: Map<string, TileSet> = new Map();
 
     id(tileSet: TileSet): string;
     id(name: string, tileMatrix: TileMatrixSet): string;
@@ -22,17 +28,19 @@ export class TileSetCache {
     add(tileSet: TileSet): void {
         const id = this.id(tileSet);
         if (this.cache.has(id)) throw new Error('Trying to add duplicate tile set:' + id);
-        this.cache.set(id, Promise.resolve(tileSet));
+        this.cache.set(id, { time: Date.now(), value: Promise.resolve(tileSet) });
     }
 
     get(name: string, tileMatrix: TileMatrixSet): Promise<TileSet | null> {
         const tsId = this.id(name, tileMatrix);
         let existing = this.cache.get(tsId);
-        if (existing == null) {
-            existing = this.loadTileSet(name, tileMatrix);
+        // Validate the data is current every ~30 seconds
+        if (existing == null || Date.now() - existing.time > this.CacheTime) {
+            const value = this.loadTileSet(name, tileMatrix);
+            existing = { time: Date.now(), value };
             this.cache.set(tsId, existing);
         }
-        return existing;
+        return existing.value;
     }
 
     async loadTileSet(name: string, tileMatrix: TileMatrixSet): Promise<TileSet | null> {
@@ -53,13 +61,22 @@ export class TileSetCache {
             return null;
         }
 
+        // If we already have a copy and it hasn't been modified just return it
+        const existing = this.tileSets.get(tileSet.id);
+        if (existing?.tileSet.updatedAt === tileSet.updatedAt) {
+            return existing;
+        }
+
         if (Config.TileSet.isRaster(tileSet)) {
             const ts = new TileSetRaster(name, tileMatrix);
             await ts.init(tileSet);
+            this.tileSets.set(tileSet.id, ts);
             return ts;
         }
+
         const ts = new TileSetVector(name, tileMatrix);
         ts.tileSet = tileSet;
+        this.tileSets.set(tileSet.id, ts);
         return ts;
     }
 


### PR DESCRIPTION
This fixes a issue where a database update is applied but some lambdas will hold onto the old config until they get restarted