### PR TITLE
release: v6.24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.24.2](https://github.com/linz/basemaps/compare/v6.24.1...v6.24.2) (2022-04-20)
+
+
+### Bug Fixes
+
+* **infra:** use the correct region to find certs ([#2159](https://github.com/linz/basemaps/issues/2159)) ([635d303](https://github.com/linz/basemaps/commit/635d303711d0b117b4b83842fe4c9d6e6d5db06d))
+* **lambda-tiler:** expose the name of the imagery set in attribution ([#2153](https://github.com/linz/basemaps/issues/2153)) ([65d22cb](https://github.com/linz/basemaps/commit/65d22cbbf805d704b0179581ac6b66e755d2ef8f))
+* **lambda-tiler:** missing tilesets should 404 not 500 ([#2149](https://github.com/linz/basemaps/issues/2149)) ([a3420bc](https://github.com/linz/basemaps/commit/a3420bcc956a7fc16e2b3867100bd5943fa13e73))
+* **server:** indexing local tiffs should not crash ([#2152](https://github.com/linz/basemaps/issues/2152)) ([066f39f](https://github.com/linz/basemaps/commit/066f39f42bec2558353c03741ca2226028ac424a))
+
+
+
+
+
 ## [6.24.1](https://github.com/linz/basemaps/compare/v6.24.0...v6.24.1) (2022-04-07)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
       "conventionalCommits": true
     }
   },
-  "version": "6.24.1"
+  "version": "6.24.2"
 }

--- a/packages/_infra/CHANGELOG.md
+++ b/packages/_infra/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.24.2](https://github.com/linz/basemaps/compare/v6.24.1...v6.24.2) (2022-04-20)
+
+
+### Bug Fixes
+
+* **infra:** use the correct region to find certs ([#2159](https://github.com/linz/basemaps/issues/2159)) ([635d303](https://github.com/linz/basemaps/commit/635d303711d0b117b4b83842fe4c9d6e6d5db06d))
+
+
+
+
+
 ## [6.24.1](https://github.com/linz/basemaps/compare/v6.24.0...v6.24.1) (2022-04-07)
 
 **Note:** Version bump only for package @basemaps/infra

--- a/packages/_infra/package.json
+++ b/packages/_infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/infra",
-  "version": "6.24.1",
+  "version": "6.24.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -24,8 +24,8 @@
     "test": "ospec --globs 'build/**/*.test.js'"
   },
   "devDependencies": {
-    "@basemaps/lambda-tiler": "^6.24.1",
-    "@basemaps/shared": "^6.24.1",
+    "@basemaps/lambda-tiler": "^6.24.2",
+    "@basemaps/shared": "^6.24.2",
     "aws-cdk": "^2.20.0",
     "aws-cdk-lib": "^2.20.0",
     "constructs": "^10.0.119"

--- a/packages/attribution/CHANGELOG.md
+++ b/packages/attribution/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.24.2](https://github.com/linz/basemaps/compare/v6.24.1...v6.24.2) (2022-04-20)
+
+
+### Bug Fixes
+
+* **lambda-tiler:** expose the name of the imagery set in attribution ([#2153](https://github.com/linz/basemaps/issues/2153)) ([65d22cb](https://github.com/linz/basemaps/commit/65d22cbbf805d704b0179581ac6b66e755d2ef8f))
+
+
+
+
+
 # [6.22.0](https://github.com/linz/basemaps/compare/v6.21.1...v6.22.0) (2022-03-20)
 
 

--- a/packages/attribution/package.json
+++ b/packages/attribution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/attribution",
-  "version": "6.22.0",
+  "version": "6.24.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -30,7 +30,7 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/geo": "^6.21.1",
+    "@basemaps/geo": "^6.24.2",
     "@linzjs/geojson": "^6.21.1"
   },
   "bundle": {

--- a/packages/bathymetry/CHANGELOG.md
+++ b/packages/bathymetry/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.24.2](https://github.com/linz/basemaps/compare/v6.24.1...v6.24.2) (2022-04-20)
+
+**Note:** Version bump only for package @basemaps/bathymetry
+
+
+
+
+
 ## [6.24.1](https://github.com/linz/basemaps/compare/v6.24.0...v6.24.1) (2022-04-07)
 
 **Note:** Version bump only for package @basemaps/bathymetry

--- a/packages/bathymetry/package.json
+++ b/packages/bathymetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/bathymetry",
-  "version": "6.24.1",
+  "version": "6.24.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -28,9 +28,9 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/cli": "^6.24.1",
-    "@basemaps/geo": "^6.21.1",
-    "@basemaps/shared": "^6.24.1",
+    "@basemaps/cli": "^6.24.2",
+    "@basemaps/geo": "^6.24.2",
+    "@basemaps/shared": "^6.24.2",
     "@rushstack/ts-command-line": "^4.3.13",
     "multihashes": "^4.0.2",
     "ulid": "^2.3.0"

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.24.2](https://github.com/linz/basemaps/compare/v6.24.1...v6.24.2) (2022-04-20)
+
+**Note:** Version bump only for package @basemaps/cli
+
+
+
+
+
 ## [6.24.1](https://github.com/linz/basemaps/compare/v6.24.0...v6.24.1) (2022-04-07)
 
 **Note:** Version bump only for package @basemaps/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli",
-  "version": "6.24.1",
+  "version": "6.24.2",
   "private": false,
   "repository": {
     "type": "git",
@@ -37,9 +37,9 @@
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "dependencies": {
-    "@basemaps/config": "^6.21.1",
-    "@basemaps/geo": "^6.21.1",
-    "@basemaps/shared": "^6.24.1",
+    "@basemaps/config": "^6.24.2",
+    "@basemaps/geo": "^6.24.2",
+    "@basemaps/shared": "^6.24.2",
     "@chunkd/fs": "^8.1.0",
     "@cogeotiff/core": "^7.0.0",
     "@linzjs/geojson": "^6.21.1",

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.24.2](https://github.com/linz/basemaps/compare/v6.24.1...v6.24.2) (2022-04-20)
+
+**Note:** Version bump only for package @basemaps/config
+
+
+
+
+
 ## [6.21.1](https://github.com/linz/basemaps/compare/v6.21.0...v6.21.1) (2022-03-17)
 
 **Note:** Version bump only for package @basemaps/config

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/config",
-  "version": "6.21.1",
+  "version": "6.24.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -28,6 +28,6 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/geo": "^6.21.1"
+    "@basemaps/geo": "^6.24.2"
   }
 }

--- a/packages/geo/CHANGELOG.md
+++ b/packages/geo/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.24.2](https://github.com/linz/basemaps/compare/v6.24.1...v6.24.2) (2022-04-20)
+
+
+### Bug Fixes
+
+* **lambda-tiler:** expose the name of the imagery set in attribution ([#2153](https://github.com/linz/basemaps/issues/2153)) ([65d22cb](https://github.com/linz/basemaps/commit/65d22cbbf805d704b0179581ac6b66e755d2ef8f))
+
+
+
+
+
 ## [6.21.1](https://github.com/linz/basemaps/compare/v6.21.0...v6.21.1) (2022-03-17)
 
 **Note:** Version bump only for package @basemaps/geo

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/geo",
-  "version": "6.21.1",
+  "version": "6.24.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",

--- a/packages/lambda-analytics/CHANGELOG.md
+++ b/packages/lambda-analytics/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.24.2](https://github.com/linz/basemaps/compare/v6.24.1...v6.24.2) (2022-04-20)
+
+**Note:** Version bump only for package @basemaps/lambda-analytics
+
+
+
+
+
 ## [6.24.1](https://github.com/linz/basemaps/compare/v6.24.0...v6.24.1) (2022-04-07)
 
 **Note:** Version bump only for package @basemaps/lambda-analytics

--- a/packages/lambda-analytics/package.json
+++ b/packages/lambda-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-analytics",
-  "version": "6.24.1",
+  "version": "6.24.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@basemaps/shared": "^6.24.1",
+    "@basemaps/shared": "^6.24.2",
     "@linzjs/s3fs": "^6.9.1"
   },
   "scripts": {

--- a/packages/lambda-tiler/CHANGELOG.md
+++ b/packages/lambda-tiler/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.24.2](https://github.com/linz/basemaps/compare/v6.24.1...v6.24.2) (2022-04-20)
+
+
+### Bug Fixes
+
+* **lambda-tiler:** expose the name of the imagery set in attribution ([#2153](https://github.com/linz/basemaps/issues/2153)) ([65d22cb](https://github.com/linz/basemaps/commit/65d22cbbf805d704b0179581ac6b66e755d2ef8f))
+* **lambda-tiler:** missing tilesets should 404 not 500 ([#2149](https://github.com/linz/basemaps/issues/2149)) ([a3420bc](https://github.com/linz/basemaps/commit/a3420bcc956a7fc16e2b3867100bd5943fa13e73))
+
+
+
+
+
 ## [6.24.1](https://github.com/linz/basemaps/compare/v6.24.0...v6.24.1) (2022-04-07)
 
 

--- a/packages/lambda-tiler/package.json
+++ b/packages/lambda-tiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-tiler",
-  "version": "6.24.1",
+  "version": "6.24.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -22,12 +22,12 @@
   "types": "./build/index.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@basemaps/config": "^6.21.1",
-    "@basemaps/geo": "^6.21.1",
+    "@basemaps/config": "^6.24.2",
+    "@basemaps/geo": "^6.24.2",
     "@basemaps/lambda": "^6.7.0",
-    "@basemaps/shared": "^6.24.1",
-    "@basemaps/tiler": "^6.23.0",
-    "@basemaps/tiler-sharp": "^6.23.0",
+    "@basemaps/shared": "^6.24.2",
+    "@basemaps/tiler": "^6.24.2",
+    "@basemaps/tiler-sharp": "^6.24.2",
     "@chunkd/fs": "^8.1.0",
     "@cogeotiff/core": "^7.0.0",
     "@cotar/core": "^5.3.0",
@@ -52,7 +52,7 @@
     "bundle": "./bundle.sh"
   },
   "devDependencies": {
-    "@basemaps/attribution": "^6.22.0",
+    "@basemaps/attribution": "^6.24.2",
     "@types/aws-lambda": "^8.10.75",
     "@types/node": "^14.11.2",
     "@types/pixelmatch": "^5.0.0",

--- a/packages/landing/CHANGELOG.md
+++ b/packages/landing/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.24.2](https://github.com/linz/basemaps/compare/v6.24.1...v6.24.2) (2022-04-20)
+
+**Note:** Version bump only for package @basemaps/landing
+
+
+
+
+
 ## [6.24.1](https://github.com/linz/basemaps/compare/v6.24.0...v6.24.1) (2022-04-07)
 
 **Note:** Version bump only for package @basemaps/landing

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/landing",
-  "version": "6.24.1",
+  "version": "6.24.2",
   "private": true,
   "repository": {
     "type": "git",
@@ -29,10 +29,10 @@
     "last 2 Chrome versions"
   ],
   "devDependencies": {
-    "@basemaps/attribution": "^6.22.0",
-    "@basemaps/geo": "^6.21.1",
-    "@basemaps/infra": "^6.24.1",
-    "@basemaps/shared": "^6.24.1",
+    "@basemaps/attribution": "^6.24.2",
+    "@basemaps/geo": "^6.24.2",
+    "@basemaps/infra": "^6.24.2",
+    "@basemaps/shared": "^6.24.2",
     "@linzjs/lui": "^10.11.3",
     "@servie/events": "^3.0.0",
     "@splitsoftware/splitio": "^10.16.1",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.24.2](https://github.com/linz/basemaps/compare/v6.24.1...v6.24.2) (2022-04-20)
+
+
+### Bug Fixes
+
+* **server:** indexing local tiffs should not crash ([#2152](https://github.com/linz/basemaps/issues/2152)) ([066f39f](https://github.com/linz/basemaps/commit/066f39f42bec2558353c03741ca2226028ac424a))
+
+
+
+
+
 ## [6.24.1](https://github.com/linz/basemaps/compare/v6.24.0...v6.24.1) (2022-04-07)
 
 **Note:** Version bump only for package @basemaps/server

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/server",
-  "version": "6.24.1",
+  "version": "6.24.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -32,10 +32,10 @@
     "bin/"
   ],
   "dependencies": {
-    "@basemaps/config": "^6.21.1",
-    "@basemaps/geo": "^6.21.1",
-    "@basemaps/lambda-tiler": "^6.24.1",
-    "@basemaps/shared": "^6.24.1",
+    "@basemaps/config": "^6.24.2",
+    "@basemaps/geo": "^6.24.2",
+    "@basemaps/lambda-tiler": "^6.24.2",
+    "@basemaps/shared": "^6.24.2",
     "@linzjs/lambda": "^2.0.0",
     "@oclif/command": "^1.8.0",
     "fastify": "^3.27.4",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.24.2](https://github.com/linz/basemaps/compare/v6.24.1...v6.24.2) (2022-04-20)
+
+**Note:** Version bump only for package @basemaps/shared
+
+
+
+
+
 ## [6.24.1](https://github.com/linz/basemaps/compare/v6.24.0...v6.24.1) (2022-04-07)
 
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/shared",
-  "version": "6.24.1",
+  "version": "6.24.2",
   "private": false,
   "repository": {
     "type": "git",
@@ -23,9 +23,9 @@
     "test": "ospec --globs 'build/**/*.test.js'"
   },
   "dependencies": {
-    "@basemaps/config": "^6.21.1",
-    "@basemaps/geo": "^6.21.1",
-    "@basemaps/tiler": "^6.23.0",
+    "@basemaps/config": "^6.24.2",
+    "@basemaps/geo": "^6.24.2",
+    "@basemaps/tiler": "^6.24.2",
     "@chunkd/source-aws-v2": "^8.1.0",
     "@linzjs/geojson": "^6.21.1",
     "@linzjs/metrics": "^6.21.1",

--- a/packages/tiler-sharp/CHANGELOG.md
+++ b/packages/tiler-sharp/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.24.2](https://github.com/linz/basemaps/compare/v6.24.1...v6.24.2) (2022-04-20)
+
+**Note:** Version bump only for package @basemaps/tiler-sharp
+
+
+
+
+
 # [6.23.0](https://github.com/linz/basemaps/compare/v6.22.1...v6.23.0) (2022-04-04)
 
 **Note:** Version bump only for package @basemaps/tiler-sharp

--- a/packages/tiler-sharp/package.json
+++ b/packages/tiler-sharp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/tiler-sharp",
-  "version": "6.23.0",
+  "version": "6.24.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -22,8 +22,8 @@
     "test": "ospec --globs 'build/**/*.test.js'"
   },
   "dependencies": {
-    "@basemaps/geo": "^6.21.1",
-    "@basemaps/tiler": "^6.23.0",
+    "@basemaps/geo": "^6.24.2",
+    "@basemaps/tiler": "^6.24.2",
     "@linzjs/metrics": "^6.21.1",
     "sharp": "^0.29.3"
   },

--- a/packages/tiler/CHANGELOG.md
+++ b/packages/tiler/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.24.2](https://github.com/linz/basemaps/compare/v6.24.1...v6.24.2) (2022-04-20)
+
+**Note:** Version bump only for package @basemaps/tiler
+
+
+
+
+
 # [6.23.0](https://github.com/linz/basemaps/compare/v6.22.1...v6.23.0) (2022-04-04)
 
 **Note:** Version bump only for package @basemaps/tiler

--- a/packages/tiler/package.json
+++ b/packages/tiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/tiler",
-  "version": "6.23.0",
+  "version": "6.24.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -22,7 +22,7 @@
     "test": "ospec --globs 'build/**/*.test.js'"
   },
   "dependencies": {
-    "@basemaps/geo": "^6.21.1",
+    "@basemaps/geo": "^6.24.2",
     "@cogeotiff/core": "^7.0.0",
     "@linzjs/metrics": "^6.21.1"
   },


### PR DESCRIPTION
- AWS CDK v2
- Names in attribution json for QGIS
- Convert http 500 errors to 404 when tilesets cannot be found