### PR TITLE
feat: filter layers by date

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -60,9 +60,9 @@ jobs:
           context: packages/cli
           platforms: linux/arm64,linux/amd64
           tags: |
-            ghcr.io/linz/basemaps/cli:${{ steps.version.outputs.version }}
             ghcr.io/linz/basemaps/cli:latest
-          push: ${{github.ref == 'refs/heads/master'}}
+            ghcr.io/linz/basemaps/cli:${{ steps.version.outputs.version }}
+          push: ${{github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'release:') == false}}
 
       - name: "@basemaps/cli - Build and push Major/Minor"
         uses: docker/build-push-action@v3
@@ -71,8 +71,11 @@ jobs:
           platforms: linux/arm64,linux/amd64
           # Publish :v6 and :v6.38 tags when publishing a release
           tags: |
+            ghcr.io/linz/basemaps/cli:latest
             ghcr.io/linz/basemaps/cli:${{ steps.version.outputs.version_major }}
             ghcr.io/linz/basemaps/cli:${{ steps.version.outputs.version_major_minor }}
+            ghcr.io/linz/basemaps/cli:${{ steps.version.outputs.version }}
+
           push: ${{github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'release:')}}
 
       - name: "@basemaps/server - Build and push"
@@ -81,9 +84,9 @@ jobs:
           context: packages/server
           platforms: linux/arm64,linux/amd64
           tags: |
-           ghcr.io/linz/basemaps/server:${{ steps.version.outputs.version }}
            ghcr.io/linz/basemaps/server:latest
-          push: ${{github.ref == 'refs/heads/master'}}
+           ghcr.io/linz/basemaps/server:${{ steps.version.outputs.version }}
+          push: ${{github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'release:') == false}}
 
       - name: "@basemaps/server - Build and push Major/Minor"
         uses: docker/build-push-action@v3
@@ -92,6 +95,8 @@ jobs:
           platforms: linux/arm64,linux/amd64
           # Publish :v6 and :v6.38 tags when publishing a release
           tags: |
+            ghcr.io/linz/basemaps/server:latest
             ghcr.io/linz/basemaps/server:${{ steps.version.outputs.version_major }}
             ghcr.io/linz/basemaps/server:${{ steps.version.outputs.version_major_minor }}
+            ghcr.io/linz/basemaps/server:${{ steps.version.outputs.version }}
           push: ${{github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'release:')}}

--- a/packages/_infra/src/edge/index.ts
+++ b/packages/_infra/src/edge/index.ts
@@ -101,7 +101,7 @@ export class EdgeStack extends cdk.Stack {
           forwardedValues: {
             /** Forward all query strings but do not use them for caching */
             queryString: true,
-            queryStringCacheKeys: ['config', 'exclude'],
+            queryStringCacheKeys: ['config', 'exclude', 'date[before]', 'date[after]'],
           },
           lambdaFunctionAssociations: [],
         },

