### PR TITLE
fix(server): close tiff connections once they have been queried

### DIFF
--- a/packages/config/src/json/tiff.config.ts
+++ b/packages/config/src/json/tiff.config.ts
@@ -110,6 +110,8 @@ export async function imageryFromTiffPath(target: string, Q: pLimit.Limit): Prom
     files: params.files,
   };
   imagery.overviews = await ConfigJson.findImageryOverviews(imagery);
+
+  await Promise.all(tiffs.map((t) => t.close()));
   return imagery;
 }
 


### PR DESCRIPTION
fixes:

```
(node:355570) [DEP0137] DeprecationWarning: Closing a FileHandle object on garbage collection is deprecated. 

Please close FileHandle objects explicitly using FileHandle.prototype.close().

 In the future, an error will be thrown if a file descriptor is closed during garbage collection.
```