### PR TITLE
fix(server): gsd does not actually need to match

### DIFF
--- a/packages/config/src/json/tiff.config.ts
+++ b/packages/config/src/json/tiff.config.ts
@@ -34,8 +34,6 @@ interface TiffSummary {
   bounds: Bounds;
   /** EpsgCode for the tiffs */
   epsg: number;
-  /** Ground sample distance of the tiffs */
-  gsd: number;
 }
 
 /**
@@ -51,24 +49,13 @@ function computeTiffSummary(target: string, tiffs: CogTiff[]): TiffSummary {
     const firstImage = tiff.getImage(0);
     const imgBounds = Bounds.fromBbox(firstImage.bbox);
 
-    /** Ground sample distance must be the same for all imagery */
-    if (res.gsd == null) res.gsd = firstImage.resolution[0];
-    else {
-      const gsdDiff = Math.abs(res.gsd - firstImage.resolution[0]);
-      if (gsdDiff > GsdFloatingErrorAllowance) {
-        throw new Error(`GSD mismatch on imagery ${res.gsd} vs ${firstImage.resolution[0]} source:` + tiff.source.uri);
-      }
-    }
-
     const epsg = firstImage.epsg;
     if (epsg == null) throw new Error(`No ESPG projection found. source:` + tiff.source.uri);
 
     // Validate all EPSG codes are the same for each imagery set
-    if (res.epsg == null) res.epsg;
-    else if (res.epsg !== res.epsg) {
-      throw new Error(
-        `ESPG projection mismatch on imagery ${res.epsg} vs ${firstImage.epsg} source:` + tiff.source.uri,
-      );
+    if (res.epsg == null) res.epsg = epsg;
+    else if (res.epsg !== epsg) {
+      throw new Error(`ESPG projection mismatch on imagery ${res.epsg} vs ${epsg} source:` + tiff.source.uri);
     }
 
     if (res.bounds == null) res.bounds = imgBounds;
@@ -78,7 +65,6 @@ function computeTiffSummary(target: string, tiffs: CogTiff[]): TiffSummary {
     res.files.push({ name: tiff.source.uri.replace(target, ''), ...imgBounds });
   }
   if (res.bounds == null) throw new Error('Failed to extract imagery bounds from:' + target);
-  if (res.gsd == null) throw new Error('Failed to extract imagery GSD from:' + target);
   if (res.epsg == null) throw new Error('Failed to extract imagery epsg from:' + target);
   if (res.files == null || res.files.length === 0) throw new Error('Failed to extract imagery from:' + target);
   return res as TiffSummary;

--- a/packages/config/src/json/tiff.config.ts
+++ b/packages/config/src/json/tiff.config.ts
@@ -23,9 +23,6 @@ function isTiff(f: string): boolean {
   return lowered.endsWith('.tif') || lowered.endsWith('.tiff');
 }
 
-/** Ground sample Distance is a floating point, allow a small amount of error between tiffs */
-const GsdFloatingErrorAllowance = 0.000001;
-
 /** Summary of a collection of tiffs */
 interface TiffSummary {
   /** List of tiffs and their extents */

--- a/packages/lambda-tiler/src/cli/render.tile.ts
+++ b/packages/lambda-tiler/src/cli/render.tile.ts
@@ -7,7 +7,7 @@ import { LambdaHttpRequest, LambdaUrlRequest, UrlEvent } from '@linzjs/lambda';
 import { Context } from 'aws-lambda';
 import { TileXyzRaster } from '../routes/tile.xyz.raster.js';
 
-const target = `/home/blacha/tmp/basemaps/`;
+const target = `/home/blacha/tmp/basemaps`;
 const tile = { z: 18, x: 126359, y: 137603 };
 const tileMatrix = Nztm2000QuadTms;
 
@@ -32,6 +32,7 @@ async function main(): Promise<void> {
   });
 
   await fsa.write(`./${tile.z}_${tile.x}_${tile.y}.png`, Buffer.from(res.body, 'base64'));
+  log.info({ path: `./${tile.z}_${tile.x}_${tile.y}.png` }, 'Tile:Write');
 }
 
 main();


### PR DESCRIPTION
the server automatically handles the scaling, so GSD numbers of tiff do not need to be consistent across imagery.