### PR TITLE
fix(landing): ignore all layers with " dem " in the title

### DIFF
--- a/packages/landing/src/attribution.ts
+++ b/packages/landing/src/attribution.ts
@@ -74,7 +74,8 @@ export class MapAttribution {
 
   // Ignore DEMS from the attribution list
   isIgnored = (attr: AttributionBounds): boolean => {
-    return attr.collection.title.toLowerCase().startsWith('geographx');
+    const title = attr.collection.title.toLowerCase();
+    return title.startsWith('geographx') || title.includes(' dem ');
   };
 
   /**


### PR DESCRIPTION
We are now using the improved titles which no longer start with geographx

Example titles to be ignored
> New Zealand 8m DEM Hillshade (2012)
> New Zealand 8m DEM Texture Shade (2012)
