### PR TITLE
build(deps): linzjs/lambda 1.1.0

### DIFF
--- a/packages/lambda-tiler/package.json
+++ b/packages/lambda-tiler/package.json
@@ -26,7 +26,7 @@
     "@cogeotiff/source-aws": "^4.3.0",
     "@cotar/core": "3.1.0",
     "@linzjs/geojson": "^6.0.0",
-    "@linzjs/lambda": "^0.3.2",
+    "@linzjs/lambda": "^1.1.0",
     "farmhash": "^3.2.1",
     "path-to-regexp": "^6.1.0",
     "pixelmatch": "^5.1.0",

--- a/packages/lambda-tiler/src/__test__/index.test.ts
+++ b/packages/lambda-tiler/src/__test__/index.test.ts
@@ -1,5 +1,6 @@
 import { LogConfig } from '@basemaps/shared';
 import { LambdaAlbRequest, LambdaHttpRequest } from '@linzjs/lambda';
+import { Context } from 'aws-lambda';
 import o from 'ospec';
 import { handleRequest } from '../index';
 
@@ -13,6 +14,7 @@ o.spec('LambdaXyz index', () => {
                 body: null,
                 isBase64Encoded: false,
             },
+            {} as Context,
             LogConfig.get(),
         );
     }

--- a/packages/lambda-tiler/src/__test__/xyz.test.ts
+++ b/packages/lambda-tiler/src/__test__/xyz.test.ts
@@ -71,7 +71,7 @@ o.spec('LambdaXyz', () => {
             o(res.status).equals(200);
             o(res.header('content-type')).equals('image/png');
             o(res.header('eTaG')).equals('foo');
-            o(res.getBody()).equals(rasterMockBuffer.toString('base64'));
+            o(res.body).equals(rasterMockBuffer.toString('base64'));
 
             // Validate the session information has been set correctly
             o(request.logContext['tileSet']).equals(tileSetName);
@@ -86,7 +86,7 @@ o.spec('LambdaXyz', () => {
         o(res.status).equals(200);
         o(res.header('content-type')).equals('image/webp');
         o(res.header('eTaG')).equals('foo');
-        o(res.getBody()).equals(rasterMockBuffer.toString('base64'));
+        o(res.body).equals(rasterMockBuffer.toString('base64'));
 
         // Validate the session information has been set correctly
         o(request.logContext['xyz']).deepEquals({ x: 0, y: 0, z: 0 });
@@ -173,7 +173,7 @@ o.spec('LambdaXyz', () => {
             o(res.header('content-type')).equals('text/xml');
             o(res.header('cache-control')).equals('max-age=0');
 
-            const body = Buffer.from(res.getBody() ?? '', 'base64').toString();
+            const body = Buffer.from(res.body ?? '', 'base64').toString();
             o(body.slice(0, 100)).equals(
                 '<?xml version="1.0"?>\n' +
                     '<Capabilities xmlns="http://www.opengis.net/wmts/1.0" xmlns:ows="http://www.op',
@@ -220,7 +220,7 @@ o.spec('LambdaXyz', () => {
             o(res.header('content-type')).equals('application/json');
             o(res.header('cache-control')).equals('max-age=120');
 
-            const body = Buffer.from(res.getBody() ?? '', 'base64').toString();
+            const body = Buffer.from(res.body ?? '', 'base64').toString();
             o(JSON.parse(body)).deepEquals({
                 tiles: [`https://tiles.test/v1/tiles/topolike/Google/{z}/{x}/{y}.pbf?api=${apiKey}`],
                 minzoom: 0,
@@ -306,7 +306,7 @@ o.spec('LambdaXyz', () => {
             o(res.header('content-type')).equals('application/json');
             o(res.header('cache-control')).equals('max-age=120');
 
-            const body = Buffer.from(res.getBody() ?? '', 'base64').toString();
+            const body = Buffer.from(res.body ?? '', 'base64').toString();
             fakeStyle.sources.basemaps_vector = {
                 type: 'vector',
                 url: 'https://tiles.test/v1/tiles/topolike/Google/tile.json?api=' + apiKey,

--- a/packages/lambda-tiler/src/__test__/xyz.util.ts
+++ b/packages/lambda-tiler/src/__test__/xyz.util.ts
@@ -3,6 +3,7 @@ import { TileMatrixSet } from '@basemaps/geo';
 import { LambdaHttpRequest, LambdaAlbRequest } from '@linzjs/lambda';
 import { LogConfig } from '@basemaps/shared';
 import { TileSetRaster } from '../tile.set.raster';
+import { Context } from 'aws-lambda';
 
 export function mockRequest(path: string, method = 'get', headers: Record<string, string> = {}): LambdaHttpRequest {
     return new LambdaAlbRequest(
@@ -14,6 +15,7 @@ export function mockRequest(path: string, method = 'get', headers: Record<string
             body: null,
             isBase64Encoded: false,
         },
+        {} as Context,
         LogConfig.get(),
     );
 }

--- a/packages/lambda-tiler/src/cli/dump.ts
+++ b/packages/lambda-tiler/src/cli/dump.ts
@@ -8,6 +8,7 @@ import { tile } from '../routes/tile';
 import { TileSet } from '../tile.set';
 import { TileSets } from '../tile.set.cache';
 import { TileSetLocal } from './tile.set.local';
+import { Context } from 'aws-lambda';
 
 if (process.stdout.isTTY) LogConfig.setOutputStream(PrettyTransform.stream());
 
@@ -46,6 +47,7 @@ async function main(): Promise<void> {
             httpMethod: 'get',
             path: `/v1/tiles/${tileSet.fullName}/${tileMatrix.identifier}/${xyz.z}/${xyz.x}/${xyz.y}.${ext}`,
         } as any,
+        {} as Context,
         logger,
     );
 

--- a/packages/lambda-tiler/src/cli/serve.ts
+++ b/packages/lambda-tiler/src/cli/serve.ts
@@ -11,6 +11,7 @@ import { TileSetRaster } from '../tile.set.raster';
 import { WmtsCapabilities } from '../wmts.capability';
 import { Provider } from '../__test__/xyz.util';
 import { TileSetLocal } from './tile.set.local';
+import { Context } from 'aws-lambda';
 
 const app = express();
 const port = Env.getNumber('PORT', 5050);
@@ -60,6 +61,7 @@ function useAws(): void {
                 path: req.path,
                 queryStringParameters: req.query,
             } as any,
+            { awsRequestId: requestId } as Context,
             logger,
         );
         const ifNoneMatch = req.header(HttpHeader.IfNoneMatch);
@@ -100,6 +102,8 @@ async function useLocal(): Promise<void> {
                 httpMethod: 'get',
                 path: `/v1/tiles/${imageryName}/${projection}/${z}/${x}/${y}.${ext}`,
             } as any,
+            {} as Context,
+
             logger,
         );
         await handleRequest(ctx, res, startTime, logger, { tile: { x, y, z } });

--- a/packages/lambda-tiler/src/index.ts
+++ b/packages/lambda-tiler/src/index.ts
@@ -1,4 +1,4 @@
-import { LambdaFunction, LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambda';
+import { lf, LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambda';
 import { LogConfig } from '@basemaps/shared';
 import { Ping, Version } from './routes/api';
 import { Health } from './routes/health';
@@ -17,4 +17,4 @@ export async function handleRequest(req: LambdaHttpRequest): Promise<LambdaHttpR
     return await app.handle(req);
 }
 
-export const handler = LambdaFunction.wrap(handleRequest, LogConfig.get());
+export const handler = lf.http(handleRequest, LogConfig.get());

--- a/packages/lambda-tiler/src/routes/__test__/health.test.ts
+++ b/packages/lambda-tiler/src/routes/__test__/health.test.ts
@@ -5,6 +5,7 @@ import * as Tile from '../tile';
 import { getExpectedTileName, Health, TestTiles } from '../health';
 import { LambdaAlbRequest, LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambda';
 import { LogConfig } from '@basemaps/shared';
+import { Context } from 'aws-lambda';
 
 const ctx: LambdaHttpRequest = new LambdaAlbRequest(
     {
@@ -14,6 +15,7 @@ const ctx: LambdaHttpRequest = new LambdaAlbRequest(
         body: null,
         isBase64Encoded: false,
     },
+    {} as Context,
     LogConfig.get(),
 );
 

--- a/packages/lambda-tiler/src/routes/health.ts
+++ b/packages/lambda-tiler/src/routes/health.ts
@@ -6,6 +6,7 @@ import { Epsg, Tile } from '@basemaps/geo';
 import { LambdaHttpResponse, LambdaHttpRequest, HttpHeader, LambdaAlbRequest } from '@linzjs/lambda';
 import { ImageFormat } from '@basemaps/tiler';
 import { tile } from './tile';
+import { Context } from 'aws-lambda';
 
 export function getExpectedTileName(projection: Epsg, tile: Tile, format: ImageFormat): string {
     // Bundle static files are at the same directory with index.js
@@ -71,14 +72,15 @@ export async function Health(req: LambdaHttpRequest): Promise<LambdaHttpResponse
                 body: null,
                 isBase64Encoded: false,
             },
+            {} as Context,
             req.log,
         );
 
         // Get the parse response tile to raw buffer
         const response = await tile(ctx);
         if (response.status !== 200) return new LambdaHttpResponse(response.status, response.statusDescription);
-        if (!Buffer.isBuffer(response.body)) throw new LambdaHttpResponse(404, 'Not a Buffer response content.');
-        const resImgBuffer = await Sharp(response.body).raw().toBuffer();
+        if (!Buffer.isBuffer(response._body)) throw new LambdaHttpResponse(404, 'Not a Buffer response content.');
+        const resImgBuffer = await Sharp(response._body).raw().toBuffer();
 
         // Get test tile to compare
         const testBuffer = await getTestBuffer(test);

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -32,7 +32,7 @@
     "@basemaps/geo": "^6.8.0",
     "@basemaps/lambda-tiler": "^6.8.0",
     "@basemaps/shared": "^6.8.0",
-    "@linzjs/lambda": "^0.3.2",
+    "@linzjs/lambda": "^1.1.0",
     "@oclif/command": "^1.8.0",
     "express": "^4.17.1",
     "pretty-json-log": "^0.3.2"

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -3,6 +3,7 @@ import { handleRequest } from '@basemaps/lambda-tiler';
 import * as ulid from 'ulid';
 import express from 'express';
 import { LogConfig } from '@basemaps/shared';
+import { Context } from 'aws-lambda';
 
 export const BasemapsServer = express();
 
@@ -16,6 +17,7 @@ BasemapsServer.get('/v1/*', async (req: express.Request, res: express.Response) 
             path: req.path,
             queryStringParameters: req.query,
         } as any,
+        {} as Context,
         logger,
     );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1542,14 +1542,14 @@
     npmlog "^4.1.2"
     write-file-atomic "^3.0.3"
 
-"@linzjs/lambda@^0.3.2":
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/@linzjs/lambda/-/lambda-0.3.2.tgz#becc4b4ef14e2b6156c150193308804591d3431d"
-  integrity sha512-vAV8Bx/PssY6kNmfZ0+jaqz3q0EIRSe12B08eymlC52Uvkdv0ht1iLtZokdGRAywM+ZiKczSE3F8WvB/+zOijQ==
+"@linzjs/lambda@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@linzjs/lambda/-/lambda-1.1.0.tgz#d3fb69386ddb6b4586c00f5143ed6842aa24e561"
+  integrity sha512-5rUz2vlkBvATmRGVnRjRPg58/HkAvfIz9nhaarik6sKb/7M9vqG0EMnSER3+Cmi0rvWjUMew3BZpPO1C8ekG8w==
   dependencies:
     "@linzjs/metrics" "^6.0.0"
     "@types/pino" "^6.3.11"
-    pino "^6.13.0"
+    pino "^6.13.1"
     ulid "^2.3.0"
 
 "@linzjs/lui@^6.0.0":
@@ -4145,6 +4145,11 @@ fast-safe-stringify@^2.0.8:
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.8.tgz#dc2af48c46cf712b683e849b2bbd446b32de936f"
   integrity sha512-lXatBjf3WPjmWD6DpIZxkeSsCOwqI0maYMpgDlx8g4U2qi4lbjA9oH/HD2a87G+KfsUmo5WbJFmqBZlPxtptag==
 
+fastify-warning@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/fastify-warning/-/fastify-warning-0.2.0.tgz#e717776026a4493dc9a2befa44db6d17f618008f"
+  integrity sha512-s1EQguBw/9qtc1p/WTY4eq9WMRIACkj+HTcOIK1in4MV5aFaQC9ZCIt0dJ7pr5bIf4lPpHvAtP2ywpTNgs7hqw==
+
 fastq@^1.6.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.8.0.tgz#550e1f9f59bbc65fe185cb6a9b4d95357107f481"
@@ -6701,13 +6706,14 @@ pino-std-serializers@^3.1.0:
   resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-3.1.0.tgz#fe62d339aeef359d9d7bdf61f4e4b2d7be8c73d4"
   integrity sha512-Fk1pxhX6tuW4ozRDFw5Mz/IHQV5wXYXZwjG/gOpTNPCbYEMeNW9VnKAEu1428CwAQVupFruOr1vkC/ufmcwedA==
 
-pino@^6.13.0:
-  version "6.13.0"
-  resolved "https://registry.yarnpkg.com/pino/-/pino-6.13.0.tgz#41810b9be213af6f8f7c23a1b17058d880267e7b"
-  integrity sha512-mRXSTfa34tbfrWqCIp1sUpZLqBhcoaGapoyxfEwaWwJGMpLijlRdDKIQUyvq4M3DUfFH5vEglwSw8POZYwbThA==
+pino@^6.13.1:
+  version "6.13.2"
+  resolved "https://registry.yarnpkg.com/pino/-/pino-6.13.2.tgz#948a0fcadca668f3b5fb8a427f2854b08661eccf"
+  integrity sha512-vmD/cabJ4xKqo9GVuAoAEeQhra8XJ7YydPV/JyIP+0zDtFTu5JSKdtt8eksGVWKtTSrNGcRrzJ4/IzvUWep3FA==
   dependencies:
     fast-redact "^3.0.0"
     fast-safe-stringify "^2.0.8"
+    fastify-warning "^0.2.0"
     flatstr "^1.0.12"
     pino-std-serializers "^3.1.0"
     quick-format-unescaped "^4.0.3"


### PR DESCRIPTION
This forces query strings to be lower cased to allow `?api=foo&API=bar`