### PR TITLE
fix(tiler): when scaling rectangles if the scaleX and scaleY differ scale using the larger dimension BM-772

### DIFF
--- a/packages/tiler-sharp/src/index.ts
+++ b/packages/tiler-sharp/src/index.ts
@@ -180,11 +180,7 @@ export class TileMakerSharp implements TileMaker {
     if (extract) sharp.extract({ top: 0, left: 0, width: extract.width, height: extract.height });
 
     if (resize) {
-      const resizeOptions: Sharp.ResizeOptions = {
-        fit: Sharp.fit.cover,
-        kernel: resize.scaleX > 1 ? resizeKernel.in : resizeKernel.out,
-      };
-      // if (Math.abs(resize.scaleX - resize.scaleY) > 0.01) resizeOptions.fit = Sharp.fit.contain;
+      const resizeOptions = { fit: Sharp.fit.cover, kernel: resize.scaleX > 1 ? resizeKernel.in : resizeKernel.out };
       sharp.resize(resize.width, resize.height, resizeOptions);
     }
 

--- a/packages/tiler/src/__tests__/tiler.test.ts
+++ b/packages/tiler/src/__tests__/tiler.test.ts
@@ -1,4 +1,4 @@
-import { Bounds, GoogleTms, Nztm2000Tms, QuadKey } from '@basemaps/geo';
+import { Bounds, GoogleTms, Nztm2000QuadTms, QuadKey } from '@basemaps/geo';
 import { Approx, TestTiff } from '@basemaps/test';
 import o from 'ospec';
 import { CompositionTiff } from '../raster.js';
@@ -40,41 +40,6 @@ o.spec('tiler.test', () => {
     });
   });
 
-  o('createComposition should handle non square images', () => {
-    const tiler = new Tiler(Nztm2000Tms);
-
-    const img = {
-      id: 6,
-      getTileBounds() {
-        return { x: 0, y: 0, width: 512, height: 388 };
-      },
-      tif: { source: { name: '15-32295-20496.tiff' } },
-      tileSize: { width: 512, height: 512 },
-    } as any;
-
-    const raster = {
-      tiff: new Bounds(4133696, 2623424, 256, 192),
-      intersection: new Bounds(4133696, 2623488, 192, 128),
-      tile: new Bounds(4133632, 2623488, 256, 256),
-    };
-
-    const ans = tiler.createComposition(img, 0, 0, 0.5, raster) as CompositionTiff;
-    if (ans == null) throw new Error('Composition should return results');
-    const { crop } = ans;
-    o(ans).deepEquals({
-      type: 'tiff',
-      asset: ans.asset,
-      source: { x: 0, y: 0, imageId: 6, width: 512, height: 388 },
-      y: 0,
-      x: 64,
-      extract: { width: 512, height: 388 },
-      resize: { width: 256, height: 194, scaleX: 0.5, scaleY: 0.5 },
-      crop,
-    });
-
-    o(crop).deepEquals(new Bounds(0, 64, 192, 130).toJson());
-  });
-
   o('should clamp required tiles', () => {
     const bounds = new Bounds(0, 0, 1024, 1024);
     const tileCount = { x: 1, y: 1 };
@@ -86,5 +51,71 @@ o.spec('tiler.test', () => {
       { x: 0, y: 0 },
       { x: 0, y: 1 },
     ]);
+  });
+
+  o.spec('createComposition', () => {
+    o('should handle non square images', () => {
+      const img = {
+        id: 6,
+        getTileBounds() {
+          return { x: 0, y: 0, width: 512, height: 388 };
+        },
+        tif: { source: { name: '15-32295-20496.tiff' } },
+        tileSize: { width: 512, height: 512 },
+      } as any;
+
+      const intersections = {
+        tiff: new Bounds(4133696, 2623424, 256, 192),
+        intersection: new Bounds(4133696, 2623488, 192, 128),
+        tile: new Bounds(4133632, 2623488, 256, 256),
+      };
+
+      const ans = Tiler.createComposition(img, 0, 0, 0.5, intersections) as CompositionTiff;
+      if (ans == null) throw new Error('Composition should return results');
+      const { crop } = ans;
+      o(ans).deepEquals({
+        type: 'tiff',
+        asset: ans.asset,
+        source: { x: 0, y: 0, imageId: 6, width: 512, height: 388 },
+        y: 0,
+        x: 64,
+        extract: { width: 512, height: 388 },
+        resize: { width: 256, height: 194, scaleX: 0.5, scaleY: 0.5 },
+        crop,
+      });
+
+      o(crop).deepEquals(new Bounds(0, 64, 192, 130).toJson());
+    });
+
+    o('should compose with fraction scales', () => {
+      const tile = { x: 126359, y: 137603, z: 18 };
+      const screenPx = Nztm2000QuadTms.tileToPixels(tile.x, tile.y);
+      const screenBoundsPx = new Bounds(screenPx.x, screenPx.y, Nztm2000QuadTms.tileSize, Nztm2000QuadTms.tileSize);
+
+      const tiffBounds = new Bounds(32347190.62750788, 35224009.946296684, 1607.5978194959462, 2411.396729245782);
+      const tileBounds = { x: 1024, y: 3584, width: 512, height: 16 };
+      const intersections = {
+        tiff: tiffBounds,
+        intersection: tiffBounds.intersection(screenBoundsPx)!,
+        tile: screenBoundsPx,
+      };
+      const img = {
+        id: 6,
+        getTileBounds: () => tileBounds,
+        tif: { source: { name: '15-32295-20496.tiff' } },
+        tileSize: { width: 512, height: 512 },
+      } as any;
+      const comp = Tiler.createComposition(img, 2, 7, 0.6698324247899835, intersections) as CompositionTiff;
+
+      o(comp).deepEquals({
+        type: 'tiff',
+        asset: comp.asset,
+        source: { x: 2, y: 7, imageId: 6, width: 512, height: 16 },
+        y: 42,
+        x: 0,
+        resize: { width: 344, height: 344, scaleX: 0.671875, scaleY: 0.671875, scaleOverride: true },
+        crop: { x: 28, y: 0, width: 256, height: 12 },
+      });
+    });
   });
 });

