### PR TITLE
 feat(landing): show cog extents in debug mode

### DIFF
--- a/packages/cli/src/cli/server/action.serve.ts
+++ b/packages/cli/src/cli/server/action.serve.ts
@@ -1,26 +1,13 @@
-import { CommandLineAction } from '@rushstack/ts-command-line';
+import { CommandLineAction, CommandLineIntegerParameter, CommandLineStringParameter } from '@rushstack/ts-command-line';
 
 import { createServer } from '@basemaps/server';
 import { Const, Env, LogConfig } from '@basemaps/shared';
 const DefaultPort = 5000;
 
 export class CommandServe extends CommandLineAction {
-  config = this.defineStringParameter({
-    argumentName: 'CONFIG',
-    parameterLongName: '--config',
-    description: 'Configuration source to use',
-  });
-  assets = this.defineStringParameter({
-    argumentName: 'ASSETS',
-    parameterLongName: '--assets',
-    description: 'Where the assets (sprites, fonts) are located',
-  });
-  port = this.defineIntegerParameter({
-    argumentName: 'PORT',
-    parameterLongName: '--port',
-    description: 'port to use',
-    defaultValue: DefaultPort,
-  });
+  config: CommandLineStringParameter;
+  assets: CommandLineStringParameter;
+  port: CommandLineIntegerParameter;
 
   public constructor() {
     super({
@@ -31,7 +18,22 @@ export class CommandServe extends CommandLineAction {
   }
 
   protected onDefineParameters(): void {
-    //noop
+    this.config = this.defineStringParameter({
+      argumentName: 'CONFIG',
+      parameterLongName: '--config',
+      description: 'Configuration source to use',
+    });
+    this.assets = this.defineStringParameter({
+      argumentName: 'ASSETS',
+      parameterLongName: '--assets',
+      description: 'Where the assets (sprites, fonts) are located',
+    });
+    this.port = this.defineIntegerParameter({
+      argumentName: 'PORT',
+      parameterLongName: '--port',
+      description: 'port to use',
+      defaultValue: DefaultPort,
+    });
   }
 
   protected async onExecute(): Promise<void> {

--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -232,7 +232,6 @@ export class Debug extends Component<
     this.loadSourceLayer(layerId, type).then(() => {
       if (map.getLayer(layerLineId) != null) return;
 
-      // if (type === 'source') {
       // Fill is needed to make the mouse move work even though it has opacity 0
       map.addLayer({
         id: layerFillId,
@@ -244,7 +243,6 @@ export class Debug extends Component<
         },
       });
       this.trackMouseMove(layerId, type);
-      // }
 
       map.addLayer({
         id: layerLineId,

--- a/packages/landing/src/config.debug.ts
+++ b/packages/landing/src/config.debug.ts
@@ -2,8 +2,10 @@ export interface DebugState {
   debug: boolean;
   /** What color should the background be */
   'debug.background': string | false;
-  /** Should the source tiles */
+  /** Should the source tiles be shown */
   'debug.source': boolean;
+  /** Should the cog outlines be shown */
+  'debug.cog': boolean;
   /** Should things be hidden to make a better screenshot */
   'debug.screenshot': boolean;
   /** What opacity is the aerial layer, 0 is off */
@@ -18,6 +20,7 @@ export const DebugDefaults: DebugState = {
   debug: false,
   'debug.background': false,
   'debug.source': false,
+  'debug.cog': false,
   'debug.screenshot': false,
   'debug.layer.linz-aerial': 0,
   'debug.layer.linz-topographic': 0,
@@ -51,6 +54,7 @@ export class ConfigDebug {
     isChanged = setKey(opt, 'debug', true);
     isChanged = setKey(opt, 'debug.background', url.get('debug.background')) || isChanged;
     isChanged = setKey(opt, 'debug.source', url.get('debug.source') != null) || isChanged;
+    isChanged = setKey(opt, 'debug.cog', url.get('debug.cog') != null) || isChanged;
     isChanged = setKey(opt, 'debug.screenshot', url.get('debug.screenshot') != null) || isChanged;
     isChanged = setNum(opt, 'debug.layer.linz-aerial', url.get('debug.layer.linz-aerial')) || isChanged;
     isChanged = setNum(opt, 'debug.layer.linz-topographic', url.get('debug.layer.linz-topographic')) || isChanged;


### PR DESCRIPTION
This adds another checkbox to show the bounding box of the generated COGs  while in debug mode.
![image](https://user-images.githubusercontent.com/1082761/178896016-ed713ea1-c420-4a8a-862c-0913a4e8fd39.png)


Additional both `Source` and `Cog` now link to their geojson source files so they can be downloaded.

