### PR TITLE
feat(infrastructure): increase performance of lambda function

### DIFF
--- a/packages/_infra/src/serve/lambda.tiler.ts
+++ b/packages/_infra/src/serve/lambda.tiler.ts
@@ -30,7 +30,7 @@ export class LambdaTiler extends cdk.Construct {
     this.lambda = new lambda.Function(this, 'Tiler', {
       vpc: props.vpc,
       runtime: lambda.Runtime.NODEJS_14_X,
-      memorySize: 2048,
+      memorySize: 4096,
       timeout: Duration.seconds(60),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(CODE_PATH),


### PR DESCRIPTION
Increasing memory size increases the cpu count used for image recompression
