### PR TITLE
feat: use transition property for fades, add fade when removing layer

### DIFF
--- a/packages/landing/src/components/map.tsx
+++ b/packages/landing/src/components/map.tsx
@@ -9,7 +9,7 @@ import { DateRange } from './daterange.js';
 import { Debug } from './debug.js';
 import { MapSwitcher } from './map.switcher.js';
 
-const layerFadeTime = 750;
+const LayerFadeTime = 750;
 
 /**
  * Map loading in maplibre is weird, the on('load') event is different to 'loaded'
@@ -119,17 +119,10 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
           id: newStyleId,
           type: 'raster',
           source: newStyleId,
-          paint: {
-            'raster-opacity': 0,
-            'raster-opacity-transition': {
-              duration: layerFadeTime,
-              delay: 0,
-            },
-          },
-        } as any);
-        // `as any` needed above due to *-transition paint properties not appearing
-        // in TS typing, per https://github.com/maplibre/maplibre-gl-js/issues/1708
-        this.map.moveLayer(newStyleId);
+          paint: { 'raster-opacity': 0 },
+        });
+        this.map.moveLayer(newStyleId); // Move to front
+        this.map.setPaintProperty(newStyleId, 'raster-opacity-transition', { duration: LayerFadeTime });
         this.map.setPaintProperty(newStyleId, 'raster-opacity', 1);
       }
     }
@@ -142,12 +135,12 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
     // The last item in the array is the top layer, we pop that to ensure it isn't removed
     filteredLayers.pop();
     for (const layer of filteredLayers) {
-      this.map.setPaintProperty(layer.id, 'raster-opacity-transition', { duration: layerFadeTime });
+      this.map.setPaintProperty(layer.id, 'raster-opacity-transition', { duration: LayerFadeTime });
       this.map.setPaintProperty(layer.id, 'raster-opacity', 0);
       setTimeout(() => {
         this.map.removeLayer(layer.id);
         this.map.removeSource(layer.source);
-      }, layerFadeTime);
+      }, LayerFadeTime);
     }
   };
 

--- a/packages/landing/src/components/map.tsx
+++ b/packages/landing/src/components/map.tsx
@@ -9,6 +9,8 @@ import { DateRange } from './daterange.js';
 import { Debug } from './debug.js';
 import { MapSwitcher } from './map.switcher.js';
 
+const layerFadeTime = 750;
+
 /**
  * Map loading in maplibre is weird, the on('load') event is different to 'loaded'
  * this function waits until the map.loaded() function is true before being run.
@@ -117,32 +119,18 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
           id: newStyleId,
           type: 'raster',
           source: newStyleId,
-          paint: { 'raster-opacity': 0 },
-        });
+          paint: {
+            'raster-opacity': 0,
+            'raster-opacity-transition': {
+              duration: layerFadeTime,
+              delay: 0,
+            },
+          },
+        } as any);
+        // `as any` needed above due to *-transition paint properties not appearing
+        // in TS typing, per https://github.com/maplibre/maplibre-gl-js/issues/1708
         this.map.moveLayer(newStyleId);
-
-        let startTime: number;
-        let previousTime: number;
-        let isDone = false;
-        const fadeTime = 1000;
-        const endOpacity = 1;
-        const rate = endOpacity / fadeTime;
-
-        const stepAnimation = (nowTime: number): void => {
-          if (startTime === undefined) startTime = nowTime;
-          const elapsed = nowTime - startTime;
-          if (previousTime !== nowTime) {
-            const opacity = Math.min(rate * elapsed, endOpacity);
-            this.map.setPaintProperty(newStyleId, 'raster-opacity', opacity);
-            if (opacity === endOpacity) isDone = true;
-          }
-          if (elapsed < fadeTime) {
-            previousTime = nowTime;
-            if (!isDone) window.requestAnimationFrame(stepAnimation);
-          }
-        };
-
-        window.requestAnimationFrame(stepAnimation);
+        this.map.setPaintProperty(newStyleId, 'raster-opacity', 1);
       }
     }
   };
@@ -154,8 +142,12 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
     // The last item in the array is the top layer, we pop that to ensure it isn't removed
     filteredLayers.pop();
     for (const layer of filteredLayers) {
-      this.map.removeLayer(layer.id);
-      this.map.removeSource(layer.source);
+      this.map.setPaintProperty(layer.id, 'raster-opacity-transition', { duration: layerFadeTime });
+      this.map.setPaintProperty(layer.id, 'raster-opacity', 0);
+      setTimeout(() => {
+        this.map.removeLayer(layer.id);
+        this.map.removeSource(layer.source);
+      }, layerFadeTime);
     }
   };
 


### PR DESCRIPTION
- Changes the layer fade animation to use the built-in MapLibre transition `raster-opacity-transition` when fading layers rather than repeatedly updating the `raster-opacity` ourselves in JavaScript as before.
- Adds an fade transition when previous layers are being removed, which makes the appearance less jarring.
- Reduces the fade time to 750ms from 1000ms.

The order of operations is now:
- The date range sliders are moved.
- We check if the layers which would be visible in the map bounding box within the date range specified have changed.
- If they have, we add a new layer with the source set to the new date after and date before values.
- The new layer fades in over 750ms.
- If the tiles for the new layer take longer than 750ms to load, they continue to load.
- Once the new layer has finished loading and no further interaction is occurring, the `idle` event is triggered.
- On the idle event, the previous layers opacity is reduced to 0 over 750ms.
- After 750ms, the previous layer and source are removed.

An `as any` typecast is required due to the `*-transition` paint properties not being included in the MapLibre TypeScript typing, which is a bug being tracked at https://github.com/maplibre/maplibre-gl-js/issues/1708.