### PR TITLE
fix(landing): remove the version information from the screenshot view

### DIFF
--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -70,6 +70,7 @@ export class Debug extends Component<
   }
 
   render(): ComponentChild {
+    if (Config.map.debug['debug.screenshot']) return null;
     return (
       <div className="debug">
         <div className="debug__info">


### PR DESCRIPTION
This removes all text, now its just the attribution shown 
![image](https://user-images.githubusercontent.com/1082761/168705969-98d6690a-83fa-4991-b3d6-660b3c719468.png)
