### PR TITLE
feat(landing): remove debug overlays to make it easier to screenshot

### DIFF
--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -295,6 +295,8 @@ export class Debug extends Component<
 
     const layers = styleJson.layers?.filter((f) => f.type !== 'custom' && f.source === 'LINZ Basemaps') ?? [];
 
+    // Do not hide topographic layers when trying to inspect the topographic layer
+    if (Config.map.layerId === 'topographic') return;
     // Force all the layers to be invisible to start, otherwise the map will "flash" on then off
     for (const layer of layers) {
       if (layer.type === 'custom') continue;

--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -52,10 +52,12 @@ export class Debug extends Component<
       });
       this.updateFromConfig();
 
-      // Jam  div into the page once the map has loaded so tools like playwright can see the map has finished loading
-      const loadedDiv = document.createElement('div');
-      loadedDiv.id = 'map-loaded';
-      document.body.appendChild(loadedDiv);
+      // Jam a div into the page once the map has loaded so tools like playwright can see the map has finished loading
+      if (Config.map.debug['debug.screenshot']) {
+        const loadedDiv = document.createElement('div');
+        loadedDiv.id = 'map-loaded';
+        document.body.appendChild(loadedDiv);
+      }
     });
   };
 

--- a/packages/landing/src/components/map.tsx
+++ b/packages/landing/src/components/map.tsx
@@ -87,7 +87,6 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
   componentDidMount(): void {
     // Force the URL to be read before loading the map
     Config.map.updateFromUrl();
-    console.log(Config.map.debug);
     this.el = document.getElementById('map') as HTMLDivElement;
 
     if (this.el == null) throw new Error('Unable to find #map element');

--- a/packages/landing/src/components/map.tsx
+++ b/packages/landing/src/components/map.tsx
@@ -58,6 +58,7 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
    * As it does not work with the projection logic we are currently using
    */
   ensureGeoControl(): void {
+    if (Config.map.debug['debug.screenshot']) return;
     if (Config.map.tileMatrix === GoogleTms) {
       if (this.controlGeo != null) return;
       this.controlGeo = new maplibre.GeolocateControl({});
@@ -86,6 +87,7 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
   componentDidMount(): void {
     // Force the URL to be read before loading the map
     Config.map.updateFromUrl();
+    console.log(Config.map.debug);
     this.el = document.getElementById('map') as HTMLDivElement;
 
     if (this.el == null) throw new Error('Unable to find #map element');
@@ -104,10 +106,11 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
 
     this.mapAttr = new MapAttribution(this.map);
 
-    const nav = new maplibre.NavigationControl({ visualizePitch: true });
-    this.map.addControl(nav, 'top-left');
-
-    this.map.addControl(new maplibre.FullscreenControl({ container: this.el }));
+    if (Config.map.debug['debug.screenshot'] !== true) {
+      const nav = new maplibre.NavigationControl({ visualizePitch: true });
+      this.map.addControl(nav, 'top-left');
+      this.map.addControl(new maplibre.FullscreenControl({ container: this.el }));
+    }
 
     this.map.on('render', this.onRender);
     this.map.on('load', () => {

--- a/packages/landing/src/config.debug.ts
+++ b/packages/landing/src/config.debug.ts
@@ -1,9 +1,16 @@
 export interface DebugState {
   debug: boolean;
+  /** What color should the background be */
   'debug.background': string | false;
+  /** Should the source tiles */
   'debug.source': boolean;
+  /** Should things be hidden to make a better screenshot */
+  'debug.screenshot': boolean;
+  /** What opacity is the aerial layer, 0 is off */
   'debug.layer.linz-aerial': number;
+  /** What opacity is the topographic layer, 0 is off */
   'debug.layer.linz-topographic': number;
+  /** What opacity is the open streetmap layer, 0 is off*/
   'debug.layer.osm': number;
 }
 
@@ -11,6 +18,7 @@ export const DebugDefaults: DebugState = {
   debug: false,
   'debug.background': false,
   'debug.source': false,
+  'debug.screenshot': false,
   'debug.layer.linz-aerial': 0,
   'debug.layer.linz-topographic': 0,
   'debug.layer.osm': 0,
@@ -43,6 +51,7 @@ export class ConfigDebug {
     isChanged = setKey(opt, 'debug', true);
     isChanged = setKey(opt, 'debug.background', url.get('debug.background')) || isChanged;
     isChanged = setKey(opt, 'debug.source', url.get('debug.source') != null) || isChanged;
+    isChanged = setKey(opt, 'debug.screenshot', url.get('debug.screenshot') != null) || isChanged;
     isChanged = setNum(opt, 'debug.layer.linz-aerial', url.get('debug.layer.linz-aerial')) || isChanged;
     isChanged = setNum(opt, 'debug.layer.linz-topographic', url.get('debug.layer.linz-topographic')) || isChanged;
     isChanged = setNum(opt, 'debug.layer.osm', url.get('debug.layer.osm')) || isChanged;


### PR DESCRIPTION
This removes the clutter when trying to create screenshots with tools like playwright.

it also adds a `map-loaded` div once the map has loaded in screenshot mode.

![image](https://user-images.githubusercontent.com/1082761/168213616-f26c821e-c49d-40d1-87e3-2fc68a7be946.png)