--- a/packages/attribution/src/attribution.ts
+++ b/packages/attribution/src/attribution.ts
@@ -27,11 +27,11 @@ export class AttributionBounds {
   }
 
   /**
-     * Does this AttributionCollection intersect with `extent`
-
-     * @param extent The extent to test for intersection against
-     * @param zoom only test extent if `zoom` is between `minZoom` and `maxZoom`
-     */
+   * Does this AttributionCollection intersect with `extent`
+   *
+   * @param extent The extent to test for intersection against
+   * @param zoom only test extent if `zoom` is between `minZoom` and `maxZoom`
+   */
   intersects(extent: BBox, zoom: number): boolean {
     if (zoom > this.maxZoom || zoom < this.minZoom) return false;
     if (!Wgs84.intersects(extent, this.bbox)) return false;
@@ -99,7 +99,7 @@ function convertToBounds(stac: AttributionStac): AttributionBounds[] {
 
 /** Get the year range for an AttributionCollection */
 function getYears(col: AttributionCollection): [number, number] {
-  const { interval } = col.extent.temporal;
+  const interval = col.extent?.temporal?.interval;
   if (interval == null || interval.length === 0) return [-1, -1];
   const range = interval[0];
   const y1 = new Date(range[0]).getFullYear();
@@ -120,10 +120,10 @@ export class Attribution {
   }
 
   /**
-     * Fetch the AttributionStac from server and load into `attributions`
-
-     * @param url the location of the AttributionStac file
-     */
+   * Fetch the AttributionStac from server and load into `attributions`
+   *
+   * @param url the location of the AttributionStac file
+   */
   static async load(url: string): Promise<Attribution> {
     const resp = await fetch(url);
     if (resp.ok) {
@@ -139,11 +139,11 @@ export class Attribution {
   }
 
   /**
-     * Filter the attributions to just those that intersect with `extent` and `zoom`
-
-     * @param extent a bounding box in the projection supplied to the constructor
-     * @param zoom the zoom level the extent is viewed at
-     */
+   * Filter the attributions to just those that intersect with `extent` and `zoom`
+   *
+   * @param extent a bounding box in the projection supplied to the constructor
+   * @param zoom the zoom level the extent is viewed at
+   */
   filter(extent: BBox, zoom: number): AttributionCollection[] {
     zoom = Math.round(zoom);
 
@@ -162,10 +162,10 @@ export class Attribution {
   isIgnored?: (attr: AttributionBounds) => boolean;
 
   /**
-     * Render the filtered attributions as a simple string suitable to display as attribution
-
-     * @param list the filtered list of attributions
-     */
+   * Render the filtered attributions as a simple string suitable to display as attribution
+   *
+   * @param list the filtered list of attributions
+   */
   renderList(list: AttributionCollection[]): string {
     if (list.length === 0) return '';
     let result = escapeHtml(list[0].title);

--- a/packages/cli/src/cli/overview/overview.wmts.ts
+++ b/packages/cli/src/cli/overview/overview.wmts.ts
@@ -22,7 +22,6 @@ export function createOverviewWmtsCapabilities(
     formats: [ImageFormat.Webp],
     httpBase: '',
     imagery: new Map(),
-    isIndividualLayers: false,
   });
 
   wmts.maxZoom = maxZoom;

--- a/packages/geo/src/stac/index.ts
+++ b/packages/geo/src/stac/index.ts
@@ -42,7 +42,7 @@ export interface StacExtent {
   spatial: {
     bbox: [number, number, number, number][];
   };
-  temporal: {
+  temporal?: {
     interval: [string, string][];
   };
 }

--- a/packages/geo/src/stac/stac.attribution.ts
+++ b/packages/geo/src/stac/stac.attribution.ts
@@ -15,9 +15,9 @@ export type AttributionCollection = StacCollection<{
 export type AttributionItem = StacItem<{
   title: string;
   category?: string;
-  datetime: null;
-  start_datetime: string;
-  end_datetime: string;
+  datetime?: null;
+  start_datetime?: string;
+  end_datetime?: string;
 }>;
 
 /**

--- a/packages/lambda-tiler/src/__tests__/wmts.capability.test.ts
+++ b/packages/lambda-tiler/src/__tests__/wmts.capability.test.ts
@@ -30,7 +30,6 @@ o.spec('WmtsCapabilities', () => {
       imagery: allImagery,
       apiKey,
       formats: [ImageFormat.Avif],
-      isIndividualLayers: false,
     }).toVNode();
 
     const urls = tags(wmts, 'ResourceURL');
@@ -51,7 +50,6 @@ o.spec('WmtsCapabilities', () => {
       apiKey,
       config: 's3://linz-basemaps/config.json',
       formats: [ImageFormat.Avif],
-      isIndividualLayers: false,
     }).toVNode();
 
     const urls = tags(wmts, 'ResourceURL');
@@ -71,7 +69,6 @@ o.spec('WmtsCapabilities', () => {
       imagery: allImagery,
       apiKey,
       formats: [ImageFormat.Avif],
-      isIndividualLayers: false,
     }).toXml();
 
     o(xml.split('\n')[0]).deepEquals('<?xml version="1.0" encoding="utf-8"?>');
@@ -90,7 +87,6 @@ o.spec('WmtsCapabilities', () => {
       imagery: allImagery,
       apiKey,
       formats: [ImageFormat.Avif],
-      isIndividualLayers: false,
     }).toVNode();
 
     const urls = tags(wmts, 'ResourceURL');
@@ -142,7 +138,7 @@ o.spec('WmtsCapabilities', () => {
       tileSet,
       imagery,
       apiKey,
-      isIndividualLayers: true,
+      layers: tileSet.layers,
     }).toVNode();
 
     const layers = tags(wmts, 'Layer').map((c) => c.find('ows:Title')?.textContent);
@@ -161,7 +157,6 @@ o.spec('WmtsCapabilities', () => {
       tileSet: TileSetAerial,
       imagery,
       apiKey,
-      isIndividualLayers: false,
     });
 
     const raw = wmts.toVNode();
@@ -213,7 +208,6 @@ o.spec('WmtsCapabilities', () => {
       tileSet: TileSetAerial,
       imagery: allImagery,
       apiKey,
-      isIndividualLayers: false,
     }).toVNode();
     const layer = raw.find('Contents', 'Layer');
 
@@ -260,7 +254,7 @@ o.spec('WmtsCapabilities', () => {
       tileSet: TileSetAerial,
       imagery: imagery,
       formats: [ImageFormat.Png],
-      isIndividualLayers: true,
+      layers: TileSetAerial.layers,
     }).toVNode();
 
     const tms = raw?.find('TileMatrixSet', 'ows:Identifier');
@@ -299,7 +293,6 @@ o.spec('WmtsCapabilities', () => {
       tileSet: TileSetAerial,
       imagery: imagery,
       formats: [ImageFormat.Png],
-      isIndividualLayers: false,
     }).toVNode();
 
     const layers = tags(raw, 'Layer');
@@ -361,7 +354,7 @@ o.spec('WmtsCapabilities', () => {
       tileSet: TileSetAerial,
       imagery: imagery,
       formats: [ImageFormat.Png],
-      isIndividualLayers: true,
+      layers: TileSetAerial.layers,
     }).toVNode();
 
     const layers = tags(raw, 'Layer');
@@ -375,7 +368,7 @@ o.spec('WmtsCapabilities', () => {
       tileSet: TileSetAerial,
       imagery: imagery,
       formats: [ImageFormat.Png],
-      isIndividualLayers: true,
+      layers: TileSetAerial.layers,
     }).toVNode();
 
     const layersB = tags(rawB, 'Layer');
@@ -408,7 +401,7 @@ o.spec('WmtsCapabilities', () => {
       tileSet,
       imagery,
       formats: [ImageFormat.Png],
-      isIndividualLayers: true,
+      layers: tileSet.layers,
     }).toVNode();
 
     const boundingBox = tags(raw, 'ows:WGS84BoundingBox').map((c) =>
@@ -447,7 +440,7 @@ o.spec('WmtsCapabilities', () => {
       tileSet,
       imagery,
       formats: [ImageFormat.Png],
-      isIndividualLayers: true,
+      layers: tileSet.layers,
     }).toVNode();
 
     const boundingBox = tags(raw, 'ows:WGS84BoundingBox').map((c) =>

--- a/packages/lambda-tiler/src/__tests__/xyz.util.ts
+++ b/packages/lambda-tiler/src/__tests__/xyz.util.ts
@@ -3,6 +3,8 @@ import { LambdaAlbRequest, LambdaHttpRequest, LambdaUrlRequest } from '@linzjs/l
 import { Context } from 'aws-lambda';
 
 export function mockRequest(path: string, method = 'get', headers: Record<string, string> = {}): LambdaHttpRequest {
+  const log = LogConfig.get();
+  log.level = 'silent';
   return new LambdaAlbRequest(
     {
       requestContext: null as any,
@@ -13,7 +15,7 @@ export function mockRequest(path: string, method = 'get', headers: Record<string
       isBase64Encoded: false,
     },
     {} as Context,
-    LogConfig.get(),
+    log,
   );
 }
 
@@ -23,6 +25,8 @@ export function mockUrlRequest(
   headers: Record<string, unknown> = {},
   method?: string,
 ): LambdaHttpRequest {
+  const log = LogConfig.get();
+  log.level = 'silent';
   return new LambdaUrlRequest(
     {
       requestContext: { http: { method: method ? method.toUpperCase() : 'GET' } },
@@ -32,7 +36,7 @@ export function mockUrlRequest(
       isBase64Encoded: false,
     } as any,
     {} as Context,
-    LogConfig.get(),
+    log,
   );
 }
 

--- a/packages/lambda-tiler/src/routes/__tests__/wmts.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/wmts.test.ts
@@ -9,9 +9,18 @@ import { Api, mockUrlRequest } from '../../__tests__/xyz.util.js';
 o.spec('WMTSRouting', () => {
   const sandbox = createSandbox();
   const config = new ConfigProviderMemory();
+  const imagery = new Map();
 
-  o.before(() => {
+  o.beforeEach(() => {
     sandbox.stub(ConfigLoader, 'load').resolves(config);
+
+    imagery.set(Imagery3857.id, Imagery3857);
+    imagery.set(Imagery2193.id, Imagery2193);
+
+    config.put(TileSetAerial);
+    config.put(Imagery2193);
+    config.put(Imagery3857);
+    config.put(Provider);
   });
 
   o.afterEach(() => {
@@ -20,15 +29,6 @@ o.spec('WMTSRouting', () => {
   });
 
   o('should default to the aerial layer', async () => {
-    const imagery = new Map();
-    imagery.set(Imagery3857.id, Imagery3857);
-    imagery.set(Imagery2193.id, Imagery2193);
-
-    config.put(TileSetAerial);
-    config.put(Imagery2193);
-    config.put(Imagery3857);
-    config.put(Provider);
-
     const req = mockUrlRequest(
       '/v1/tiles/WMTSCapabilities.xml',
       `format=png&api=${Api.key}&config=s3://linz-basemaps/config.json`,
@@ -51,6 +51,61 @@ o.spec('WMTSRouting', () => {
     o(resourceURLs).deepEquals([
       '<ResourceURL format="image/png" resourceType="tile" template="https://tiles.test/v1/tiles/aerial/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png?api=d01f7w7rnhdzg0p7fyrc9v9ard1&amp;config=Q5pC4UjWdtFLU1CYtLcRSmB49RekgDgMa5EGJnB2M" />',
       '<ResourceURL format="image/png" resourceType="tile" template="https://tiles.test/v1/tiles/ōtorohanga-urban-2021-0.1m/{TileMatrixSet}/{TileMatrix}/{TileCol}/{TileRow}.png?api=d01f7w7rnhdzg0p7fyrc9v9ard1&amp;config=Q5pC4UjWdtFLU1CYtLcRSmB49RekgDgMa5EGJnB2M" />',
+    ]);
+  });
+
+  o('should filter out date[after] by year', async () => {
+    const req = mockUrlRequest(
+      '/v1/tiles/WMTSCapabilities.xml',
+      `format=png&api=${Api.key}&config=s3://linz-basemaps/config.json&date[after]=2022`,
+    );
+    const res = await handler.router.handle(req);
+
+    o(res.status).equals(200);
+    const lines = Buffer.from(res.body, 'base64').toString().split('\n');
+    const titles = lines.filter((f) => f.startsWith('      <ows:Title>')).map((f) => f.trim());
+
+    o(titles).deepEquals([
+      '<ows:Title>Aerial Imagery</ows:Title>',
+      '<ows:Title>Google Maps Compatible for the World</ows:Title>',
+      '<ows:Title>LINZ NZTM2000 Map Tile Grid V2</ows:Title>',
+    ]);
+  });
+
+  o('should filter out date[before] by year', async () => {
+    const req = mockUrlRequest(
+      '/v1/tiles/WMTSCapabilities.xml',
+      `format=png&api=${Api.key}&config=s3://linz-basemaps/config.json&date[before]=2020`,
+    );
+    const res = await handler.router.handle(req);
+
+    o(res.status).equals(200);
+    const lines = Buffer.from(res.body, 'base64').toString().split('\n');
+    const titles = lines.filter((f) => f.startsWith('      <ows:Title>')).map((f) => f.trim());
+
+    o(titles).deepEquals([
+      '<ows:Title>Aerial Imagery</ows:Title>',
+      '<ows:Title>Google Maps Compatible for the World</ows:Title>',
+      '<ows:Title>LINZ NZTM2000 Map Tile Grid V2</ows:Title>',
+    ]);
+  });
+
+  o('should filter inclusive date[before] by year', async () => {
+    const req = mockUrlRequest(
+      '/v1/tiles/WMTSCapabilities.xml',
+      `format=png&api=${Api.key}&config=s3://linz-basemaps/config.json&date[before]=2021`,
+    );
+    const res = await handler.router.handle(req);
+
+    o(res.status).equals(200);
+    const lines = Buffer.from(res.body, 'base64').toString().split('\n');
+    const titles = lines.filter((f) => f.startsWith('      <ows:Title>')).map((f) => f.trim());
+
+    o(titles).deepEquals([
+      '<ows:Title>Aerial Imagery</ows:Title>',
+      '<ows:Title>Ōtorohanga 0.1m Urban Aerial Photos (2021)</ows:Title>',
+      '<ows:Title>Google Maps Compatible for the World</ows:Title>',
+      '<ows:Title>LINZ NZTM2000 Map Tile Grid V2</ows:Title>',
     ]);
   });
 });

--- a/packages/lambda-tiler/src/routes/attribution.ts
+++ b/packages/lambda-tiler/src/routes/attribution.ts
@@ -11,12 +11,13 @@ import {
   StacProvider,
   TileMatrixSet,
 } from '@basemaps/geo';
-import { extractYearRangeFromName, Projection, titleizeImageryName } from '@basemaps/shared';
+import { extractYearRangeFromTitle, Projection } from '@basemaps/shared';
 import { BBox, MultiPolygon, multiPolygonToWgs84, Pair, union, Wgs84 } from '@linzjs/geojson';
 import { HttpHeader, LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambda';
 import { ConfigLoader } from '../util/config.loader.js';
 
 import { Etag } from '../util/etag.js';
+import { filterLayers, yearRangeToInterval } from '../util/filter.js';
 import { NotFound, NotModified } from '../util/response.js';
 import { Validate } from '../util/validate.js';
 
@@ -86,30 +87,22 @@ async function tileSetAttribution(
 
   const config = await ConfigLoader.load(req);
   const imagery = await getAllImagery(config, tileSet.layers, [tileMatrix.projection]);
+  const filteredLayers = await filterLayers(req, tileSet.layers);
 
   const host = await config.Provider.get(config.Provider.id('linz'));
 
-  for (const layer of tileSet.layers) {
+  for (const layer of filteredLayers) {
     const imgId = layer[proj.epsg.code];
     if (imgId == null) continue;
     const im = imagery.get(imgId);
     if (im == null) continue;
+    if (im.title == null) continue;
 
     const bbox = proj.boundsToWgs84BoundingBox(im.bounds).map(roundNumber) as BBox;
 
-    const years = extractYearRangeFromName(im.name);
-    if (years[0] === -1) {
-      req.log.debug({ imagery: im.name }, 'Attribution:DefaultYear');
-      // Put it in the future so people know its a "fake" date
-      years[0] = new Date().getUTCFullYear() + 1;
-      years[1] = years[0] + 1;
-    }
+    const extent: StacExtent = { spatial: { bbox: [bbox] } };
 
-    const interval = [years.map((y) => `${y}-01-01T00:00:00Z`) as [string, string]];
-
-    const extent: StacExtent = { spatial: { bbox: [bbox] }, temporal: { interval } };
-
-    items.push({
+    const item: AttributionItem = {
       type: 'Feature',
       stac_version: Stac.Version,
       id: imgId + '_item',
@@ -119,13 +112,19 @@ async function tileSetAttribution(
       bbox,
       geometry: { type: 'MultiPolygon', coordinates: createCoordinates(bbox, im.files, proj) },
       properties: {
-        title: im.title ?? titleizeImageryName(im.name),
+        title: im.title,
         category: im.category,
-        datetime: null,
-        start_datetime: interval[0][0],
-        end_datetime: interval[0][1],
       },
-    });
+    };
+    const years = extractYearRangeFromTitle(im.title);
+    if (years) {
+      const interval = yearRangeToInterval(years);
+      extent.temporal = { interval: [interval] };
+      item.properties.datetime = null;
+      item.properties.start_datetime = interval[0];
+      item.properties.end_datetime = interval[1];
+    }
+    items.push(item);
 
     const zoomMin = TileMatrixSet.convertZoomLevel(layer.minZoom ? layer.minZoom : 0, GoogleTms, tileMatrix, true);
     const zoomMax = TileMatrixSet.convertZoomLevel(layer.maxZoom ? layer.maxZoom : 32, GoogleTms, tileMatrix, true);
@@ -134,7 +133,7 @@ async function tileSetAttribution(
       license: Stac.License,
       id: im.id,
       providers: getHost(host),
-      title: im.title ?? titleizeImageryName(im.name),
+      title: im.title,
       description: 'No description',
       extent,
       links: [],

--- a/packages/lambda-tiler/src/routes/attribution.ts
+++ b/packages/lambda-tiler/src/routes/attribution.ts
@@ -87,7 +87,7 @@ async function tileSetAttribution(
 
   const config = await ConfigLoader.load(req);
   const imagery = await getAllImagery(config, tileSet.layers, [tileMatrix.projection]);
-  const filteredLayers = await filterLayers(req, tileSet.layers);
+  const filteredLayers = filterLayers(req, tileSet.layers);
 
   const host = await config.Provider.get(config.Provider.id('linz'));
 
@@ -119,10 +119,10 @@ async function tileSetAttribution(
     const years = extractYearRangeFromTitle(im.title);
     if (years) {
       const interval = yearRangeToInterval(years);
-      extent.temporal = { interval: [interval] };
+      extent.temporal = { interval: [[interval[0].toISOString(), interval[1].toISOString()]] };
       item.properties.datetime = null;
-      item.properties.start_datetime = interval[0];
-      item.properties.end_datetime = interval[1];
+      item.properties.start_datetime = interval[0].toISOString();
+      item.properties.end_datetime = interval[1].toISOString();
     }
     items.push(item);
 

--- a/packages/lambda-tiler/src/routes/tile.json.ts
+++ b/packages/lambda-tiler/src/routes/tile.json.ts
@@ -2,6 +2,7 @@ import { GoogleTms, TileJson, TileMatrixSet } from '@basemaps/geo';
 import { Env, toQueryString } from '@basemaps/shared';
 import { HttpHeader, LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambda';
 import { ConfigLoader } from '../util/config.loader.js';
+import { getFilters } from '../util/filter.js';
 import { NotFound } from '../util/response.js';
 import { Validate } from '../util/validate.js';
 
@@ -31,7 +32,7 @@ export async function tileJsonGet(req: LambdaHttpRequest<TileJsonGet>): Promise<
 
   const configLocation = ConfigLoader.extract(req);
 
-  const query = toQueryString({ api: apiKey, config: configLocation });
+  const query = toQueryString({ api: apiKey, config: configLocation, ...getFilters(req) });
 
   const tileUrl =
     [host, 'v1', 'tiles', tileSet.name, tileMatrix.identifier, '{z}', '{x}', '{y}'].join('/') + `.${format[0]}${query}`;

--- a/packages/lambda-tiler/src/routes/tile.style.json.ts
+++ b/packages/lambda-tiler/src/routes/tile.style.json.ts
@@ -8,6 +8,7 @@ import { Validate } from '../util/validate.js';
 import { Etag } from '../util/etag.js';
 import { ConfigLoader } from '../util/config.loader.js';
 import { GoogleTms, ImageFormat, TileMatrixSets } from '@basemaps/geo';
+import { getFilters } from '../util/filter.js';
 
 /**
  * Convert relative URLS into a full hostname url
@@ -73,7 +74,7 @@ export async function tileSetToStyle(
   if (tileFormat == null) return new LambdaHttpResponse(400, 'Invalid image format');
 
   const configLocation = ConfigLoader.extract(req);
-  const query = toQueryString({ config: configLocation, api: apiKey });
+  const query = toQueryString({ config: configLocation, api: apiKey, ...getFilters(req) });
 
   const tileUrl = fsa.join(
     Env.get(Env.PublicUrlBase) ?? '',

--- a/packages/lambda-tiler/src/routes/tile.wmts.ts
+++ b/packages/lambda-tiler/src/routes/tile.wmts.ts
@@ -8,6 +8,7 @@ import { Validate } from '../util/validate.js';
 import { WmtsCapabilities } from '../wmts.capability.js';
 import { Etag } from '../util/etag.js';
 import { ConfigLoader } from '../util/config.loader.js';
+import { filterLayers } from '../util/filter.js';
 
 export interface WmtsCapabilitiesGet {
   Params: {
@@ -59,11 +60,11 @@ export async function wmtsCapabilitiesGet(req: LambdaHttpRequest<WmtsCapabilitie
     provider: provider ?? undefined,
     tileSet,
     tileMatrix,
-    isIndividualLayers: req.params.tileMatrix == null,
     imagery,
     apiKey,
     config: ConfigLoader.extract(req),
     formats: Validate.getRequestedFormats(req),
+    layers: req.params.tileMatrix == null ? filterLayers(req, tileSet.layers) : null,
   }).toXml();
   if (xml == null) return NotFound();
 

--- a/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
+++ b/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
@@ -33,7 +33,7 @@ export const TileXyzRaster = {
   async getAssetsForTile(req: LambdaHttpRequest, tileSet: ConfigTileSetRaster, xyz: TileXyz): Promise<string[]> {
     const config = await ConfigLoader.load(req);
     const imagery = await getAllImagery(config, tileSet.layers, [xyz.tileMatrix.projection]);
-    const filteredLayers = await filterLayers(req, tileSet.layers);
+    const filteredLayers = filterLayers(req, tileSet.layers);
 
     const output: string[] = [];
     const tileBounds = xyz.tileMatrix.tileToSourceBounds(xyz.tile);

--- a/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
+++ b/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
@@ -9,6 +9,7 @@ import { HttpHeader, LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambd
 import pLimit from 'p-limit';
 import { ConfigLoader } from '../util/config.loader.js';
 import { Etag } from '../util/etag.js';
+import { filterLayers } from '../util/filter.js';
 import { NotFound, NotModified } from '../util/response.js';
 import { CoSources } from '../util/source.cache.js';
 import { TileXyz } from '../util/validate.js';
@@ -32,13 +33,14 @@ export const TileXyzRaster = {
   async getAssetsForTile(req: LambdaHttpRequest, tileSet: ConfigTileSetRaster, xyz: TileXyz): Promise<string[]> {
     const config = await ConfigLoader.load(req);
     const imagery = await getAllImagery(config, tileSet.layers, [xyz.tileMatrix.projection]);
+    const filteredLayers = await filterLayers(req, tileSet.layers);
 
     const output: string[] = [];
     const tileBounds = xyz.tileMatrix.tileToSourceBounds(xyz.tile);
 
     // All zoom level config is stored as Google zoom levels
     const filterZoom = TileMatrixSet.convertZoomLevel(xyz.tile.z, xyz.tileMatrix, TileMatrixSets.get(Epsg.Google));
-    for (const layer of tileSet.layers) {
+    for (const layer of filteredLayers) {
       if (layer.maxZoom != null && filterZoom > layer.maxZoom) continue;
       if (layer.minZoom != null && filterZoom < layer.minZoom) continue;
 

--- a/packages/lambda-tiler/src/util/__test__/filter.test.ts
+++ b/packages/lambda-tiler/src/util/__test__/filter.test.ts
@@ -23,55 +23,55 @@ o.spec('filterLayers', () => {
     },
   ];
 
-  o('should not filter with empty parameters', async () => {
-    const layers = await filterLayers(mockUrlRequest('/foo/bar,js'), sourceLayers);
+  o('should not filter with empty parameters', () => {
+    const layers = filterLayers(mockUrlRequest('/foo/bar,js'), sourceLayers);
     o(layers).deepEquals(sourceLayers);
   });
 
-  o('should filter date[after]', async () => {
+  o('should filter date[after]', () => {
     const dateAfter = '2003-12-31T23:59:59.999';
-    const layers = await filterLayers(mockUrlRequest('/foo/bar,js', `?date[after]=${dateAfter}`), sourceLayers);
+    const layers = filterLayers(mockUrlRequest('/foo/bar,js', `?date[after]=${dateAfter}`), sourceLayers);
     o(layers).deepEquals([sourceLayers[0]]);
   });
 
-  o('should filter date[before]', async () => {
+  o('should filter date[before]', () => {
     const dateBefore = '2003-01-01T00:00:00.000Z';
-    const layers = await filterLayers(mockUrlRequest('/foo/bar,js', `?date[before]=${dateBefore}`), sourceLayers);
+    const layers = filterLayers(mockUrlRequest('/foo/bar,js', `?date[before]=${dateBefore}`), sourceLayers);
     o(layers).deepEquals(sourceLayers.slice(1));
   });
 
-  o('should filter date[before] in between years', async () => {
+  o('should filter date[before] in between years', () => {
     const dateBefore = '2026-01-01T00:00:00.000Z';
     const layer = [{ name: '', title: 'Waikato 0.625m SNC12836 (2020-2028)' }];
-    const layers = await filterLayers(mockUrlRequest('/foo/bar,js', `?date[before]=${dateBefore}`), layer);
+    const layers = filterLayers(mockUrlRequest('/foo/bar,js', `?date[before]=${dateBefore}`), layer);
     o(layers).deepEquals(layer);
   });
 
-  o('should filter date[after] in between years', async () => {
+  o('should filter date[after] in between years', () => {
     const dateAfter = '2026-12-31T23:59:59.999Z';
     const layer = [{ name: '', title: 'Waikato 0.625m SNC12836 (2020-2028)' }];
-    const layers = await filterLayers(mockUrlRequest('/foo/bar,js', `?date[after]=${dateAfter}`), layer);
+    const layers = filterLayers(mockUrlRequest('/foo/bar,js', `?date[after]=${dateAfter}`), layer);
     o(layers).deepEquals(layer);
   });
 
-  o('should filter date[after] and date[before] in between years', async () => {
+  o('should filter date[after] and date[before] in between years', () => {
     const dateAfter = '2026-12-31T23:59:59.999Z';
     const dateBefore = '2028-01-01T00:00:00.000Z';
 
     const layer = [{ name: '', title: 'Waikato 0.625m SNC12836 (2020-2028)' }];
-    const layers = await filterLayers(
+    const layers = filterLayers(
       mockUrlRequest('/foo/bar,js', `?date[after]=${dateAfter}&date[before]=${dateBefore}`),
       layer,
     );
     o(layers).deepEquals(layer);
   });
 
-  o('should filter date[after] and date[before] in between years', async () => {
+  o('should filter date[after] and date[before] in between years with single year', () => {
     const dateAfter = '2026-12-31T23:59:59.999Z';
     const dateBefore = '2028-01-01T00:00:00.000Z';
 
     const layer = [{ name: '', title: 'Waikato 0.625m SNC12836 (2028)' }];
-    const layers = await filterLayers(
+    const layers = filterLayers(
       mockUrlRequest('/foo/bar,js', `?date[after]=${dateAfter}&date[before]=${dateBefore}`),
       layer,
     );

--- a/packages/lambda-tiler/src/util/__test__/filter.test.ts
+++ b/packages/lambda-tiler/src/util/__test__/filter.test.ts
@@ -1,0 +1,80 @@
+import { ConfigLayer } from '@basemaps/config';
+import o from 'ospec';
+import { mockUrlRequest } from '../../__tests__/xyz.util.js';
+import { filterLayers } from '../filter.js';
+
+o.spec('filterLayers', () => {
+  const sourceLayers: ConfigLayer[] = [
+    {
+      name: 'waikato-0_625m-snc12836-2004',
+      title: 'Waikato 0.625m SNC12836 (2004-2008)',
+    },
+    {
+      name: 'hawkes-bay--manawat-whanganui-0_75m-snc30001-2002',
+      title: 'Hawkes Bay / Manawatū-Whanganui 0.75m SNC30001 (2002)',
+    },
+    {
+      name: 'canterbury-0_75m-snc25054-2000-2001',
+      title: 'Canterbury 0.75m SNC25054 (2000-2001)',
+    },
+    {
+      name: 'otago-0_375m-sn3806-1975',
+      title: 'Otago 0.375m SN3806 (1975)',
+    },
+  ];
+
+  o('should not filter with empty parameters', async () => {
+    const layers = await filterLayers(mockUrlRequest('/foo/bar,js'), sourceLayers);
+    o(layers).deepEquals(sourceLayers);
+  });
+
+  o('should filter date[after]', async () => {
+    const dateAfter = '2003-12-31T23:59:59.999';
+    const layers = await filterLayers(mockUrlRequest('/foo/bar,js', `?date[after]=${dateAfter}`), sourceLayers);
+    o(layers).deepEquals([sourceLayers[0]]);
+  });
+
+  o('should filter date[before]', async () => {
+    const dateBefore = '2003-01-01T00:00:00.000Z';
+    const layers = await filterLayers(mockUrlRequest('/foo/bar,js', `?date[before]=${dateBefore}`), sourceLayers);
+    o(layers).deepEquals(sourceLayers.slice(1));
+  });
+
+  o('should filter date[before] in between years', async () => {
+    const dateBefore = '2026-01-01T00:00:00.000Z';
+    const layer = [{ name: '', title: 'Waikato 0.625m SNC12836 (2020-2028)' }];
+    const layers = await filterLayers(mockUrlRequest('/foo/bar,js', `?date[before]=${dateBefore}`), layer);
+    o(layers).deepEquals(layer);
+  });
+
+  o('should filter date[after] in between years', async () => {
+    const dateAfter = '2026-12-31T23:59:59.999Z';
+    const layer = [{ name: '', title: 'Waikato 0.625m SNC12836 (2020-2028)' }];
+    const layers = await filterLayers(mockUrlRequest('/foo/bar,js', `?date[after]=${dateAfter}`), layer);
+    o(layers).deepEquals(layer);
+  });
+
+  o('should filter date[after] and date[before] in between years', async () => {
+    const dateAfter = '2026-12-31T23:59:59.999Z';
+    const dateBefore = '2028-01-01T00:00:00.000Z';
+
+    const layer = [{ name: '', title: 'Waikato 0.625m SNC12836 (2020-2028)' }];
+    const layers = await filterLayers(
+      mockUrlRequest('/foo/bar,js', `?date[after]=${dateAfter}&date[before]=${dateBefore}`),
+      layer,
+    );
+    o(layers).deepEquals(layer);
+  });
+
+  o('should filter date[after] and date[before] in between years', async () => {
+    const dateAfter = '2026-12-31T23:59:59.999Z';
+    const dateBefore = '2028-01-01T00:00:00.000Z';
+
+    const layer = [{ name: '', title: 'Waikato 0.625m SNC12836 (2028)' }];
+    const layers = await filterLayers(
+      mockUrlRequest('/foo/bar,js', `?date[after]=${dateAfter}&date[before]=${dateBefore}`),
+      layer,
+    );
+    o(layers).deepEquals(layer);
+  });
+});

--- a/packages/lambda-tiler/src/util/config.loader.ts
+++ b/packages/lambda-tiler/src/util/config.loader.ts
@@ -14,9 +14,9 @@ export class ConfigLoader {
   static async getDefaultConfig(): Promise<BasemapsConfigProvider> {
     const config = getDefaultConfig();
     if (config.assets == null) {
-      // const cb = await config.ConfigBundle.get(config.ConfigBundle.id('latest'));
-      // if (cb == null) throw new LambdaHttpResponse(400, 'Unable to get lastest config bundle for asset.');
-      // config.assets = cb.assets;
+      const cb = await config.ConfigBundle.get(config.ConfigBundle.id('latest'));
+      if (cb == null) throw new LambdaHttpResponse(400, 'Unable to get lastest config bundle for asset.');
+      config.assets = cb.assets;
     }
     return config;
   }

--- a/packages/lambda-tiler/src/util/config.loader.ts
+++ b/packages/lambda-tiler/src/util/config.loader.ts
@@ -14,9 +14,9 @@ export class ConfigLoader {
   static async getDefaultConfig(): Promise<BasemapsConfigProvider> {
     const config = getDefaultConfig();
     if (config.assets == null) {
-      const cb = await config.ConfigBundle.get(config.ConfigBundle.id('latest'));
-      if (cb == null) throw new LambdaHttpResponse(400, 'Unable to get lastest config bundle for asset.');
-      config.assets = cb.assets;
+      // const cb = await config.ConfigBundle.get(config.ConfigBundle.id('latest'));
+      // if (cb == null) throw new LambdaHttpResponse(400, 'Unable to get lastest config bundle for asset.');
+      // config.assets = cb.assets;
     }
     return config;
   }

--- a/packages/lambda-tiler/src/util/filter.ts
+++ b/packages/lambda-tiler/src/util/filter.ts
@@ -1,0 +1,51 @@
+import { ConfigLayer } from '@basemaps/config';
+import { extractYearRangeFromTitle } from '@basemaps/shared';
+import { LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambda';
+
+export const FilterNames = {
+  DateBefore: 'date[before]',
+  DateAfter: 'date[after]',
+};
+
+export function getFilters(req: LambdaHttpRequest): Record<string, string | undefined> {
+  return {
+    [FilterNames.DateBefore]: req.query.get(FilterNames.DateBefore) ?? undefined,
+    [FilterNames.DateAfter]: req.query.get(FilterNames.DateAfter) ?? undefined,
+  };
+}
+/**
+ * Convert the year range into full ISO date year range
+ *
+ * Expand to the full year of jan 1st 00:00 -> Dec 31st 23:59
+ */
+export function yearRangeToInterval(x: [number] | [number, number]): [string, string] {
+  if (x.length === 1) return [`${x[0]}-01-01T00:00:00.000Z`, `${x[0]}-12-31T23:59:59.999Z`];
+  return [`${x[0]}-01-01T00:00:00.000Z`, `${x[1]}-12-31T23:59:59.999Z`];
+}
+
+function parseDateAsIso(s: string | null): string | null {
+  if (s == null) return null;
+  const date = new Date(s);
+  if (isNaN(date.getTime())) throw new LambdaHttpResponse(400, `Invalid date format: "${s}"`);
+  return date.toISOString();
+}
+
+export async function filterLayers(req: LambdaHttpRequest, layers: ConfigLayer[]): Promise<ConfigLayer[]> {
+  const dateAfterQuery = req.query.get(FilterNames.DateAfter);
+  const dateBeforeQuery = req.query.get(FilterNames.DateBefore);
+
+  if (dateAfterQuery == null && dateBeforeQuery == null) return layers;
+  const dateAfter = parseDateAsIso(dateAfterQuery);
+  const dateBefore = parseDateAsIso(dateBeforeQuery);
+
+  return layers.filter((l) => {
+    if (l.title == null) return false;
+    const yearRange = extractYearRangeFromTitle(l.title);
+    if (yearRange == null) return false;
+
+    const ranges = yearRangeToInterval(yearRange);
+    const startYear = ranges[0];
+    const endYear = ranges[1];
+    return (dateAfter == null || endYear >= dateAfter) && (dateBefore == null || startYear <= dateBefore);
+  });
+}

--- a/packages/lambda-tiler/src/util/filter.ts
+++ b/packages/lambda-tiler/src/util/filter.ts
@@ -18,19 +18,19 @@ export function getFilters(req: LambdaHttpRequest): Record<string, string | unde
  *
  * Expand to the full year of jan 1st 00:00 -> Dec 31st 23:59
  */
-export function yearRangeToInterval(x: [number] | [number, number]): [string, string] {
-  if (x.length === 1) return [`${x[0]}-01-01T00:00:00.000Z`, `${x[0]}-12-31T23:59:59.999Z`];
-  return [`${x[0]}-01-01T00:00:00.000Z`, `${x[1]}-12-31T23:59:59.999Z`];
+export function yearRangeToInterval(x: [number] | [number, number]): [Date, Date] {
+  if (x.length === 1) return [new Date(`${x[0]}-01-01T00:00:00.000Z`), new Date(`${x[0]}-12-31T23:59:59.999Z`)];
+  return [new Date(`${x[0]}-01-01T00:00:00.000Z`), new Date(`${x[1]}-12-31T23:59:59.999Z`)];
 }
 
-function parseDateAsIso(s: string | null): string | null {
+function parseDateAsIso(s: string | null): Date | null {
   if (s == null) return null;
   const date = new Date(s);
   if (isNaN(date.getTime())) throw new LambdaHttpResponse(400, `Invalid date format: "${s}"`);
-  return date.toISOString();
+  return date;
 }
 
-export async function filterLayers(req: LambdaHttpRequest, layers: ConfigLayer[]): Promise<ConfigLayer[]> {
+export function filterLayers(req: LambdaHttpRequest, layers: ConfigLayer[]): ConfigLayer[] {
   const dateAfterQuery = req.query.get(FilterNames.DateAfter);
   const dateBeforeQuery = req.query.get(FilterNames.DateBefore);
 

--- a/packages/lambda-tiler/src/wmts.capability.ts
+++ b/packages/lambda-tiler/src/wmts.capability.ts
@@ -29,7 +29,7 @@ export interface WmtsCapabilitiesParams {
   /** List of tile matrixes to output */
   tileMatrix: TileMatrixSet[];
   /** Should WMTS Layers be created for each imagery set inside this tileSet */
-  isIndividualLayers: boolean;
+  // isIndividualLayers: boolean;
   /** All the imagery used by the tileSet and tileMatrixes */
   imagery: Map<string, ConfigImagery>;
   /** API key to append to all resource urls */
@@ -38,6 +38,8 @@ export interface WmtsCapabilitiesParams {
   formats?: ImageFormat[] | null;
   /** Config location */
   config?: string | null;
+  /** Specific layers to add to the WMTS */
+  layers?: ConfigLayer[] | null;
 }
 
 /** Number of decimal places to use in lat lng */
@@ -66,17 +68,19 @@ export class WmtsCapabilities {
 
   minZoom = 0;
   maxZoom = 32;
+  layers: ConfigLayer[] | null | undefined;
 
   constructor(params: WmtsCapabilitiesParams) {
     this.httpBase = params.httpBase;
     this.provider = params.provider;
     this.tileSet = params.tileSet;
     this.config = params.config;
-    this.isIndividualLayers = params.isIndividualLayers;
+    // this.isIndividualLayers = params.isIndividualLayers;
     for (const tms of params.tileMatrix) this.tileMatrixSets.set(tms.identifier, tms);
     this.apiKey = params.apiKey;
     this.formats = params.formats ?? ImageFormatOrder;
     this.imagery = params.imagery;
+    this.layers = params.layers;
   }
 
   buildWgs84BoundingBox(tms: TileMatrixSet, layers: Bounds[]): VNodeElement {
@@ -287,10 +291,10 @@ export class WmtsCapabilities {
     const layers: (VNodeElement | null)[] = [];
     layers.push(this.buildLayer(this.tileSet));
 
-    if (this.isIndividualLayers) {
+    if (this.layers) {
       const layerByName = new Map<string, ConfigLayer>();
       // Dedupe the layers by unique name
-      for (const img of this.tileSet.layers) layerByName.set(standardizeLayerName(img.name), img);
+      for (const img of this.layers) layerByName.set(standardizeLayerName(img.name), img);
       const orderedLayers = Array.from(layerByName.values()).sort((a, b) =>
         (a.title ?? a.name).localeCompare(b.title ?? b.name),
       );

--- a/packages/lambda-tiler/src/wmts.capability.ts
+++ b/packages/lambda-tiler/src/wmts.capability.ts
@@ -28,8 +28,6 @@ export interface WmtsCapabilitiesParams {
   tileSet: ConfigTileSet;
   /** List of tile matrixes to output */
   tileMatrix: TileMatrixSet[];
-  /** Should WMTS Layers be created for each imagery set inside this tileSet */
-  // isIndividualLayers: boolean;
   /** All the imagery used by the tileSet and tileMatrixes */
   imagery: Map<string, ConfigImagery>;
   /** API key to append to all resource urls */
@@ -64,7 +62,6 @@ export class WmtsCapabilities {
   tileMatrixSets = new Map<string, TileMatrixSet>();
   imagery: Map<string, ConfigImagery>;
   formats: ImageFormat[];
-  isIndividualLayers = false;
 
   minZoom = 0;
   maxZoom = 32;
@@ -75,7 +72,6 @@ export class WmtsCapabilities {
     this.provider = params.provider;
     this.tileSet = params.tileSet;
     this.config = params.config;
-    // this.isIndividualLayers = params.isIndividualLayers;
     for (const tms of params.tileMatrix) this.tileMatrixSets.set(tms.identifier, tms);
     this.apiKey = params.apiKey;
     this.formats = params.formats ?? ImageFormatOrder;

--- a/packages/shared/src/__tests__/util.test.ts
+++ b/packages/shared/src/__tests__/util.test.ts
@@ -1,5 +1,11 @@
 import o from 'ospec';
-import { extractYearRangeFromName, getUrlHost, s3ToVsis3, titleizeImageryName } from '../util.js';
+import {
+  extractYearRangeFromName,
+  extractYearRangeFromTitle,
+  getUrlHost,
+  s3ToVsis3,
+  titleizeImageryName,
+} from '../util.js';
 
 o.spec('util', () => {
   o('extractYearRangeFromName', () => {
@@ -10,6 +16,18 @@ o.spec('util', () => {
     o(extractYearRangeFromName('2019_abc2020')).deepEquals([2019, 2021]);
     o(extractYearRangeFromName('2020_abc2019')).deepEquals([2019, 2021]);
     o(extractYearRangeFromName('2020-23abc')).deepEquals([2020, 2024]);
+
+    o(extractYearRangeFromName('wellington_urban_2017_0.10m')).deepEquals([2017, 2018]);
+    o(extractYearRangeFromName('gebco_2020_305-75m')).deepEquals([2020, 2021]);
+    // FIXME these are currently broken
+    // o(extractYearRangeFromName('otago_0_375m_sn3806_1975')).deepEquals([1975, 1976]);
+  });
+
+  o.only('extractYearRangeFromTitle', () => {
+    o(extractYearRangeFromTitle('Banks Peninsula 0.075m Urban Aerial Photos (2019-2020)')).deepEquals([2019, 2020]);
+    o(extractYearRangeFromTitle('Manawatu 0.125m Urban Aerial Photos (2019)')).deepEquals([2019]);
+
+    o(extractYearRangeFromTitle('Manawatu 0.125m Urban Aerial Photos (2019a)')).deepEquals(null);
   });
 
   o('titleizeImageryName', () => {

--- a/packages/shared/src/util.ts
+++ b/packages/shared/src/util.ts
@@ -56,7 +56,7 @@ export function extractYearRangeFromTitle(t: string): [number] | [number, number
     .split('-')
     .map(Number);
   if (chunks.length === 1 && !isNaN(chunks[0])) return chunks as [number];
-  else if (chunks.length === 2 && !isNaN(chunks[0]) && !isNaN(chunks[0])) return chunks as [number, number];
+  else if (chunks.length === 2 && !isNaN(chunks[0]) && !isNaN(chunks[1])) return chunks as [number, number];
   return null;
 }
 

--- a/packages/shared/src/util.ts
+++ b/packages/shared/src/util.ts
@@ -46,6 +46,20 @@ export function extractYearRangeFromName(name: string): [number, number] {
   return [years[0], years[years.length - 1] + 1];
 }
 
+export function extractYearRangeFromTitle(t: string): [number] | [number, number] | null {
+  const yearChunk = t.slice(t.lastIndexOf(' ') + 1).trim(); // "(2019)" or "(2019-2020)"
+  if (yearChunk == null) return null;
+  if (!yearChunk.endsWith(')') || !yearChunk.startsWith('(')) return null;
+
+  const chunks = yearChunk
+    .slice(1, yearChunk.length - 1)
+    .split('-')
+    .map(Number);
+  if (chunks.length === 1 && !isNaN(chunks[0])) return chunks as [number];
+  else if (chunks.length === 2 && !isNaN(chunks[0]) && !isNaN(chunks[0])) return chunks as [number, number];
+  return null;
+}
+
 export function s3ToVsis3(name: string): string {
   return name.startsWith('s3://') ? '/vsis3/' + name.slice('s3://'.length) : name;
 }


### PR DESCRIPTION
This adds `?date[before]=` and `?date[after]=` to a number of routes to filter the imagery down to a specific date rate.

These dates are inclusive so `?date[before]=2022` its a `less than or equal`.
