### PR TITLE
fix(lambda-tiler): do not crash server when assets are not found

### DIFF
--- a/packages/lambda-tiler/src/util/config.loader.ts
+++ b/packages/lambda-tiler/src/util/config.loader.ts
@@ -15,8 +15,7 @@ export class ConfigLoader {
     const config = getDefaultConfig();
     if (config.assets == null) {
       const cb = await config.ConfigBundle.get(config.ConfigBundle.id('latest'));
-      if (cb == null) throw new LambdaHttpResponse(400, 'Unable to get lastest config bundle for asset.');
-      config.assets = cb.assets;
+      if (cb) config.assets = cb.assets;
     }
     return config;
   }


### PR DESCRIPTION
When starting a server without assets all urls fail with this error, assets are not required.
