### PR TITLE
Revert "release: v6.21.0 (#2104)"

### DIFF
--- a/packages/_infra/package.json
+++ b/packages/_infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/infra",
-  "version": "6.21.0",
+  "version": "6.20.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -37,8 +37,8 @@
     "@aws-cdk/aws-lambda-event-sources": ">=1.144.0",
     "@aws-cdk/aws-s3": ">=1.144.0",
     "@aws-cdk/core": ">=1.144.0",
-    "@basemaps/lambda-tiler": "^6.21.0",
-    "@basemaps/shared": "^6.21.0",
+    "@basemaps/lambda-tiler": "^6.20.0",
+    "@basemaps/shared": "^6.20.0",
     "aws-cdk": "^1.144.0"
   }
 }

--- a/packages/attribution/package.json
+++ b/packages/attribution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/attribution",
-  "version": "6.21.0",
+  "version": "6.17.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -30,7 +30,7 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/geo": "^6.21.0",
+    "@basemaps/geo": "^6.10.0",
     "@linzjs/geojson": "^6.10.0"
   },
   "bundle": {

--- a/packages/bathymetry/package.json
+++ b/packages/bathymetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/bathymetry",
-  "version": "6.21.0",
+  "version": "6.20.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -28,9 +28,9 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/cli": "^6.21.0",
-    "@basemaps/geo": "^6.21.0",
-    "@basemaps/shared": "^6.21.0",
+    "@basemaps/cli": "^6.20.0",
+    "@basemaps/geo": "^6.10.0",
+    "@basemaps/shared": "^6.20.0",
     "@rushstack/ts-command-line": "^4.3.13",
     "multihashes": "^4.0.2",
     "ulid": "^2.3.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli",
-  "version": "6.21.0",
+  "version": "6.20.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -37,9 +37,9 @@
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "dependencies": {
-    "@basemaps/config": "^6.21.0",
-    "@basemaps/geo": "^6.21.0",
-    "@basemaps/shared": "^6.21.0",
+    "@basemaps/config": "^6.18.0",
+    "@basemaps/geo": "^6.10.0",
+    "@basemaps/shared": "^6.20.0",
     "@chunkd/fs": "^8.1.0",
     "@cogeotiff/core": "^6.1.1",
     "@linzjs/geojson": "^6.10.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/config",
-  "version": "6.21.0",
+  "version": "6.18.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -28,6 +28,6 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/geo": "^6.21.0"
+    "@basemaps/geo": "^6.10.0"
   }
 }

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/geo",
-  "version": "6.21.0",
+  "version": "6.10.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",

