### PR TITLE
ci: correct the ordering of docker tags in github webui

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -60,9 +60,9 @@ jobs:
           context: packages/cli
           platforms: linux/arm64,linux/amd64
           tags: |
-            ghcr.io/linz/basemaps/cli:${{ steps.version.outputs.version }}
             ghcr.io/linz/basemaps/cli:latest
-          push: ${{github.ref == 'refs/heads/master'}}
+            ghcr.io/linz/basemaps/cli:${{ steps.version.outputs.version }}
+          push: ${{github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'release:') == false}}
 
       - name: "@basemaps/cli - Build and push Major/Minor"
         uses: docker/build-push-action@v3
@@ -71,8 +71,11 @@ jobs:
           platforms: linux/arm64,linux/amd64
           # Publish :v6 and :v6.38 tags when publishing a release
           tags: |
+            ghcr.io/linz/basemaps/cli:latest
             ghcr.io/linz/basemaps/cli:${{ steps.version.outputs.version_major }}
             ghcr.io/linz/basemaps/cli:${{ steps.version.outputs.version_major_minor }}
+            ghcr.io/linz/basemaps/cli:${{ steps.version.outputs.version }}
+
           push: ${{github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'release:')}}
 
       - name: "@basemaps/server - Build and push"
@@ -81,9 +84,9 @@ jobs:
           context: packages/server
           platforms: linux/arm64,linux/amd64
           tags: |
-           ghcr.io/linz/basemaps/server:${{ steps.version.outputs.version }}
            ghcr.io/linz/basemaps/server:latest
-          push: ${{github.ref == 'refs/heads/master'}}
+           ghcr.io/linz/basemaps/server:${{ steps.version.outputs.version }}
+          push: ${{github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'release:') == false}}
 
       - name: "@basemaps/server - Build and push Major/Minor"
         uses: docker/build-push-action@v3
@@ -92,6 +95,8 @@ jobs:
           platforms: linux/arm64,linux/amd64
           # Publish :v6 and :v6.38 tags when publishing a release
           tags: |
+            ghcr.io/linz/basemaps/server:latest
             ghcr.io/linz/basemaps/server:${{ steps.version.outputs.version_major }}
             ghcr.io/linz/basemaps/server:${{ steps.version.outputs.version_major_minor }}
+            ghcr.io/linz/basemaps/server:${{ steps.version.outputs.version }}
           push: ${{github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'release:')}}


### PR DESCRIPTION
Previously it was making two container hashes and the order of the tags was

- major.minor, major
- latest, major.minor.patch