### PR TITLE
perf: lower the lambda size as the timeout bug has been fixed

### DIFF
--- a/packages/_infra/src/serve/lambda.tiler.ts
+++ b/packages/_infra/src/serve/lambda.tiler.ts
@@ -30,7 +30,7 @@ export class LambdaTiler extends cdk.Construct {
     this.lambda = new lambda.Function(this, 'Tiler', {
       vpc: props.vpc,
       runtime: lambda.Runtime.NODEJS_14_X,
-      memorySize: 4096,
+      memorySize: 2048,
       timeout: Duration.seconds(60),
       handler: 'index.handler',
       code: lambda.Code.fromAsset(CODE_PATH),


### PR DESCRIPTION
This cache size change means the lambda's no longer run out of memory #1882 