--- a/packages/lambda-analytics/package.json
+++ b/packages/lambda-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-analytics",
-  "version": "6.21.0",
+  "version": "6.20.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@basemaps/shared": "^6.21.0",
+    "@basemaps/shared": "^6.20.0",
     "@linzjs/s3fs": "^6.9.1"
   },
   "scripts": {

--- a/packages/lambda-tiler/package.json
+++ b/packages/lambda-tiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-tiler",
-  "version": "6.21.0",
+  "version": "6.20.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -22,12 +22,12 @@
   "types": "./build/index.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@basemaps/config": "^6.21.0",
-    "@basemaps/geo": "^6.21.0",
+    "@basemaps/config": "^6.18.0",
+    "@basemaps/geo": "^6.10.0",
     "@basemaps/lambda": "^6.7.0",
-    "@basemaps/shared": "^6.21.0",
-    "@basemaps/tiler": "^6.21.0",
-    "@basemaps/tiler-sharp": "^6.21.0",
+    "@basemaps/shared": "^6.20.0",
+    "@basemaps/tiler": "^6.20.0",
+    "@basemaps/tiler-sharp": "^6.20.0",
     "@chunkd/fs": "^8.1.0",
     "@cogeotiff/core": "^6.1.1",
     "@cotar/core": "^5.2.0",
@@ -52,7 +52,7 @@
     "bundle": "./bundle.sh"
   },
   "devDependencies": {
-    "@basemaps/attribution": "^6.21.0",
+    "@basemaps/attribution": "^6.17.0",
     "@types/aws-lambda": "^8.10.75",
     "@types/express": "^4.17.11",
     "@types/node": "^14.11.2",

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/landing",
-  "version": "6.21.0",
+  "version": "6.20.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -29,10 +29,10 @@
     "last 2 Chrome versions"
   ],
   "devDependencies": {
-    "@basemaps/attribution": "^6.21.0",
-    "@basemaps/geo": "^6.21.0",
-    "@basemaps/infra": "^6.21.0",
-    "@basemaps/shared": "^6.21.0",
+    "@basemaps/attribution": "^6.17.0",
+    "@basemaps/geo": "^6.10.0",
+    "@basemaps/infra": "^6.20.0",
+    "@basemaps/shared": "^6.20.0",
     "@linzjs/lui": "^10.11.3",
     "@servie/events": "^3.0.0",
     "@splitsoftware/splitio": "^10.16.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/server",
-  "version": "6.21.0",
+  "version": "6.20.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -32,10 +32,10 @@
     "bin/"
   ],
   "dependencies": {
-    "@basemaps/config": "^6.21.0",
-    "@basemaps/geo": "^6.21.0",
-    "@basemaps/lambda-tiler": "^6.21.0",
-    "@basemaps/shared": "^6.21.0",
+    "@basemaps/config": "^6.18.0",
+    "@basemaps/geo": "^6.10.0",
+    "@basemaps/lambda-tiler": "^6.20.0",
+    "@basemaps/shared": "^6.20.0",
     "@linzjs/lambda": "^2.0.0",
     "@oclif/command": "^1.8.0",
     "express": "^4.17.1",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/shared",
-  "version": "6.21.0",
+  "version": "6.20.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -23,9 +23,9 @@
     "test": "ospec --globs 'build/**/*.test.js'"
   },
   "dependencies": {
-    "@basemaps/config": "^6.21.0",
-    "@basemaps/geo": "^6.21.0",
-    "@basemaps/tiler": "^6.21.0",
+    "@basemaps/config": "^6.18.0",
+    "@basemaps/geo": "^6.10.0",
+    "@basemaps/tiler": "^6.20.0",
     "@chunkd/source-aws-v2": "^8.1.0",
     "@linzjs/geojson": "^6.10.0",
     "@linzjs/metrics": "^6.11.0",

--- a/packages/tiler-sharp/package.json
+++ b/packages/tiler-sharp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/tiler-sharp",
-  "version": "6.21.0",
+  "version": "6.20.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -22,8 +22,8 @@
     "test": "ospec --globs 'build/**/*.test.js'"
   },
   "dependencies": {
-    "@basemaps/geo": "^6.21.0",
-    "@basemaps/tiler": "^6.21.0",
+    "@basemaps/geo": "^6.10.0",
+    "@basemaps/tiler": "^6.20.0",
     "@linzjs/metrics": "^6.11.0",
     "sharp": "^0.29.3"
   },

--- a/packages/tiler/package.json
+++ b/packages/tiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/tiler",
-  "version": "6.21.0",
+  "version": "6.20.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -22,7 +22,7 @@
     "test": "ospec --globs 'build/**/*.test.js'"
   },
   "dependencies": {
-    "@basemaps/geo": "^6.21.0",
+    "@basemaps/geo": "^6.10.0",
     "@cogeotiff/core": "^6.1.1",
     "@linzjs/metrics": "^6.11.0"
   },


### PR DESCRIPTION
This reverts commit d57532186c445aa3b03efe3d91645c4efb2d714d.


Since v6.21.0 was never published to NPM the deployment process will fail until it is, this reverts all the versions back to pre v6.21.0 numbers a new v6.22.0 will be published later.