### PR TITLE
fix(cli): allow unicode job names

### DIFF
--- a/packages/cli/src/cli/cogify/__test__/action.batch.test.ts
+++ b/packages/cli/src/cli/cogify/__test__/action.batch.test.ts
@@ -1,5 +1,6 @@
 import o from 'ospec';
-import { extractResolutionFromName } from '../action.batch.js';
+import { CogJob } from '../../../cog/types.js';
+import { ActionBatchJob, extractResolutionFromName } from '../action.batch.js';
 
 o.spec('action.batch', () => {
   o('extractResolutionFromName', () => {
@@ -10,5 +11,13 @@ o.spec('action.batch', () => {
     o(extractResolutionFromName('wellington_urban_2017_0-10m')).equals(100);
     o(extractResolutionFromName('wellington_urban_2017_1.00m')).equals(1000);
     o(extractResolutionFromName('wellington_urban_2017_0.025m')).equals(25);
+  });
+
+  o('should create valid jobNames', () => {
+    const fakeJob = { id: '01FHRPYJ5FV1XAARZAC4T4K6MC', name: 'geographx_nz_texture_shade_2012_8-0m' } as CogJob;
+    o(ActionBatchJob.id(fakeJob, '0')).equals('01FHRPYJ5FV1XAARZAC4T4K6MC-9af5e139bbb3e502-0');
+
+    fakeJob.name = 'ōtorohanga_urban_2021_0.1m_RGB';
+    o(ActionBatchJob.id(fakeJob, '0')).equals('01FHRPYJ5FV1XAARZAC4T4K6MC-5294acface81c107-0');
   });
 });

--- a/packages/cli/src/cli/cogify/__test__/action.batch.test.ts
+++ b/packages/cli/src/cli/cogify/__test__/action.batch.test.ts
@@ -20,4 +20,17 @@ o.spec('action.batch', () => {
     fakeJob.name = 'ōtorohanga_urban_2021_0.1m_RGB';
     o(ActionBatchJob.id(fakeJob, '0')).equals('01FHRPYJ5FV1XAARZAC4T4K6MC-5294acface81c107-0');
   });
+
+  o('should truncate job names to 128 characters', () => {
+    const fakeJob = { id: '01FHRPYJ5FV1XAARZAC4T4K6MC', name: 'geographx_nz_texture_shade_2012_8-0m' } as CogJob;
+
+    o(
+      ActionBatchJob.id(
+        fakeJob,
+        'this is a really long file name it should over flow 128 characters so it should be truncated at some point.tiff',
+      ),
+    ).equals(
+      '01FHRPYJ5FV1XAARZAC4T4K6MC-9af5e139bbb3e502-this is a really long file name it should over flow 128 characters so it should be t',
+    );
+  });
 });

--- a/packages/cli/src/cli/cogify/action.batch.ts
+++ b/packages/cli/src/cli/cogify/action.batch.ts
@@ -2,6 +2,7 @@ import { TileMatrixSet } from '@basemaps/geo';
 import { Env, fsa, LogConfig, LogType, Projection } from '@basemaps/shared';
 import { CommandLineAction, CommandLineFlagParameter, CommandLineStringParameter } from '@rushstack/ts-command-line';
 import Batch from 'aws-sdk/clients/batch.js';
+import { createHash } from 'crypto';
 import { CogStacJob } from '../../cog/cog.stac.job.js';
 import { CogJob } from '../../cog/types.js';
 
@@ -37,8 +38,18 @@ export class ActionBatchJob extends CommandLineAction {
     });
   }
 
-  static id(job: CogJob, name: string): string {
-    return `${job.id}-${job.name}-${name}`;
+  /**
+   * Create a id for a job
+   *
+   * This needs to be within `[a-Z_-]` upto 128 characters log
+   * @param job job to process
+   * @param fileName output filename
+   * @returns job id
+   */
+  static id(job: CogJob, fileName: string): string {
+    // Job names are uncontrolled so hash the name and grab a small slice to use as a identifier
+    const jobName = createHash('sha256').update(job.name).digest('hex').slice(0, 16);
+    return `${job.id}-${jobName}-${fileName}`.slice(0, 128);
   }
 
   static async batchOne(


### PR DESCRIPTION
AWS Batch does not allow unicode in job names so replace the job name with a hex digested hash