### PR TITLE
feat(landing): support ?tileFormat as a alias to format BM-636

### DIFF
--- a/packages/lambda-tiler/src/routes/__tests__/wmts.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/wmts.test.ts
@@ -41,6 +41,12 @@ o.spec('GetImageFormats', () => {
     const formats = getImageFormats(req);
     o(formats).deepEquals([ImageFormat.Png, ImageFormat.Jpeg]);
   });
+
+  o('should support "tileFormat" Alias all formats', () => {
+    const req = newRequest('/v1/blank', 'tileFormat=png&format=jpeg');
+    const formats = getImageFormats(req);
+    o(formats).deepEquals([ImageFormat.Png, ImageFormat.Jpeg]);
+  });
 });
 
 o.spec('WMTSRouting', () => {

--- a/packages/lambda-tiler/src/routes/__tests__/wmts.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/wmts.test.ts
@@ -45,7 +45,13 @@ o.spec('GetImageFormats', () => {
   o('should support "tileFormat" Alias all formats', () => {
     const req = newRequest('/v1/blank', 'tileFormat=png&format=jpeg');
     const formats = getImageFormats(req);
-    o(formats).deepEquals([ImageFormat.Png, ImageFormat.Jpeg]);
+    o(formats).deepEquals([ImageFormat.Jpeg, ImageFormat.Png]);
+  });
+
+  o('should not duplicate "tileFormat" alias all formats', () => {
+    const req = newRequest('/v1/blank', 'tileFormat=jpeg&format=jpeg');
+    const formats = getImageFormats(req);
+    o(formats).deepEquals([ImageFormat.Jpeg]);
   });
 });
 

--- a/packages/lambda-tiler/src/routes/tile.wmts.ts
+++ b/packages/lambda-tiler/src/routes/tile.wmts.ts
@@ -10,7 +10,7 @@ import { NotFound, NotModified } from './response.js';
 import { TileEtag } from './tile.etag.js';
 
 export function getImageFormats(req: LambdaHttpRequest): ImageFormat[] | undefined {
-  const formats = req.query.getAll('format');
+  const formats = [...req.query.getAll('format'), ...req.query.getAll('tileFormat')];
   if (formats == null || formats.length === 0) return undefined;
 
   const output: Set<ImageFormat> = new Set();

--- a/packages/lambda-tiler/src/routes/tile.wmts.ts
+++ b/packages/lambda-tiler/src/routes/tile.wmts.ts
@@ -11,7 +11,7 @@ import { TileEtag } from './tile.etag.js';
 
 export function getImageFormats(req: LambdaHttpRequest): ImageFormat[] | undefined {
   const formats = [...req.query.getAll('format'), ...req.query.getAll('tileFormat')];
-  if (formats == null || formats.length === 0) return undefined;
+  if (formats.length === 0) return;
 
   const output: Set<ImageFormat> = new Set();
   for (const fmt of formats) {
@@ -19,7 +19,7 @@ export function getImageFormats(req: LambdaHttpRequest): ImageFormat[] | undefin
     if (parsed == null) continue;
     output.add(parsed);
   }
-  if (output.size === 0) return undefined;
+  if (output.size === 0) return;
   return [...output.values()];
 }
 


### PR DESCRIPTION
ArcGIS Pro has "format" as a reserved word and cannot be used.


BM-636