### PR TITLE
fix(server): use default of local file system for unknown paths

### DIFF
--- a/packages/shared/src/file/index.ts
+++ b/packages/shared/src/file/index.ts
@@ -43,3 +43,9 @@ fsa.configure = function configure(cfg: FileConfig): void {
   const bucketUri = `s3://${bucket}/`;
   this.register(bucketUri, FsAwsS3.fromRoleArn(cfg.roleArn, cfg.externalId));
 };
+
+/**
+ *  Default to using the file handler useful for folders like
+ * "C:\" or "directory_name/sub_directory"
+ */
+fsa.register('', fsa.get('file://'));


### PR DESCRIPTION
this fixes a issue where the server cannot find tiffs in paths like "some_folder/foo.tiff" or "c:\bar.tiff"
