### PR TITLE
feat(landing): show number of COGs in current imagery

### DIFF
--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -175,11 +175,13 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
   }
 
   renderWMTS(): ReactNode {
+    const imagery = this.state.imagery;
     return (
       <div className="debug__info">
         <label className="debug__label"></label>
         <div className="debug__value">
-          {Config.map.tileMatrix.projection.toEpsgString()} - <a href={this.getWMTSLink()}>WMTS</a>
+          {Config.map.tileMatrix.projection.toEpsgString()} - <a href={this.getWMTSLink()}>WMTS </a>
+          {imagery == null ? null : <div title="Number of tiffs in imagery"> - {imagery.files.length} Tiffs</div>}
         </div>
       </div>
     );


### PR DESCRIPTION
Adds a count of the number of files in the imagery configuration to the debug viewer

![image](https://user-images.githubusercontent.com/1082761/234741975-728dc82e-7960-4001-ae56-26c4e229dbe0.png)
