### PR TITLE
feat(server): add ability to serve a folder full of tiffs

### DIFF
--- a/packages/lambda-tiler/src/cli/tile.set.local.ts
+++ b/packages/lambda-tiler/src/cli/tile.set.local.ts
@@ -1,8 +1,6 @@
 import { Epsg, GoogleTms, TileMatrixSets } from '@basemaps/geo';
 import { fsa, LogConfig } from '@basemaps/shared';
 import { CogTiff, TiffTagGeo } from '@cogeotiff/core';
-import { promises as fsPromises } from 'fs';
-import { join } from 'path';
 import { TileSetRaster } from '../tile.set.raster.js';
 
 function isTiff(fileName: string): boolean {

--- a/packages/lambda-tiler/src/cli/tile.set.local.ts
+++ b/packages/lambda-tiler/src/cli/tile.set.local.ts
@@ -31,20 +31,7 @@ export class TileSetLocal extends TileSetRaster {
 
     const fileList = isTiff(this.filePath) ? [this.filePath] : await fsa.toArray(fsa.list(this.filePath));
     const files = fileList.filter(isTiff);
-    if (files.length === 0 && !this.filePath.startsWith('s3://')) {
-      for (const dir of fileList.sort()) {
-        const st = await fsPromises.stat(dir);
-        if (st.isDirectory()) {
-          for (const file of await fsPromises.readdir(dir)) {
-            const filePath = join(dir, file);
-            if (isTiff(filePath)) files.push(filePath);
-          }
-        }
-      }
-    }
-    if (files.length === 0) {
-      throw new Error(`No tiff files found in ${this.filePath}`);
-    }
+    if (files.length === 0) throw new Error(`No tiff files found in ${this.filePath}`);
 
     this.tiffs = files.map((filePath) => new CogTiff(fsa.source(filePath)));
 

--- a/packages/lambda-tiler/src/tile.set.cache.ts
+++ b/packages/lambda-tiler/src/tile.set.cache.ts
@@ -25,17 +25,17 @@ export class TileSetCache {
     return `${name.fullName}_${name.tileMatrix.identifier}`;
   }
 
-  add(tileSet: TileSet): void {
+  add(tileSet: TileSet, expiresAt = Date.now() + this.CacheTime): void {
     const id = this.id(tileSet);
     if (this.cache.has(id)) throw new Error('Trying to add duplicate tile set:' + id);
-    this.cache.set(id, { time: Date.now(), value: Promise.resolve(tileSet) });
+    this.cache.set(id, { time: expiresAt, value: Promise.resolve(tileSet) });
   }
 
   get(name: string, tileMatrix: TileMatrixSet): Promise<TileSet | null> {
     const tsId = this.id(name, tileMatrix);
     let existing = this.cache.get(tsId);
     // Validate the data is current every ~30 seconds
-    if (existing == null || Date.now() - existing.time > this.CacheTime) {
+    if (existing == null || Date.now() - existing.time > 0) {
       const value = this.loadTileSet(name, tileMatrix);
       existing = { time: Date.now(), value };
       this.cache.set(tsId, existing);

--- a/packages/lambda-tiler/src/tile.set.raster.ts
+++ b/packages/lambda-tiler/src/tile.set.raster.ts
@@ -137,6 +137,7 @@ export class TileSetRaster extends TileSetHandler<ConfigTileSetRaster> {
 
       const imagery = this.imagery.get(imgId);
       if (imagery == null) {
+        console.log('Failed', { imagery, i: this.imagery, ts: this.tileSet.layers });
         log?.warn(
           { layer: layer.name, projection: this.tileMatrix.projection.code, imgId },
           'Failed to lookup imagery',

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -1,11 +1,26 @@
 // Configure the logging before importing everything
-import { ConfigPrefix, ConfigProviderMemory, parseRgba } from '@basemaps/config';
+import { ConfigPrefix, ConfigProvider, ConfigProviderMemory, parseRgba } from '@basemaps/config';
+import { TileSetLocal } from '@basemaps/lambda-tiler/build/cli/tile.set.local.js';
+import { TileSets } from '@basemaps/lambda-tiler/build/tile.set.cache.js';
 import { Config, Env, LogConfig } from '@basemaps/shared';
 import { fsa } from '@linzjs/s3fs';
 import { Command, flags } from '@oclif/command';
+import { basename, dirname } from 'path';
 import { BasemapsServer } from './server.js';
 
 const logger = LogConfig.get();
+
+const BaseProvider: ConfigProvider = {
+  id: 'pv_linz',
+  version: 1,
+  serviceIdentification: {},
+  serviceProvider: {
+    name: '@basemaps/server',
+    contact: {
+      address: {},
+    },
+  },
+} as any;
 
 export class BasemapsServerCommand extends Command {
   static description = 'Create a WMTS/XYZ Tile server for basemaps config';
@@ -25,8 +40,27 @@ export class BasemapsServerCommand extends Command {
 
     const config = new ConfigProviderMemory();
     Config.setConfigProvider(config);
+
+    const tifSets = new Map<string, TileSetLocal>();
+
     for await (const file of fsa.listDetails(args.configPath)) {
-      if (!file.path.endsWith('.json')) continue;
+      const lowerPath = file.path.toLowerCase();
+      if (lowerPath.endsWith('.tiff') || lowerPath.endsWith('.tif')) {
+        const tiffPath = dirname(file.path);
+        if (tifSets.has(tiffPath)) continue;
+
+        const tileSet = basename(tiffPath);
+        const tsl = new TileSetLocal(tileSet, tiffPath);
+
+        await tsl.load();
+        TileSets.add(tsl, new Date('3000-01-01').getTime());
+
+        const wmtsUrl = `${ServerUrl}/v1/tiles/${tileSet}/WMTSCapabilities.xml`;
+        logger.info({ tileSetId: tileSet, wmtsUrl }, 'TileSet:Loaded');
+        if (!config.objects.has('pv_linz')) config.put(BaseProvider);
+      }
+
+      if (!lowerPath.endsWith('.json')) continue;
       logger.trace({ path: file.path, size: file.size }, 'Config:Load');
 
       const jsonData = await fsa.read(file.path).then((c) => JSON.parse(c.toString()));

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -15,7 +15,7 @@ const BaseProvider: ConfigProvider = {
   version: 1,
   serviceIdentification: {},
   serviceProvider: {
-    name: '@basemaps/server',
+    name: 'basemaps/server',
     contact: {
       address: {},
     },


### PR DESCRIPTION
`basemaps-server` CLI can now be pointed at a folder of COGs

```
./basemaps-server /home/blacha/cogs
```

aswell as being pointed at the basemaps configuration repo

```
./basemaps-server /home/blacha/basemaps-config/config
```

