### PR TITLE
feat(cli): Create pull request cli to format the config files by npx prettier. BM-810

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -52,7 +52,6 @@ jobs:
           # Files are packed into the base directory
           cp *.tgz packages/server/
           cp *.tgz packages/cli/
-          cp node_modules/@linzjs/style/.prettierrc.js packages/cli/
 
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -16,7 +16,6 @@ RUN npm install sharp@0.30.7
 # Install the landing assets
 COPY ./basemaps-landing*.tgz /app/
 COPY ./basemaps-cogify*.tgz /app/
-COPY ./.prettierrc.js /app/node_modules/@linzjs/style/.prettierrc.js
 
 RUN npm install ./basemaps-landing*.tgz ./basemaps-cogify*.tgz
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -60,14 +60,12 @@
     "get-port": "^6.1.2",
     "node-fetch": "^3.2.3",
     "p-limit": "^4.0.0",
-    "prettier": "^2.8.8",
     "pretty-json-log": "^1.0.0",
     "slugify": "^1.6.5",
     "zod": "^3.17.3"
   },
   "devDependencies": {
     "@types/deep-diff": "^1.0.1",
-    "@types/prettier": "^2.7.2",
     "@types/proj4": "^2.5.2",
     "@types/sharp": "^0.31.0"
   },

--- a/packages/cli/src/cli/github/make.cog.pr.ts
+++ b/packages/cli/src/cli/github/make.cog.pr.ts
@@ -22,9 +22,9 @@ export class MakeCogGithub extends Github {
   /**
    * Format the config files by prettier
    */
-  formatConfigFile(): void {
+  formatConfigFile(path = './config/'): void {
     this.logger.info({ repository: this.repo }, 'GitHub: Prettier');
-    execFileSync('npx', ['prettier', '-w', 'config'], { cwd: this.repoName });
+    execFileSync('npx', ['prettier', '-w', path], { cwd: this.repoName });
   }
 
   /**

--- a/packages/cli/src/cli/github/make.cog.pr.ts
+++ b/packages/cli/src/cli/github/make.cog.pr.ts
@@ -52,20 +52,22 @@ export class MakeCogGithub extends Github {
         title: layer.title,
         layers: [layer],
       };
-      const tileSetPath = fsa.joinAll(this.repoName, 'config', 'tileset', 'individual', `${layer.name}.json`);
-      await fsa.write(tileSetPath, JSON.stringify(tileSet));
+      const tileSetPath = fsa.joinAll('config', 'tileset', 'individual', `${layer.name}.json`);
+      const fullPath = fsa.join(this.repoName, tileSetPath);
+      await fsa.write(fullPath, JSON.stringify(tileSet));
       // Format the config file by prettier
-      this.formatConfigFile();
+      this.formatConfigFile(tileSetPath);
     } else {
       // Prepare new aerial tileset config
-      const tileSetPath = fsa.joinAll(this.repoName, 'config', 'tileset', `${filename}.json`);
-      const tileSet = await fsa.readJson<ConfigTileSetRaster>(tileSetPath);
+      const tileSetPath = fsa.joinAll('config', 'tileset', `${filename}.json`);
+      const fullPath = fsa.join(this.repoName, tileSetPath);
+      const tileSet = await fsa.readJson<ConfigTileSetRaster>(fullPath);
       const newTileSet = await this.prepareRasterTileSetConfig(layer, tileSet, category);
       // skip pull request if not an urban or rural imagery
       if (newTileSet == null) return;
-      await fsa.write(tileSetPath, JSON.stringify(newTileSet));
+      await fsa.write(fullPath, JSON.stringify(newTileSet));
       // Format the config file by prettier
-      this.formatConfigFile();
+      this.formatConfigFile(tileSetPath);
     }
 
     // Commit and push the changes
@@ -152,15 +154,16 @@ export class MakeCogGithub extends Github {
 
     // Prepare new aerial tileset config
     this.logger.info({ imagery: this.imagery }, 'GitHub: Get the master TileSet config file');
-    const tileSetPath = fsa.joinAll(this.repoName, 'config', 'tileset', `${filename}.json`);
-    const tileSet = await fsa.readJson<ConfigTileSetVector>(tileSetPath);
+    const tileSetPath = fsa.joinAll('config', 'tileset', `${filename}.json`);
+    const fullPath = fsa.join(this.repoName, tileSetPath);
+    const tileSet = await fsa.readJson<ConfigTileSetVector>(fullPath);
     const newTileSet = await this.prepareVectorTileSetConfig(layer, tileSet);
 
     // skip pull request if not an urban or rural imagery
     if (newTileSet == null) return;
-    await fsa.write(tileSetPath, JSON.stringify(newTileSet));
+    await fsa.write(fullPath, JSON.stringify(newTileSet));
     // Format the config file by prettier
-    this.formatConfigFile();
+    this.formatConfigFile(tileSetPath);
 
     // Commit and push the changes
     const message = `config(vector): Update the ${this.imagery} to ${filename} config file.`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1959,11 +1959,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/prettier@^2.7.2":
-  version "2.7.2"
-  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.2.tgz#6c2324641cc4ba050a8c710b2b251b377581fbf0"
-  integrity sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==
-
 "@types/proj4@^2.5.2":
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/@types/proj4/-/proj4-2.5.2.tgz#e3afa4e09e5cf08d8bc74e1b3de3b2111324ee33"
@@ -6755,11 +6750,6 @@ prettier@^2.8.2:
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.3.tgz#ab697b1d3dd46fb4626fbe2f543afe0cc98d8632"
   integrity sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==
-
-prettier@^2.8.8:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 pretty-json-log@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### Why?
When we make changes to config file in the basemaps-config repo, we need to format it before commit. Current way of using prettier is broken because we need to install @linzjs/style into the cli docker container. A better solution is just run prettier in the config directory before commit the changes.

#### Issue Link: [BM-810](https://toitutewhenua.atlassian.net/browse/BM-810)

### Description of Changes:
- Remove all the prettier stuff from cli
- Run npx prettier in the chirld process in config repo.

#### Author Checklist:
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in PR title

[BM-810]: https://toitutewhenua.atlassian.net/browse/BM-810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