### PR TITLE
Revert "feat(lambda-tiler): return 204 no content instead of a empty images (#2829)"

### DIFF
--- a/packages/lambda-tiler/src/__tests__/config.data.ts
+++ b/packages/lambda-tiler/src/__tests__/config.data.ts
@@ -20,7 +20,6 @@ export const TileSetAerial: ConfigTileSetRaster = {
   description: 'aerial__description',
   title: 'Aerial Imagery',
   category: 'Basemap',
-  background: { r: 0xff, g: 0x00, b: 0xff, alpha: 0.5 },
   layers: [
     {
       2193: 'im_01FYWKAJ86W9P7RWM1VB62KD0H',

--- a/packages/lambda-tiler/src/routes/__tests__/attribution.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/attribution.test.ts
@@ -309,12 +309,12 @@ o.spec('/v1/attribution', () => {
 
   o('should 304 with etag match', async () => {
     const request = mockUrlRequest(`/v1/attribution/aerial/EPSG:3857/summary.json`, 'get', {
-      [HttpHeader.IfNoneMatch]: '3un15yA8o1ZDiyYpHXwUQHYXPxd5uGtzHS3R8gug9Nn1',
+      [HttpHeader.IfNoneMatch]: 'E5HGpTqF8AiJ7VgGVKLehYnVfLN9jaVw8Sy6UafJRh2f',
     });
 
     const res = await handler.router.handle(request);
 
-    if (res.status === 200) o(res.header('etag')).equals('3un15yA8o1ZDiyYpHXwUQHYXPxd5uGtzHS3R8gug9Nn1');
+    if (res.status === 200) o(res.header('etag')).equals('E5HGpTqF8AiJ7VgGVKLehYnVfLN9jaVw8Sy6UafJRh2f');
 
     console.log(res.header('etag'));
     o(res.status).equals(304);

--- a/packages/lambda-tiler/src/routes/__tests__/xyz.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/xyz.test.ts
@@ -100,16 +100,6 @@ o.spec('/v1/tiles', () => {
     o(resB.status).equals(404);
   });
 
-  o('should 204 if a tile is outside of the bounds', async () => {
-    const fakeTileSet = FakeData.tileSetRaster('🦄 🌈');
-    fakeTileSet.background = undefined;
-    config.put(fakeTileSet);
-    const res = await handler.router.handle(
-      mockRequest('/v1/tiles/🦄 🌈/global-mercator/0/0/0.png', 'get', Api.header),
-    );
-    o(res.status).equals(204);
-  });
-
   o('should support utf8 tilesets', async () => {
     const fakeTileSet = FakeData.tileSetRaster('🦄 🌈');
     config.put(fakeTileSet);


### PR DESCRIPTION
This reverts commit db3ff1b09f849a26d7287925c7b57d71e1fa6d76.

Research documentation suggest to use 200 Transparent Image.
https://github.com/linz/basemaps/blob/master/docs/api/empty-tiles.md