### PR TITLE
feat(lambda-tiler): serve assets via /v1/sprites and /v1/fonts

### DIFF
--- a/packages/lambda-tiler/src/index.ts
+++ b/packages/lambda-tiler/src/index.ts
@@ -8,6 +8,8 @@ import { createHash } from 'crypto';
 import { Imagery } from './routes/imagery.js';
 import { Esri } from './routes/esri/rest.js';
 import { St } from './source.tracer.js';
+import { spriteGet } from './routes/sprites.js';
+import { fontGet, fontList } from './routes/fonts.js';
 
 const app = new Router();
 
@@ -49,4 +51,9 @@ export async function handleRequest(req: LambdaHttpRequest): Promise<LambdaHttpR
 }
 
 export const handler = lf.http(LogConfig.get());
+
+handler.router.get('/v1/sprites/:spriteName', spriteGet);
+handler.router.get('/v1/fonts.json', fontList);
+handler.router.get('/v1/fonts/:fontStack/:range.pbf', fontGet);
+
 handler.router.get('*', handleRequest);

--- a/packages/lambda-tiler/src/routes/__tests__/fonts.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/fonts.test.ts
@@ -1,0 +1,68 @@
+import { fsa } from '@chunkd/fs';
+import o from 'ospec';
+import { fontGet, fontList, getFonts } from '../fonts.js';
+import { FsMemory } from './memory.fs.js';
+import { mockRequest } from '../../__tests__/xyz.util.js';
+import { Env } from '@basemaps/shared';
+import { handler } from '../../index.js';
+
+o.spec('listFonts', () => {
+  const memory = new FsMemory();
+  o.before(() => {
+    fsa.register('memory://', memory);
+  });
+
+  o.beforeEach(() => {
+    process.env[Env.AssetLocation] = 'memory://';
+  });
+
+  o.afterEach(() => {
+    delete process.env[Env.AssetLocation];
+    memory.files.clear();
+  });
+
+  o('should list font types', async () => {
+    await Promise.all([
+      fsa.write('memory://fonts/Roboto Thin/0-255.pbf', Buffer.from('')),
+      fsa.write('memory://fonts/Roboto Thin/256-512.pbf', Buffer.from('')),
+      fsa.write('memory://fonts/Roboto Black/0-255.pbf', Buffer.from('')),
+    ]);
+
+    const fonts = await getFonts('memory://fonts/');
+    o(fonts).deepEquals(['Roboto Black', 'Roboto Thin']);
+  });
+
+  o('should return empty list if no fonts found', async () => {
+    const res = await fontList();
+    o(res.status).equals(200);
+    o(res.body).equals('[]');
+  });
+
+  o('should return 404 if no assets defined', async () => {
+    delete process.env[Env.AssetLocation];
+    const res = await fontList();
+    o(res.status).equals(404);
+  });
+
+  o('should return a list of fonts found', async () => {
+    await Promise.all([
+      fsa.write('memory://fonts/Roboto Thin/0-255.pbf', Buffer.from('')),
+      fsa.write('memory://fonts/Roboto Thin/256-512.pbf', Buffer.from('')),
+      fsa.write('memory://fonts/Roboto Black/0-255.pbf', Buffer.from('')),
+    ]);
+    const res = await fontList();
+    o(res.status).equals(200);
+    o(res.body).equals(JSON.stringify(['Roboto Black', 'Roboto Thin']));
+  });
+
+  o('should get the correct font', async () => {
+    await fsa.write('memory://fonts/Roboto Thin/0-255.pbf', Buffer.from(''));
+
+    const res255 = await handler.router.handle(mockRequest('/v1/fonts/Roboto Thin/0-255.pbf'));
+    o(res255.status).equals(200);
+    o(res255.header('content-type')).equals('application/x-protobuf');
+
+    const res404 = await handler.router.handle(mockRequest('/v1/fonts/Roboto Thin/256-512.pbf'));
+    o(res404.status).equals(404);
+  });
+});

--- a/packages/lambda-tiler/src/routes/__tests__/fonts.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/fonts.test.ts
@@ -1,10 +1,10 @@
+import { Env } from '@basemaps/shared';
 import { fsa } from '@chunkd/fs';
 import o from 'ospec';
