### PR TITLE
fix(cli): Correct the path of linzijs prettierrc.js location.

### DIFF
--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -16,7 +16,7 @@ RUN npm install sharp@0.30.7
 # Install the landing assets
 COPY ./basemaps-landing*.tgz /app/
 COPY ./basemaps-cogify*.tgz /app/
-COPY ./.prettierrc.js /app/node_modules/@linzjs/.prettierrc.js
+COPY ./.prettierrc.js /app/node_modules/@linzjs/style/.prettierrc.js
 
 RUN npm install ./basemaps-landing*.tgz ./basemaps-cogify*.tgz
 


### PR DESCRIPTION
This been saved in the incorrect location.

`"type":"Error","message
":"Cannot find module '@linzjs/style/.prettierrc.js'\nRequire stack:\n- /app/basemaps-config/.prettierrc.cjs\n- /app/index.cjs"`