### PR TITLE
feat(cli): Make a sseperate folder for each tiff for group cogs batch job.

### DIFF
--- a/packages/cli/src/cli/folder.ts
+++ b/packages/cli/src/cli/folder.ts
@@ -10,3 +10,11 @@ export async function makeTempFolder(folder: string): Promise<string> {
   await fs.mkdir(folderPath, { recursive: true });
   return folderPath;
 }
+
+/** Make a tiff folder inside TEMP_FOLDER's path */
+export async function makeTiffFolder(tmpFolder: string, name: string): Promise<string> {
+  const folderPath = path.join(tmpFolder, name);
+
+  await fs.mkdir(folderPath, { recursive: true });
+  return folderPath;
+}


### PR DESCRIPTION
This should fix the following problem when we process multiple tiffs in one batch job. 
![image](https://user-images.githubusercontent.com/12163920/170406971-93f250cb-6567-4878-ae0d-88269c0366e0.png)
