### PR TITLE
feat(cli): Pass processingId to action job cli for the batch job.

### DIFF
--- a/packages/cli/src/cli/cogify/action.job.ts
+++ b/packages/cli/src/cli/cogify/action.job.ts
@@ -54,6 +54,7 @@ export class ActionJobCreate extends CommandLineAction {
   private tileMatrix: CommandLineStringParameter;
   private oneCog: CommandLineFlagParameter;
   private fileList: CommandLineStringParameter;
+  private processingId: CommandLineStringParameter;
 
   public constructor() {
     super({
@@ -130,6 +131,7 @@ export class ActionJobCreate extends CommandLineAction {
         id: this.overrideId?.value ?? CliId,
         projection: Epsg.tryGet(this.sourceProjection?.value),
         resampling,
+        processingId: this.processingId?.value,
       },
       batch: this.submitBatch?.value ?? false,
       oneCogCovering: this.oneCog?.value ?? false,
@@ -217,6 +219,13 @@ export class ActionJobCreate extends CommandLineAction {
       argumentName: 'FILE_LIST',
       parameterLongName: '--filelist',
       description: 'supply a list of files to use as source imagery',
+      required: false,
+    });
+
+    this.processingId = this.defineStringParameter({
+      argumentName: 'PROCESSING_ID',
+      parameterLongName: '--processing-id',
+      description: 'pass the job processing id',
       required: false,
     });
   }


### PR DESCRIPTION
Processing ID need to pass action.job cli as a parameter, in order to prepare the JobContext in batch with the processingId.