### PR TITLE
Revert "fix(tiler): when scaling rectangles if the scaleX and scaleY differ scale using the larger dimension BM-772 (#2693)"

### DIFF
--- a/packages/tiler-sharp/src/index.ts
+++ b/packages/tiler-sharp/src/index.ts
@@ -136,11 +136,6 @@ export class TileMakerSharp implements TileMaker {
     const todo: Promise<SharpOverlay | null>[] = [];
     for (const comp of ctx.layers) {
       if (this.isTooLarge(comp)) continue;
-      // Track that a scaleOverride was used, this can be removed once we determine how often this override is used.
-      if (comp.type === 'tiff' && comp.resize && comp.resize.scaleOverride) {
-        metrics.start('compose:scale:override');
-        metrics.end('compose:scale:override');
-      }
       todo.push(this.composeTile(comp, ctx.resizeKernel));
     }
     const overlays = await Promise.all(todo).then((items) => items.filter(notEmpty));

--- a/packages/tiler/src/__tests__/tiler.test.ts
+++ b/packages/tiler/src/__tests__/tiler.test.ts
@@ -1,4 +1,4 @@
-import { Bounds, GoogleTms, Nztm2000QuadTms, QuadKey } from '@basemaps/geo';
+import { Bounds, GoogleTms, Nztm2000Tms, QuadKey } from '@basemaps/geo';
 import { Approx, TestTiff } from '@basemaps/test';
 import o from 'ospec';
 import { CompositionTiff } from '../raster.js';
@@ -40,6 +40,41 @@ o.spec('tiler.test', () => {
     });
   });
 
+  o('createComposition should handle non square images', () => {
+    const tiler = new Tiler(Nztm2000Tms);
+
+    const img = {
+      id: 6,
+      getTileBounds() {
+        return { x: 0, y: 0, width: 512, height: 388 };
+      },
+      tif: { source: { name: '15-32295-20496.tiff' } },
+      tileSize: { width: 512, height: 512 },
+    } as any;
+
+    const raster = {
+      tiff: new Bounds(4133696, 2623424, 256, 192),
+      intersection: new Bounds(4133696, 2623488, 192, 128),
+      tile: new Bounds(4133632, 2623488, 256, 256),
+    };
+
+    const ans = tiler.createComposition(img, 0, 0, 0.5, raster) as CompositionTiff;
+    if (ans == null) throw new Error('Composition should return results');
+    const { crop } = ans;
+    o(ans).deepEquals({
+      type: 'tiff',
+      asset: ans.asset,
+      source: { x: 0, y: 0, imageId: 6, width: 512, height: 388 },
+      y: 0,
+      x: 64,
+      extract: { width: 512, height: 388 },
+      resize: { width: 256, height: 194, scaleX: 0.5, scaleY: 0.5 },
+      crop,
+    });
+
+    o(crop).deepEquals(new Bounds(0, 64, 192, 130).toJson());
+  });
+
   o('should clamp required tiles', () => {
     const bounds = new Bounds(0, 0, 1024, 1024);
     const tileCount = { x: 1, y: 1 };
@@ -51,71 +86,5 @@ o.spec('tiler.test', () => {
       { x: 0, y: 0 },
       { x: 0, y: 1 },
     ]);
-  });
-
-  o.spec('createComposition', () => {
-    o('should handle non square images', () => {
-      const img = {
-        id: 6,
-        getTileBounds() {
-          return { x: 0, y: 0, width: 512, height: 388 };
-        },
-        tif: { source: { name: '15-32295-20496.tiff' } },
-        tileSize: { width: 512, height: 512 },
-      } as any;
-
-      const intersections = {
-        tiff: new Bounds(4133696, 2623424, 256, 192),
-        intersection: new Bounds(4133696, 2623488, 192, 128),
-        tile: new Bounds(4133632, 2623488, 256, 256),
-      };
-
-      const ans = Tiler.createComposition(img, 0, 0, 0.5, intersections) as CompositionTiff;
-      if (ans == null) throw new Error('Composition should return results');
-      const { crop } = ans;
-      o(ans).deepEquals({
-        type: 'tiff',
-        asset: ans.asset,
-        source: { x: 0, y: 0, imageId: 6, width: 512, height: 388 },
-        y: 0,
-        x: 64,
-        extract: { width: 512, height: 388 },
-        resize: { width: 256, height: 194, scaleX: 0.5, scaleY: 0.5 },
-        crop,
-      });
-
-      o(crop).deepEquals(new Bounds(0, 64, 192, 130).toJson());
-    });
-
-    o('should compose with fraction scales', () => {
-      const tile = { x: 126359, y: 137603, z: 18 };
-      const screenPx = Nztm2000QuadTms.tileToPixels(tile.x, tile.y);
-      const screenBoundsPx = new Bounds(screenPx.x, screenPx.y, Nztm2000QuadTms.tileSize, Nztm2000QuadTms.tileSize);
-
-      const tiffBounds = new Bounds(32347190.62750788, 35224009.946296684, 1607.5978194959462, 2411.396729245782);
-      const tileBounds = { x: 1024, y: 3584, width: 512, height: 16 };
-      const intersections = {
-        tiff: tiffBounds,
-        intersection: tiffBounds.intersection(screenBoundsPx)!,
-        tile: screenBoundsPx,
-      };
-      const img = {
-        id: 6,
-        getTileBounds: () => tileBounds,
-        tif: { source: { name: '15-32295-20496.tiff' } },
-        tileSize: { width: 512, height: 512 },
-      } as any;
-      const comp = Tiler.createComposition(img, 2, 7, 0.6698324247899835, intersections) as CompositionTiff;
-
-      o(comp).deepEquals({
-        type: 'tiff',
-        asset: comp.asset,
-        source: { x: 2, y: 7, imageId: 6, width: 512, height: 16 },
-        y: 42,
-        x: 0,
-        resize: { width: 344, height: 344, scaleX: 0.671875, scaleY: 0.671875, scaleOverride: true },
-        crop: { x: 28, y: 0, width: 256, height: 12 },
-      });
-    });
   });
 });

--- a/packages/tiler/src/raster.ts
+++ b/packages/tiler/src/raster.ts
@@ -41,8 +41,6 @@ export interface CompositionTiff {
     scaleX: number;
     /** Scale height  < 1 to zoom in, > 1 to zoom out */
     scaleY: number;
-    /** If a warning was found with the scaling */
-    scaleOverride?: boolean;
   };
   /** Crop after the resize */
   crop?: Size & Point;


### PR DESCRIPTION
This reverts commit c498856b1851026d0f3cb87fc9be4ac8cb0b4bc2.