### PR TITLE
fix(cli): work around certificate issues

### DIFF
--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -2,7 +2,11 @@ FROM osgeo/gdal:ubuntu-small-3.3.0
 
 WORKDIR /usr/src/app
 
-RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && apt-get install nodejs -y
+RUN apt-get update
+RUN apt-get install -y openssl ca-certificates > /dev/null 2>&1
+RUN update-ca-certificates
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+RUN apt-get install -y nodejs
 
 COPY dist/* ./
 


### PR DESCRIPTION
Docker build is currently broken due

> @basemaps/infra:   Certificate verification failed: The certificate is NOT trusted. The certificate chain uses expired certificate.  Could not handshake: Error in the certificate verification. [IP: 23.222.12.50 443]


This is caused by https://github.com/nodesource/distributions/issues/1266

We can remove this workaround once it is fixed upstream