--- a/packages/tiler/src/raster.ts
+++ b/packages/tiler/src/raster.ts
@@ -41,6 +41,8 @@ export interface CompositionTiff {
     scaleX: number;
     /** Scale height  < 1 to zoom in, > 1 to zoom out */
     scaleY: number;
+    /** If a warning was found with the scaling */
+    scaleOverride?: boolean;
   };
   /** Crop after the resize */
   crop?: Size & Point;

--- a/packages/tiler/src/tiler.ts
+++ b/packages/tiler/src/tiler.ts
@@ -88,7 +88,7 @@ export class Tiler {
     return { tiff: tiffBoundsPx, intersection: intersectionPx, tile: screenBoundsPx };
   }
 
-  createComposition(
+  static createComposition(
     img: CogTiffImage,
     x: number,
     y: number,
@@ -96,7 +96,6 @@ export class Tiler {
     raster: RasterPixelBounds,
   ): Composition | null {
     const source = Bounds.fromJson(img.getTileBounds(x, y));
-
     const target = source.scale(scaleFactor, scaleFactor).add(raster.tiff).round(ROUND_BIAS);
 
     // Validate that the requested COG tile actually intersects with the output raster
@@ -118,9 +117,11 @@ export class Tiler {
       x: Math.max(0, Math.round(drawAtRegion.x)),
     };
 
+    const tileSize = img.tileSize;
+
     // Sometimes the source image is smaller than the tile size,
     // Need to crop the tile down to the actual image extent
-    if (source.width < img.tileSize.width || source.height < img.tileSize.height) {
+    if (source.width < tileSize.width || source.height < tileSize.height) {
       composition.extract = { width: source.width, height: source.height };
     }
 
@@ -130,9 +131,29 @@ export class Tiler {
       const scaleX = target.width / source.width;
       const scaleY = target.height / source.height;
       composition.resize = { width: target.width, height: target.height, scaleX, scaleY };
+
+      /**
+       * Due to rounding to the nearest pixel sometimes thin lines ( 512x16 px or 16x512 ) can scale
+       * to a different ratio on X and Y,
+       *
+       * If the ratio differs too much (> 1%) it can cause distortions in the imagery.
+       * If this occurs, scale the imagery using the biggest dimension to keep the aspect ratio.
+       *
+       * For example a 512x16 scaled at 67.185% would result in a 343x12 image which is scaled at 68% and 75%.
+       *
+       * If the scale differs by X & Y and we it is going to extract a portion from the end of the image
+       * just scale it as a square then extract the portion
+       */
+      if (Math.abs(scaleX - scaleY) > 0.01 && composition.extract) {
+        delete composition.extract;
+        const sourceWidth = Math.max(source.width, source.height);
+        const width = Math.max(composition.resize.width, composition.resize.height);
+        const scale = width / sourceWidth;
+        composition.resize = { width, height: width, scaleX: scale, scaleY: scale, scaleOverride: true };
+      }
     }
 
-    // If the output XYZ tile needs a piece of a COG tile, extract the speicific
+    // If the output XYZ tile needs a piece of a COG tile, extract the specific
     // Bounding box
     if (
       tileBounds.y !== 0 ||
@@ -166,7 +187,7 @@ export class Tiler {
 
     // For each geotiff tile that is required, scale it to the size of the raster output tile
     for (const pt of Tiler.getRequiredTiles(requiredTifPixels, pixelScale, tileSize, tileCount)) {
-      const composition = this.createComposition(img, pt.x, pt.y, pixelScaleInv, rasterBounds);
+      const composition = Tiler.createComposition(img, pt.x, pt.y, pixelScaleInv, rasterBounds);
       if (composition != null) composites.push(composition);
     }
 


### PR DESCRIPTION
This should reduce the amount of error when scaling large aspect ratios eg 512x16