### PR TITLE
wip: cache the chunks of the files as a single large cache rather than source files

### DIFF
--- a/packages/lambda-tiler/src/index.ts
+++ b/packages/lambda-tiler/src/index.ts
@@ -11,8 +11,8 @@ import { styleJsonGet } from './routes/tile.style.json.js';
 import { wmtsCapabilitiesGet } from './routes/tile.wmts.js';
 import { tileXyzGet } from './routes/tile.xyz.js';
 import { versionGet } from './routes/version.js';
+import { ChunkCache } from './util/chunk.cache.js';
 import { NotFound } from './util/response.js';
-import { CoSources } from './util/source.cache.js';
 import { St } from './util/source.tracer.js';
 
 export const handler = lf.http(LogConfig.get());
@@ -35,14 +35,14 @@ handler.router.hook('response', (req, res) => {
     req.set('requestCount', St.requests.length);
   }
   // Log the source cache hit/miss ratio
-  req.set('sources', {
-    hits: CoSources.cache.hits,
-    misses: CoSources.cache.misses,
-    size: CoSources.cache.currentSize,
-    resets: CoSources.cache.resets,
-    clears: CoSources.cache.clears,
-    cacheA: CoSources.cache.cacheA.size,
-    cacheB: CoSources.cache.cacheB.size,
+  req.set('chunks', {
+    hits: ChunkCache.hits,
+    misses: ChunkCache.misses,
+    size: ChunkCache.currentSize,
+    resets: ChunkCache.resets,
+    clears: ChunkCache.clears,
+    cacheA: ChunkCache.cacheA.size,
+    cacheB: ChunkCache.cacheB.size,
   });
 
   // Force access-control-allow-origin to everything

--- a/packages/lambda-tiler/src/util/chunk.cache.ts
+++ b/packages/lambda-tiler/src/util/chunk.cache.ts
@@ -1,0 +1,30 @@
+import { ChunkSource } from '@chunkd/core';
+import { SwappingLru } from './swapping.lru.js';
+
+export const ChunkCache = new SwappingLru<DataView>(1000); // Chunks are generally 64KB so 1000 * 64KB of storage
+
+export class SharedSourceCache {
+  source: ChunkSource;
+  constructor(source: ChunkSource) {
+    this.source = source;
+  }
+  get(chunkId: number): DataView | undefined {
+    return ChunkCache.get(`${this.source.uri}@${chunkId}x${this.source.chunkSize}`);
+  }
+
+  has(chunkId: number): boolean {
+    return ChunkCache.get(`${this.source.uri}@${chunkId}x${this.source.chunkSize}`) != null;
+  }
+
+  set(chunkId: number, value: DataView): void {
+    return ChunkCache.set(`${this.source.uri}@${chunkId}x${this.source.chunkSize}`, value);
+  }
+
+  clear(): void {
+    throw new Error('Cannot clear shared cache');
+  }
+
+  get size(): number {
+    throw new Error('Cannot get size of shared cache');
+  }
+}

--- a/packages/lambda-tiler/src/util/source.cache.ts
+++ b/packages/lambda-tiler/src/util/source.cache.ts
@@ -1,5 +1,4 @@
 import { fsa } from '@basemaps/shared';
-import { ChunkSourceBase } from '@chunkd/core';
 import { CogTiff } from '@cogeotiff/core';
 import { Cotar } from '@cotar/core';
 import { St } from './source.tracer.js';
@@ -24,12 +23,6 @@ class LruStrutObj<T extends LruStrut> {
   constructor(ob: T) {
     this.ob = ob;
     if (this.ob._value == null) this.ob.value.then((c) => (this.ob._value = c));
-  }
-
-  get size(): number {
-    const val = this.ob._value;
-    if (val == null) return 0;
-    return val.source.chunkSize * (val.source as ChunkSourceBase).chunks.size;
   }
 }
 
@@ -68,5 +61,5 @@ export class SourceCache {
   }
 }
 
-/** Approx 1GB */
-export const CoSources = new SourceCache(1000 * 1000 * 1000);
+/** Track the last 5,000 Sources so we don't have to re-init them */
+export const CoSources = new SourceCache(5_000);


### PR DESCRIPTION
this gives a lot more power in terms of what "chunks" of a file are cached rather than entire file