-import { fontGet, fontList, getFonts } from '../fonts.js';
-import { FsMemory } from './memory.fs.js';
-import { mockRequest } from '../../__tests__/xyz.util.js';
-import { Env } from '@basemaps/shared';
 import { handler } from '../../index.js';
+import { mockRequest } from '../../__tests__/xyz.util.js';
+import { fontList, getFonts } from '../fonts.js';
+import { FsMemory } from './memory.fs.js';
 
 o.spec('listFonts', () => {
   const memory = new FsMemory();

--- a/packages/lambda-tiler/src/routes/__tests__/memory.fs.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/memory.fs.ts
@@ -1,0 +1,77 @@
+import { ChunkSource, CompositeError, FileInfo, FileSystem } from '@chunkd/core';
+import { Readable } from 'stream';
+
+export async function toBuffer(stream: Readable): Promise<Buffer> {
+  return new Promise<Buffer>((resolve, reject) => {
+    const buf: Buffer[] = [];
+
+    stream.on('data', (chunk) => buf.push(chunk));
+    stream.on('end', () => resolve(Buffer.concat(buf)));
+    stream.on('error', (err) => reject(`error converting stream - ${err}`));
+  });
+}
+export function toReadable(r: string | Buffer | Readable): Readable {
+  if (typeof r === 'string') r = Buffer.from(r);
+  return Readable.from(r);
+}
+
+// TODO this should be provided by @chunkd/fs as it already provides a memory source
+export class FsMemory implements FileSystem {
+  protocol = 'memory';
+
+  files: Map<string, Buffer> = new Map();
+
+  async read(filePath: string): Promise<Buffer> {
+    const data = this.files.get(filePath);
+    if (data == null) throw new CompositeError('Not found', 404, new Error());
+    return data;
+  }
+
+  stream(filePath: string): Readable {
+    const buf = this.files.get(filePath);
+    if (buf == null) throw new CompositeError('Not found', 404, new Error());
+    return toReadable(buf);
+  }
+
+  async write(filePath: string, buffer: string | Buffer | Readable): Promise<void> {
+    if (typeof buffer === 'string') {
+      this.files.set(filePath, Buffer.from(buffer));
+      return;
+    }
+    if (Buffer.isBuffer(buffer)) {
+      this.files.set(filePath, buffer);
+      return;
+    }
+    const buf = await toBuffer(buffer);
+    this.files.set(filePath, buf);
+  }
+
+  async *list(filePath: string): AsyncGenerator<string> {
+    for (const file of this.files.keys()) {
+      if (file.startsWith(filePath)) yield file;
+    }
+  }
+
+  async *details(filePath: string): AsyncGenerator<FileInfo> {
+    for await (const file of this.list(filePath)) {
+      const data = await this.head(file);
+      if (data == null) continue;
+      yield data;
+    }
+  }
+
+  async exists(filePath: string): Promise<boolean> {
+    const dat = await this.head(filePath);
+    return dat != null;
+  }
+
+  async head(filePath: string): Promise<FileInfo | null> {
+    const buf = this.files.get(filePath);
+    if (buf == null) return null;
+    return { path: filePath, size: buf.length };
+  }
+
+  source(): ChunkSource {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/packages/lambda-tiler/src/routes/fonts.ts
+++ b/packages/lambda-tiler/src/routes/fonts.ts
@@ -2,6 +2,7 @@ import { Env } from '@basemaps/shared';
 import { fsa } from '@chunkd/fs';
 import { LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambda';
 import path from 'path';
+import { NotFound } from './response.js';
 
 interface FontGet {
   Params: { fontStack: string; range: string };
@@ -9,7 +10,7 @@ interface FontGet {
 
 export async function fontGet(req: LambdaHttpRequest<FontGet>): Promise<LambdaHttpResponse> {
   const assetLocation = Env.get(Env.AssetLocation);
-  if (assetLocation == null) return new LambdaHttpResponse(404, 'No Found');
+  if (assetLocation == null) return NotFound;
 
   try {
     const filePath = fsa.join(assetLocation, path.join('fonts', req.params.fontStack, req.params.range)) + '.pbf';
@@ -18,14 +19,14 @@ export async function fontGet(req: LambdaHttpRequest<FontGet>): Promise<LambdaHt
     res.buffer(buf, 'application/x-protobuf');
     return res;
   } catch (e: any) {
-    if (e.code === 404) return new LambdaHttpResponse(404, 'No Found');
+    if (e.code === 404) return NotFound;
     throw e;
   }
 }
 
 export async function fontList(): Promise<LambdaHttpResponse> {
   const assetLocation = Env.get(Env.AssetLocation);
-  if (assetLocation == null) return new LambdaHttpResponse(404, 'No Found');
+  if (assetLocation == null) return NotFound;
 
   try {
     const filePath = fsa.join(assetLocation, '/fonts');
@@ -44,7 +45,7 @@ export async function fontList(): Promise<LambdaHttpResponse> {
     res.buffer(JSON.stringify([...fonts].sort()), 'application/json');
     return res;
   } catch (e: any) {
-    if (e.code === 404) return new LambdaHttpResponse(404, 'No Found');
+    if (e.code === 404) return NotFound;
     throw e;
   }
 }

--- a/packages/lambda-tiler/src/routes/fonts.ts
+++ b/packages/lambda-tiler/src/routes/fonts.ts
@@ -24,26 +24,31 @@ export async function fontGet(req: LambdaHttpRequest<FontGet>): Promise<LambdaHt
   }
 }
 
+/** Get the unique name of folders is a path that contain .pbf files */
+export async function getFonts(fontPath: string): Promise<string[]> {
+  const fonts = new Set<string>();
+
+  // TODO use {recursive: false}
+  for await (const font of fsa.list(fontPath)) {
+    if (!font.endsWith('.pbf')) continue;
+    const dirName = path.basename(path.dirname(font)); // TODO this only works for /a/b.pbf and not /a/b/c.pbf
+    if (dirName.includes('/')) continue;
+    fonts.add(dirName);
+  }
+  // Ensure the fonts are alphabetical
+  return [...fonts].sort();
+}
+
 export async function fontList(): Promise<LambdaHttpResponse> {
   const assetLocation = Env.get(Env.AssetLocation);
   if (assetLocation == null) return NotFound;
 
   try {
     const filePath = fsa.join(assetLocation, '/fonts');
-    const fonts = new Set<string>();
-
-    // TODO use {recursive: false}
-    for await (const fontPath of fsa.list(filePath)) {
-      if (!fontPath.endsWith('.pbf')) continue;
-      const basePath = fontPath.slice(filePath.length + 1);
-      const dirName = path.dirname(basePath); // TODO this only works for /a/b.pbf and not /a/b/c.pbf
-      if (dirName.includes('/')) continue;
-      fonts.add(dirName);
-    }
+    const fonts = await getFonts(filePath);
 
     const res = new LambdaHttpResponse(200, 'ok');
-    res.buffer(JSON.stringify([...fonts].sort()), 'application/json');
-    return res;
+    return res.buffer(JSON.stringify(fonts), 'application/json');
   } catch (e: any) {
     if (e.code === 404) return NotFound;
     throw e;

--- a/packages/lambda-tiler/src/routes/fonts.ts
+++ b/packages/lambda-tiler/src/routes/fonts.ts
@@ -1,0 +1,50 @@
+import { Env } from '@basemaps/shared';
+import { fsa } from '@chunkd/fs';
+import { LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambda';
+import path from 'path';
+
+interface FontGet {
+  Params: { fontStack: string; range: string };
+}
+
+export async function fontGet(req: LambdaHttpRequest<FontGet>): Promise<LambdaHttpResponse> {
+  const assetLocation = Env.get(Env.AssetLocation);
+  if (assetLocation == null) return new LambdaHttpResponse(404, 'No Found');
+
+  try {
+    const filePath = fsa.join(assetLocation, path.join('fonts', req.params.fontStack, req.params.range)) + '.pbf';
+    const buf = await fsa.read(filePath);
+    const res = new LambdaHttpResponse(200, 'ok');
+    res.buffer(buf, 'application/x-protobuf');
+    return res;
+  } catch (e: any) {
+    if (e.code === 404) return new LambdaHttpResponse(404, 'No Found');
+    throw e;
+  }
+}
+
+export async function fontList(): Promise<LambdaHttpResponse> {
+  const assetLocation = Env.get(Env.AssetLocation);
+  if (assetLocation == null) return new LambdaHttpResponse(404, 'No Found');
+
+  try {
+    const filePath = fsa.join(assetLocation, '/fonts');
+    const fonts = new Set<string>();
+
+    // TODO use {recursive: false}
+    for await (const fontPath of fsa.list(filePath)) {
+      if (!fontPath.endsWith('.pbf')) continue;
+      const basePath = fontPath.slice(filePath.length + 1);
+      const dirName = path.dirname(basePath); // TODO this only works for /a/b.pbf and not /a/b/c.pbf
+      if (dirName.includes('/')) continue;
+      fonts.add(dirName);
+    }
+
+    const res = new LambdaHttpResponse(200, 'ok');
+    res.buffer(JSON.stringify([...fonts].sort()), 'application/json');
+    return res;
+  } catch (e: any) {
+    if (e.code === 404) return new LambdaHttpResponse(404, 'No Found');
+    throw e;
+  }
+}

--- a/packages/lambda-tiler/src/routes/sprites.ts
+++ b/packages/lambda-tiler/src/routes/sprites.ts
@@ -1,0 +1,35 @@
+import { Env } from '@basemaps/shared';
+import { fsa } from '@chunkd/fs';
+import path from 'path';
+import { LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambda';
+
+interface SpriteGet {
+  Params: {
+    spriteName: string;
+  };
+}
+
+const Extensions = new Map();
+Extensions.set('.png', 'image/png');
+Extensions.set('.json', 'application/json');
+
+export async function spriteGet(req: LambdaHttpRequest<SpriteGet>): Promise<LambdaHttpResponse> {
+  const spriteLocation = Env.get(Env.AssetLocation);
+  if (spriteLocation == null) return new LambdaHttpResponse(404, 'No Found');
+
+  const extension = path.extname(req.params.spriteName);
+  const mimeType = Extensions.get(extension);
+  if (mimeType == null) return new LambdaHttpResponse(404, 'No Found');
+
+  try {
+    const filePath = fsa.join(spriteLocation, fsa.join('/sprites', req.params.spriteName));
+    req.set('target', filePath);
+    const buf = await fsa.read(filePath);
+    const res = new LambdaHttpResponse(200, 'ok');
+    res.buffer(buf, extension);
+    return res;
+  } catch (e: any) {
+    if (e.code === 404) return new LambdaHttpResponse(404, 'No Found');
+    throw e;
+  }
+}

--- a/packages/lambda-tiler/src/routes/sprites.ts
+++ b/packages/lambda-tiler/src/routes/sprites.ts
@@ -2,6 +2,7 @@ import { Env } from '@basemaps/shared';
 import { fsa } from '@chunkd/fs';
 import path from 'path';
 import { LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambda';
+import { NotFound } from './response.js';
 
 interface SpriteGet {
   Params: {
@@ -15,11 +16,11 @@ Extensions.set('.json', 'application/json');
 
 export async function spriteGet(req: LambdaHttpRequest<SpriteGet>): Promise<LambdaHttpResponse> {
   const spriteLocation = Env.get(Env.AssetLocation);
-  if (spriteLocation == null) return new LambdaHttpResponse(404, 'No Found');
+  if (spriteLocation == null) return NotFound;
 
   const extension = path.extname(req.params.spriteName);
   const mimeType = Extensions.get(extension);
-  if (mimeType == null) return new LambdaHttpResponse(404, 'No Found');
+  if (mimeType == null) return NotFound;
 
   try {
     const filePath = fsa.join(spriteLocation, fsa.join('/sprites', req.params.spriteName));
@@ -29,7 +30,7 @@ export async function spriteGet(req: LambdaHttpRequest<SpriteGet>): Promise<Lamb
     res.buffer(buf, extension);
     return res;
   } catch (e: any) {
-    if (e.code === 404) return new LambdaHttpResponse(404, 'No Found');
+    if (e.code === 404) return NotFound;
     throw e;
   }
 }

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -37,6 +37,11 @@ export class BasemapsServerCommand extends BaseCommandLine {
     parameterLongName: '--bundle',
     description: 'Compile the configuration into a bundle and output path',
   });
+  assets = this.defineStringParameter({
+    argumentName: 'ASSETS',
+    parameterLongName: '--assets',
+    description: 'Where the assets (sprites, fonts) are located',
+  });
   port = this.defineIntegerParameter({
     argumentName: 'PORT',
     parameterLongName: '--port',
@@ -119,6 +124,12 @@ export class BasemapsServerCommand extends BaseCommandLine {
 
       mem.createVirtualTileSets();
       Config.setConfigProvider(mem);
+    }
+
+    if (this.assets.value) {
+      const isExists = await fsa.exists(this.assets.value);
+      if (!isExists) throw new Error('--asset path is missing');
+      process.env[Env.AssetLocation] = this.assets.value;
     }
 
     if (this.bundle.value != null) {

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -18,11 +18,15 @@ function isAlbResult(r: ALBResult | CloudFrontRequestResult | APIGatewayProxyRes
 const instanceId = ulid.ulid();
 
 function getLandingLocation(): string | null {
-  if (typeof require !== 'undefined' && typeof require.resolve === 'function') {
-    return require.resolve('@basemaps/landing/dist');
-  } else {
-    const require = createRequire(import.meta.url);
-    return require.resolve('@basemaps/landing/dist');
+  try {
+    if (typeof require !== 'undefined' && typeof require.resolve === 'function') {
+      return require.resolve('@basemaps/landing/dist');
+    } else {
+      const require = createRequire(import.meta.url);
+      return require.resolve('@basemaps/landing/dist');
+    }
+  } catch (e) {
+    return null;
   }
 }
 

--- a/packages/shared/src/const.ts
+++ b/packages/shared/src/const.ts
@@ -18,6 +18,9 @@ export const Env = {
   /** Public URL base that tiles are served from */
   PublicUrlBase: 'BASEMAPS_PUBLIC_URL',
 
+  /** Location of sprites and glyphs */
+  AssetLocation: 'BASEMAPS_ASSEST_LOCATION',
+
   /** How many tiffs to load at one time */
   TiffConcurrency: 'TIFF_CONCURRENCY',
 

--- a/packages/tiler-sharp/package.json
+++ b/packages/tiler-sharp/package.json
@@ -25,7 +25,7 @@
     "@basemaps/geo": "^6.28.1",
     "@basemaps/tiler": "^6.28.1",
     "@linzjs/metrics": "^6.28.1",
-    "sharp": "0.30.6"
+    "sharp": "^0.30.6"
   },
   "devDependencies": {
     "@types/pixelmatch": "^5.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6832,7 +6832,7 @@ shallow-clone@^3.0.0:
   dependencies:
     kind-of "^6.0.2"
 
-sharp@0.30.6, sharp@^0.30.6:
+sharp@^0.30.6:
   version "0.30.6"
   resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.30.6.tgz#02264e9826b5f1577509f70bb627716099778873"
   integrity sha512-lSdVxFxcndzcXggDrak6ozdGJgmIgES9YVZWtAFrwi+a/H5vModaf51TghBtMPw+71sLxUsTy2j+aB7qLIODQg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6832,7 +6832,7 @@ shallow-clone@^3.0.0:
   dependencies:
     kind-of "^6.0.2"
 
-sharp@^0.30.6:
+sharp@0.30.6, sharp@^0.30.6:
   version "0.30.6"
   resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.30.6.tgz#02264e9826b5f1577509f70bb627716099778873"
   integrity sha512-lSdVxFxcndzcXggDrak6ozdGJgmIgES9YVZWtAFrwi+a/H5vModaf51TghBtMPw+71sLxUsTy2j+aB7qLIODQg==


### PR DESCRIPTION
Using `/v1/fonts` over `/v1/glyphs` as the uri as that is what tileserver-gl uses