### PR TITLE
ci: head_ref doesnt exist on "push"

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,7 +13,7 @@ jobs:
 
   build-deploy:
     runs-on: ubuntu-latest
-    concurrency: deploy-${{ github.head_ref }}
+    concurrency: deploy-${{ github.ref }}
 
     permissions:
       id-token: write


### PR DESCRIPTION
To fix this:

![image](https://user-images.githubusercontent.com/1082761/180672759-ded87e07-1c67-48f7-8b06-720a2bdb84c2.png)

`github.head_ref`  is used for `pull_request` events.

>  This property is only available when the event that triggers a workflow run is either pull_request or pull_request_target

 `push` does not have a value.

https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

