### PR TITLE
fix(lambda-tiler): p-limit is a needed dependency

### DIFF
--- a/packages/bathymetry/src/bathy.maker.ts
+++ b/packages/bathymetry/src/bathy.maker.ts
@@ -3,7 +3,7 @@ import { GdalCommand } from '@basemaps/cli/build/gdal/gdal.command.js';
 import { Bounds, Epsg, Tile, TileMatrixSet } from '@basemaps/geo';
 import { fsa, LogType, s3ToVsis3 } from '@basemaps/shared';
 import * as os from 'os';
-import type { Limit } from 'p-limit';
+import type { LimitFunction } from 'p-limit';
 import PLimit from 'p-limit';
 import * as path from 'path';
 import { basename } from 'path';
@@ -50,7 +50,7 @@ export class BathyMaker {
   /** Current gdal version @see Gdal.version */
   gdalVersion: Promise<string>;
   /** Concurrent limiting queue, all work should be done inside the queue */
-  q: Limit;
+  q: LimitFunction;
 
   constructor(ctx: BathyMakerContext) {
     this.config = { ...BathyMakerContextDefault, ...ctx };

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,7 +46,7 @@
     "@linzjs/geojson": "^6.10.0",
     "@rushstack/ts-command-line": "^4.3.13",
     "ansi-colors": "^4.1.1",
-    "p-limit": "^3.0.1",
+    "p-limit": "^4.0.0",
     "pretty-json-log": "^1.0.0",
     "zod": "^3.2.0"
   },

--- a/packages/cli/src/cog/builder.ts
+++ b/packages/cli/src/cog/builder.ts
@@ -4,7 +4,7 @@ import { ChunkSource } from '@chunkd/core';
 import { CogTiff, TiffTag, TiffTagGeo } from '@cogeotiff/core';
 import { createHash } from 'crypto';
 import { existsSync, mkdirSync } from 'fs';
-import pLimit from 'p-limit';
+import pLimit, { LimitFunction } from 'p-limit';
 import * as path from 'path';
 import { basename } from 'path';
 import { Cutline } from './cutline.js'; //
@@ -34,7 +34,7 @@ export function guessProjection(wkt: string | null): Epsg | null {
 }
 
 export class CogBuilder {
-  q: pLimit.Limit;
+  q: LimitFunction;
   logger: LogType;
   targetTms: TileMatrixSet;
   srcProj?: Epsg;

--- a/packages/lambda-tiler/package.json
+++ b/packages/lambda-tiler/package.json
@@ -33,6 +33,7 @@
     "@cotar/core": "^5.0.1",
     "@linzjs/geojson": "^6.10.0",
     "@linzjs/lambda": "^2.0.0",
+    "p-limit": "^4.0.0",
     "path-to-regexp": "^6.1.0",
     "pixelmatch": "^5.1.0",
     "sharp": "^0.28.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6771,12 +6771,12 @@ p-limit@^2.2.0:
   dependencies:
     p-try "^2.0.0"
 
-p-limit@^3.0.1:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-3.1.0.tgz#e1daccbe78d0d1388ca18c64fea38e3e57e3706b"
-  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+p-limit@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-4.0.0.tgz#914af6544ed32bfa54670b061cafcbd04984b644"
+  integrity sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==
   dependencies:
-    yocto-queue "^0.1.0"
+    yocto-queue "^1.0.0"
 
 p-locate@^2.0.0:
   version "2.0.0"
@@ -9205,10 +9205,10 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yocto-queue@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
-  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+yocto-queue@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
+  integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
 zip-stream@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
p-limit is needed to run the basemaps server but its not listed as a dependency

```
npm install @basemaps/server
npx basemaps-server foo // "Cannot find package 'p-limit'"
````