### PR TITLE
release: v6.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.28.1](https://github.com/linz/basemaps/compare/v6.28.0...v6.28.1) (2022-06-07)
+
+**Note:** Version bump only for package @basemaps/core
+
+
+
+
+
 # [6.28.0](https://github.com/linz/basemaps/compare/v6.27.0...v6.28.0) (2022-06-06)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
       "conventionalCommits": true
     }
   },
-  "version": "6.28.0"
+  "version": "6.28.1"
 }

--- a/packages/__tests__/CHANGELOG.md
+++ b/packages/__tests__/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.28.1](https://github.com/linz/basemaps/compare/v6.28.0...v6.28.1) (2022-06-07)
+
+**Note:** Version bump only for package @basemaps/test
+
+
+
+
+
 ## [6.21.1](https://github.com/linz/basemaps/compare/v6.21.0...v6.21.1) (2022-03-17)
 
 **Note:** Version bump only for package @basemaps/test

--- a/packages/__tests__/package.json
+++ b/packages/__tests__/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/test",
-  "version": "6.21.1",
+  "version": "6.28.1",
   "private": true,
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/packages/_infra/CHANGELOG.md
+++ b/packages/_infra/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.28.1](https://github.com/linz/basemaps/compare/v6.28.0...v6.28.1) (2022-06-07)
+
+**Note:** Version bump only for package @basemaps/infra
+
+
+
+
+
 # [6.28.0](https://github.com/linz/basemaps/compare/v6.27.0...v6.28.0) (2022-06-06)
 
 **Note:** Version bump only for package @basemaps/infra

--- a/packages/_infra/package.json
+++ b/packages/_infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/infra",
-  "version": "6.28.0",
+  "version": "6.28.1",
   "private": true,
   "repository": {
     "type": "git",
@@ -24,8 +24,8 @@
     "test": "ospec --globs 'build/**/*.test.js'"
   },
   "devDependencies": {
-    "@basemaps/lambda-tiler": "^6.28.0",
-    "@basemaps/shared": "^6.28.0",
+    "@basemaps/lambda-tiler": "^6.28.1",
+    "@basemaps/shared": "^6.28.1",
     "aws-cdk": "^2.21.0",
     "aws-cdk-lib": "^2.21.0",
     "constructs": "^10.0.119"

--- a/packages/attribution/CHANGELOG.md
+++ b/packages/attribution/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.28.1](https://github.com/linz/basemaps/compare/v6.28.0...v6.28.1) (2022-06-07)
+
+**Note:** Version bump only for package @basemaps/attribution
+
+
+
+
+
 # [6.28.0](https://github.com/linz/basemaps/compare/v6.27.0...v6.28.0) (2022-06-06)
 
 **Note:** Version bump only for package @basemaps/attribution

--- a/packages/attribution/package.json
+++ b/packages/attribution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/attribution",
-  "version": "6.28.0",
+  "version": "6.28.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -30,8 +30,8 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/geo": "^6.26.0",
-    "@linzjs/geojson": "^6.28.0"
+    "@basemaps/geo": "^6.28.1",
+    "@linzjs/geojson": "^6.28.1"
   },
   "bundle": {
     "entry": "src/attribution.index.ts",

--- a/packages/bathymetry/CHANGELOG.md
+++ b/packages/bathymetry/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.28.1](https://github.com/linz/basemaps/compare/v6.28.0...v6.28.1) (2022-06-07)
+
+**Note:** Version bump only for package @basemaps/bathymetry
+
+
+
+
+
 # [6.28.0](https://github.com/linz/basemaps/compare/v6.27.0...v6.28.0) (2022-06-06)
 
 

--- a/packages/bathymetry/package.json
+++ b/packages/bathymetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/bathymetry",
-  "version": "6.28.0",
+  "version": "6.28.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -28,9 +28,9 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/cli": "^6.28.0",
-    "@basemaps/geo": "^6.26.0",
-    "@basemaps/shared": "^6.28.0",
+    "@basemaps/cli": "^6.28.1",
+    "@basemaps/geo": "^6.28.1",
+    "@basemaps/shared": "^6.28.1",
     "@rushstack/ts-command-line": "^4.3.13",
     "multihashes": "^4.0.2",
     "ulid": "^2.3.0"

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.28.1](https://github.com/linz/basemaps/compare/v6.28.0...v6.28.1) (2022-06-07)
+
+**Note:** Version bump only for package @basemaps/cli
+
+
+
+
+
 # [6.28.0](https://github.com/linz/basemaps/compare/v6.27.0...v6.28.0) (2022-06-06)
 
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli",
-  "version": "6.28.0",
+  "version": "6.28.1",
   "private": false,
   "repository": {
     "type": "git",
@@ -37,12 +37,12 @@
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "dependencies": {
-    "@basemaps/config": "^6.28.0",
-    "@basemaps/geo": "^6.26.0",
-    "@basemaps/shared": "^6.28.0",
+    "@basemaps/config": "^6.28.1",
+    "@basemaps/geo": "^6.28.1",
+    "@basemaps/shared": "^6.28.1",
     "@chunkd/fs": "^8.1.0",
     "@cogeotiff/core": "^7.0.0",
-    "@linzjs/geojson": "^6.28.0",
+    "@linzjs/geojson": "^6.28.1",
     "@rushstack/ts-command-line": "^4.3.13",
     "ansi-colors": "^4.1.1",
     "node-fetch": "^3.2.3",

--- a/packages/config-cli/CHANGELOG.md
+++ b/packages/config-cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.28.1](https://github.com/linz/basemaps/compare/v6.28.0...v6.28.1) (2022-06-07)
+
+**Note:** Version bump only for package @basemaps/config-cli
+
+
+
+
+
 # [6.28.0](https://github.com/linz/basemaps/compare/v6.27.0...v6.28.0) (2022-06-06)
 
 

--- a/packages/config-cli/package.json
+++ b/packages/config-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/config-cli",
-  "version": "6.28.0",
+  "version": "6.28.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -32,9 +32,9 @@
     "bin/"
   ],
   "dependencies": {
-    "@basemaps/config-cli": "^6.28.0",
-    "@basemaps/geo": "^6.26.0",
-    "@basemaps/shared": "^6.28.0",
+    "@basemaps/config-cli": "^6.28.1",
+    "@basemaps/geo": "^6.28.1",
+    "@basemaps/shared": "^6.28.1",
     "@rushstack/ts-command-line": "^4.3.13",
     "playwright": "^1.22.0",
     "zod": "^3.17.3"

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.28.1](https://github.com/linz/basemaps/compare/v6.28.0...v6.28.1) (2022-06-07)
+
+**Note:** Version bump only for package @basemaps/config
+
+
+
+
+
 # [6.28.0](https://github.com/linz/basemaps/compare/v6.27.0...v6.28.0) (2022-06-06)
 
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/config",
-  "version": "6.28.0",
+  "version": "6.28.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -28,6 +28,6 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/geo": "^6.26.0"
+    "@basemaps/geo": "^6.28.1"
   }
 }

--- a/packages/geo/CHANGELOG.md
+++ b/packages/geo/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.28.1](https://github.com/linz/basemaps/compare/v6.28.0...v6.28.1) (2022-06-07)
+
+**Note:** Version bump only for package @basemaps/geo
+
+
+
+
+
 # [6.26.0](https://github.com/linz/basemaps/compare/v6.25.0...v6.26.0) (2022-05-12)
 
 

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/geo",
-  "version": "6.26.0",
+  "version": "6.28.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",

--- a/packages/lambda-analytics/CHANGELOG.md
+++ b/packages/lambda-analytics/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.28.1](https://github.com/linz/basemaps/compare/v6.28.0...v6.28.1) (2022-06-07)
+
+**Note:** Version bump only for package @basemaps/lambda-analytics
+
+
+
+
+
 # [6.28.0](https://github.com/linz/basemaps/compare/v6.27.0...v6.28.0) (2022-06-06)
 
 **Note:** Version bump only for package @basemaps/lambda-analytics

--- a/packages/lambda-analytics/package.json
+++ b/packages/lambda-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-analytics",
-  "version": "6.28.0",
+  "version": "6.28.1",
   "private": true,
   "repository": {
     "type": "git",
@@ -18,7 +18,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@basemaps/shared": "^6.28.0"
+    "@basemaps/shared": "^6.28.1"
   },
   "scripts": {
     "test": "ospec --globs 'build/**/*.test.js'",

--- a/packages/lambda-cog/CHANGELOG.md
+++ b/packages/lambda-cog/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.28.1](https://github.com/linz/basemaps/compare/v6.28.0...v6.28.1) (2022-06-07)
+
+**Note:** Version bump only for package @basemaps/lambda-cog
+
+
+
+
+
 # [6.28.0](https://github.com/linz/basemaps/compare/v6.27.0...v6.28.0) (2022-06-06)
 
 **Note:** Version bump only for package @basemaps/lambda-cog

--- a/packages/lambda-cog/package.json
+++ b/packages/lambda-cog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-cog",
-  "version": "6.28.0",
+  "version": "6.28.1",
   "private": true,
   "repository": {
     "type": "git",
@@ -20,11 +20,11 @@
   "types": "./build/index.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@basemaps/cli": "^6.28.0",
-    "@basemaps/config": "^6.28.0",
-    "@basemaps/geo": "^6.26.0",
+    "@basemaps/cli": "^6.28.1",
+    "@basemaps/config": "^6.28.1",
+    "@basemaps/geo": "^6.28.1",
     "@basemaps/lambda": "^6.7.0",
-    "@basemaps/shared": "^6.28.0",
+    "@basemaps/shared": "^6.28.1",
     "@chunkd/fs": "^8.1.0",
     "@linzjs/lambda": "^3.0.1"
   },

--- a/packages/lambda-tiler/CHANGELOG.md
+++ b/packages/lambda-tiler/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.28.1](https://github.com/linz/basemaps/compare/v6.28.0...v6.28.1) (2022-06-07)
+
+**Note:** Version bump only for package @basemaps/lambda-tiler
+
+
+
+
+
 # [6.28.0](https://github.com/linz/basemaps/compare/v6.27.0...v6.28.0) (2022-06-06)
 
 

--- a/packages/lambda-tiler/package.json
+++ b/packages/lambda-tiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-tiler",
-  "version": "6.28.0",
+  "version": "6.28.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -22,16 +22,16 @@
   "types": "./build/index.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@basemaps/config": "^6.28.0",
-    "@basemaps/geo": "^6.26.0",
+    "@basemaps/config": "^6.28.1",
+    "@basemaps/geo": "^6.28.1",
     "@basemaps/lambda": "^6.7.0",
-    "@basemaps/shared": "^6.28.0",
-    "@basemaps/tiler": "^6.28.0",
-    "@basemaps/tiler-sharp": "^6.28.0",
+    "@basemaps/shared": "^6.28.1",
+    "@basemaps/tiler": "^6.28.1",
+    "@basemaps/tiler-sharp": "^6.28.1",
     "@chunkd/fs": "^8.1.0",
     "@cogeotiff/core": "^7.0.0",
     "@cotar/core": "^5.3.0",
-    "@linzjs/geojson": "^6.28.0",
+    "@linzjs/geojson": "^6.28.1",
     "@linzjs/lambda": "^3.0.1",
     "p-limit": "^4.0.0",
     "path-to-regexp": "^6.1.0",
@@ -52,7 +52,7 @@
     "bundle": "./bundle.sh"
   },
   "devDependencies": {
-    "@basemaps/attribution": "^6.28.0",
+    "@basemaps/attribution": "^6.28.1",
     "@types/aws-lambda": "^8.10.75",
     "@types/node": "^17.0.34",
     "@types/pixelmatch": "^5.0.0",

--- a/packages/landing/CHANGELOG.md
+++ b/packages/landing/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.28.1](https://github.com/linz/basemaps/compare/v6.28.0...v6.28.1) (2022-06-07)
+
+**Note:** Version bump only for package @basemaps/landing
+
+
+
+
+
 # [6.28.0](https://github.com/linz/basemaps/compare/v6.27.0...v6.28.0) (2022-06-06)
 
 **Note:** Version bump only for package @basemaps/landing

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/landing",
-  "version": "6.28.0",
+  "version": "6.28.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -28,10 +28,10 @@
     "last 2 Chrome versions"
   ],
   "devDependencies": {
-    "@basemaps/attribution": "^6.28.0",
-    "@basemaps/geo": "^6.26.0",
-    "@basemaps/infra": "^6.28.0",
-    "@basemaps/shared": "^6.28.0",
+    "@basemaps/attribution": "^6.28.1",
+    "@basemaps/geo": "^6.28.1",
+    "@basemaps/infra": "^6.28.1",
+    "@basemaps/shared": "^6.28.1",
     "@linzjs/lui": "^10.11.3",
     "@servie/events": "^3.0.0",
     "@splitsoftware/splitio": "^10.16.1",

--- a/packages/linzjs-docker-command/CHANGELOG.md
+++ b/packages/linzjs-docker-command/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.28.1](https://github.com/linz/basemaps/compare/v6.28.0...v6.28.1) (2022-06-07)
+
+**Note:** Version bump only for package @linzjs/docker-command
+
+
+
+
+
 # [6.28.0](https://github.com/linz/basemaps/compare/v6.27.0...v6.28.0) (2022-06-06)
 
 **Note:** Version bump only for package @linzjs/docker-command

--- a/packages/linzjs-docker-command/package.json
+++ b/packages/linzjs-docker-command/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linzjs/docker-command",
-  "version": "6.28.0",
+  "version": "6.28.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",

--- a/packages/linzjs-geojson/CHANGELOG.md
+++ b/packages/linzjs-geojson/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.28.1](https://github.com/linz/basemaps/compare/v6.28.0...v6.28.1) (2022-06-07)
+
+**Note:** Version bump only for package @linzjs/geojson
+
+
+
+
+
 # [6.28.0](https://github.com/linz/basemaps/compare/v6.27.0...v6.28.0) (2022-06-06)
 
 **Note:** Version bump only for package @linzjs/geojson

--- a/packages/linzjs-geojson/package.json
+++ b/packages/linzjs-geojson/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linzjs/geojson",
-  "version": "6.28.0",
+  "version": "6.28.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",

--- a/packages/linzjs-metrics/CHANGELOG.md
+++ b/packages/linzjs-metrics/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.28.1](https://github.com/linz/basemaps/compare/v6.28.0...v6.28.1) (2022-06-07)
+
+**Note:** Version bump only for package @linzjs/metrics
+
+
+
+
+
 ## [6.21.1](https://github.com/linz/basemaps/compare/v6.21.0...v6.21.1) (2022-03-17)
 
 **Note:** Version bump only for package @linzjs/metrics

--- a/packages/linzjs-metrics/package.json
+++ b/packages/linzjs-metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@linzjs/metrics",
-  "version": "6.21.1",
+  "version": "6.28.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.28.1](https://github.com/linz/basemaps/compare/v6.28.0...v6.28.1) (2022-06-07)
+
+**Note:** Version bump only for package @basemaps/server
+
+
+
+
+
 # [6.28.0](https://github.com/linz/basemaps/compare/v6.27.0...v6.28.0) (2022-06-06)
 
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/server",
-  "version": "6.28.0",
+  "version": "6.28.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -44,17 +44,17 @@
     "bin/"
   ],
   "optionalDependencies": {
-    "@basemaps/landing": "^6.28.0"
+    "@basemaps/landing": "^6.28.1"
   },
   "dependencies": {
     "sharp": "^0.30.2"
   },
   "devDependencies": {
-    "@basemaps/config": "^6.28.0",
-    "@basemaps/geo": "^6.26.0",
-    "@basemaps/lambda-tiler": "^6.28.0",
+    "@basemaps/config": "^6.28.1",
+    "@basemaps/geo": "^6.28.1",
+    "@basemaps/lambda-tiler": "^6.28.1",
     "@basemaps/landing": "^6.27.0",
-    "@basemaps/shared": "^6.28.0",
+    "@basemaps/shared": "^6.28.1",
     "@fastify/static": "^5.0.2",
     "fastify": "^3.27.4",
     "pretty-json-log": "^1.0.0"

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.28.1](https://github.com/linz/basemaps/compare/v6.28.0...v6.28.1) (2022-06-07)
+
+**Note:** Version bump only for package @basemaps/shared
+
+
+
+
+
 # [6.28.0](https://github.com/linz/basemaps/compare/v6.27.0...v6.28.0) (2022-06-06)
 
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/shared",
-  "version": "6.28.0",
+  "version": "6.28.1",
   "private": false,
   "repository": {
     "type": "git",
@@ -23,12 +23,12 @@
     "test": "ospec --globs 'build/**/*.test.js'"
   },
   "dependencies": {
-    "@basemaps/config": "^6.28.0",
-    "@basemaps/geo": "^6.26.0",
-    "@basemaps/tiler": "^6.28.0",
+    "@basemaps/config": "^6.28.1",
+    "@basemaps/geo": "^6.28.1",
+    "@basemaps/tiler": "^6.28.1",
     "@chunkd/source-aws-v2": "^8.1.0",
-    "@linzjs/geojson": "^6.28.0",
-    "@linzjs/metrics": "^6.21.1",
+    "@linzjs/geojson": "^6.28.1",
+    "@linzjs/metrics": "^6.28.1",
     "aws-sdk": "^2.890.0",
     "pino": "^7.5.0",
     "proj4": "^2.6.2",

--- a/packages/sprites/CHANGELOG.md
+++ b/packages/sprites/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.28.1](https://github.com/linz/basemaps/compare/v6.28.0...v6.28.1) (2022-06-07)
+
+**Note:** Version bump only for package @basemaps/sprites
+
+
+
+
+
 # [6.28.0](https://github.com/linz/basemaps/compare/v6.27.0...v6.28.0) (2022-06-06)
 
 

--- a/packages/sprites/package.json
+++ b/packages/sprites/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/sprites",
-  "version": "6.28.0",
+  "version": "6.28.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",

--- a/packages/tiler-sharp/CHANGELOG.md
+++ b/packages/tiler-sharp/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.28.1](https://github.com/linz/basemaps/compare/v6.28.0...v6.28.1) (2022-06-07)
+
+**Note:** Version bump only for package @basemaps/tiler-sharp
+
+
+
+
+
 # [6.28.0](https://github.com/linz/basemaps/compare/v6.27.0...v6.28.0) (2022-06-06)
 
 

--- a/packages/tiler-sharp/package.json
+++ b/packages/tiler-sharp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/tiler-sharp",
-  "version": "6.28.0",
+  "version": "6.28.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -22,9 +22,9 @@
     "test": "ospec --globs 'build/**/*.test.js'"
   },
   "dependencies": {
-    "@basemaps/geo": "^6.26.0",
-    "@basemaps/tiler": "^6.28.0",
-    "@linzjs/metrics": "^6.21.1",
+    "@basemaps/geo": "^6.28.1",
+    "@basemaps/tiler": "^6.28.1",
+    "@linzjs/metrics": "^6.28.1",
     "sharp": "0.29.2"
   },
   "devDependencies": {

--- a/packages/tiler/CHANGELOG.md
+++ b/packages/tiler/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [6.28.1](https://github.com/linz/basemaps/compare/v6.28.0...v6.28.1) (2022-06-07)
+
+**Note:** Version bump only for package @basemaps/tiler
+
+
+
+
+
 # [6.28.0](https://github.com/linz/basemaps/compare/v6.27.0...v6.28.0) (2022-06-06)
 
 

--- a/packages/tiler/package.json
+++ b/packages/tiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/tiler",
-  "version": "6.28.0",
+  "version": "6.28.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -22,9 +22,9 @@
     "test": "ospec --globs 'build/**/*.test.js'"
   },
   "dependencies": {
-    "@basemaps/geo": "^6.26.0",
+    "@basemaps/geo": "^6.28.1",
     "@cogeotiff/core": "^7.0.0",
-    "@linzjs/metrics": "^6.21.1"
+    "@linzjs/metrics": "^6.28.1"
   },
   "devDependencies": {
     "@chunkd/fs": "^8.1.0",


### PR DESCRIPTION
Fix up the docker container taging so it should now tag as `v6.28.1` on release tags