### PR TITLE
Revert "feat(landing): Update the layer selector to use all imagery tileset. BM-807 (#2809)"

### DIFF
--- a/packages/landing/src/url.ts
+++ b/packages/landing/src/url.ts
@@ -94,7 +94,7 @@ export const WindowUrl = {
 
   toBaseWmts(): string {
     const query = toQueryString({ api: Config.ApiKey, config: ensureBase58(Config.map.config) });
-    return `${this.baseUrl()}/v1/tiles/all/WMTSCapabilities.xml${query}`;
+    return `${this.baseUrl()}/v1/tiles/aerial/WMTSCapabilities.xml${query}`;
   },
 
   toImageryUrl(layerId: string, imageryType: string): string {


### PR DESCRIPTION
This reverts commit 10eb750b32dccb4a5f5496862bebb7cb51ca8ee9.

To revert the changes to have a smooth release, and update this for next release.