### PR TITLE
fix(landing): load the correct layer on first load

### DIFF
--- a/packages/landing/src/components/map.tsx
+++ b/packages/landing/src/components/map.tsx
@@ -31,6 +31,8 @@ export class Basemaps extends Component {
   };
 
   componentDidMount(): void {
+    // Force the URL to be read before loading the map
+    Config.map.updateFromUrl();
     this.el = document.getElementById('map') as HTMLDivElement;
 
     if (this.el == null) throw new Error('Unable to find #map element');


### PR DESCRIPTION
Rather than starting to load aerial imagery then switching to the "correct" layer
