### PR TITLE
feat(cli): Update the create pr cli to import layer based on filename.

### DIFF
--- a/packages/cli/src/cli/cogify/action.make.cog.pr.ts
+++ b/packages/cli/src/cli/cogify/action.make.cog.pr.ts
@@ -36,7 +36,7 @@ export class CommandCogPullRequest extends CommandLineAction {
   private layer: CommandLineStringParameter;
   private category: CommandLineStringParameter;
   private repository: CommandLineStringParameter;
-  private individual: CommandLineFlagParameter;
+  private filename: CommandLineStringParameter;
   private vector: CommandLineFlagParameter;
 
   public constructor() {
@@ -67,10 +67,11 @@ export class CommandCogPullRequest extends CommandLineAction {
       defaultValue: 'linz/basemaps-config',
       required: false,
     });
-    this.individual = this.defineFlagParameter({
-      parameterLongName: '--individual',
-      description: 'Import imagery as individual layer in basemaps.',
-      required: false,
+    this.filename = this.defineStringParameter({
+      argumentName: 'FILENAME',
+      parameterLongName: '--filename',
+      description: 'Which tileset config file to import into',
+      defaultValue: 'aerial',
     });
     this.vector = this.defineFlagParameter({
       parameterLongName: '--vector',
@@ -84,8 +85,10 @@ export class CommandCogPullRequest extends CommandLineAction {
     const layerStr = this.layer.value;
     const category = this.category.value ? parseCategory(this.category.value) : Category.Other;
     const repo = this.repository.value ?? this.repository.defaultValue;
+    const filename = this.filename.value ?? this.filename.defaultValue;
     if (layerStr == null) throw new Error('Please provide a valid input layer and urls');
     if (repo == null) throw new Error('Please provide a repository');
+    if (filename == null) throw new Error('Please provide a tileset config filename');
     let layer: ConfigLayer;
     try {
       layer = JSON.parse(layerStr);
@@ -98,6 +101,6 @@ export class CommandCogPullRequest extends CommandLineAction {
 
     const git = new MakeCogGithub(layer.name, repo, logger);
     if (this.vector.value) await git.updateVectorTileSet('topographic', layer);
-    else await git.updateRasterTileSet('aerial', layer, category, this.individual.value);
+    else await git.updateRasterTileSet(filename, layer, category);
   }
 }

--- a/packages/cli/src/cli/github/make.cog.pr.ts
+++ b/packages/cli/src/cli/github/make.cog.pr.ts
@@ -35,12 +35,7 @@ export class MakeCogGithub extends Github {
   /**
    * Prepare and create pull request for the aerial tileset config
    */
-  async updateRasterTileSet(
-    filename: string,
-    layer: ConfigLayer,
-    category: Category,
-    individual: boolean,
-  ): Promise<void> {
+  async updateRasterTileSet(filename: string, layer: ConfigLayer, category: Category): Promise<void> {
     const branch = `feat/bot-config-raster-${this.imagery}`;
 
     // Clone the basemaps-config repo and checkout branch
@@ -49,7 +44,7 @@ export class MakeCogGithub extends Github {
     this.getBranch(branch);
 
     this.logger.info({ imagery: this.imagery }, 'GitHub: Get the master TileSet config file');
-    if (individual) {
+    if (filename === 'individual') {
       // Prepare new standalone tileset config
       const tileSet: TileSetConfigSchema = {
         type: TileSetType.Raster,
@@ -57,7 +52,7 @@ export class MakeCogGithub extends Github {
         title: layer.title,
         layers: [layer],
       };
-      const tileSetPath = fsa.joinAll(this.repoName, 'config', 'tileset', 'individual', `${layer.name}.json`);
+      const tileSetPath = fsa.joinAll(this.repoName, 'config', 'tileset', filename, `${layer.name}.json`);
       await fsa.write(tileSetPath, await this.formatConfigFile(tileSetPath, tileSet));
     } else {
       // Prepare new aerial tileset config


### PR DESCRIPTION
The reason I don't want the individual flag,

- This makes argo workflow harder to use flag parameter as `--individual` means true instead of `--individual true`. We need a if condition in argo to determine whether to add the `--individual` flag instead of just pass the true as parameter.

- Another reason is once we use the filename, this makes use better to manage if we have more different configs like import the imagery into `historical.json` config directly. So we just use `--finename historical` 