### PR TITLE
fix(cli): Run npm install in the basemaps-config to install the @linz/style

### DIFF
--- a/packages/cli/src/cli/github/make.cog.pr.ts
+++ b/packages/cli/src/cli/github/make.cog.pr.ts
@@ -74,9 +74,9 @@ export class MakeCogGithub extends Github {
 
     // Commit and push the changes
     const message = `config(raster): Add imagery ${this.imagery} to ${filename} config file.`;
-    // this.commit(message);
-    // this.push();
-    // await this.createPullRequests(branch, message, false);
+    this.commit(message);
+    this.push();
+    await this.createPullRequests(branch, message, false);
   }
 
   /**

--- a/packages/cli/src/cli/github/make.cog.pr.ts
+++ b/packages/cli/src/cli/github/make.cog.pr.ts
@@ -14,6 +14,7 @@ import { execFileSync } from 'child_process';
 
 export class MakeCogGithub extends Github {
   imagery: string;
+  _formatInstalled = false;
   constructor(imagery: string, repo: string, logger: LogType) {
     super(repo, logger);
     this.imagery = imagery;
@@ -22,15 +23,17 @@ export class MakeCogGithub extends Github {
   /**
    * Install the dependencies for the cloned repo
    */
-  npmInstall(): void {
+  npmInstall(): boolean {
     this.logger.info({ repository: this.repo }, 'GitHub: Npm Install');
     execFileSync('npm', ['install', '--include=dev'], { cwd: this.repoName });
+    return true;
   }
 
   /**
    * Format the config files by prettier
    */
   formatConfigFile(path = './config/'): void {
+    if (!this._formatInstalled) this._formatInstalled = this.npmInstall();
     this.logger.info({ repository: this.repo }, 'GitHub: Prettier');
     execFileSync('npx', ['prettier', '-w', path], { cwd: this.repoName });
   }
@@ -48,7 +51,6 @@ export class MakeCogGithub extends Github {
 
     // Clone the basemaps-config repo and checkout branch
     this.clone();
-    this.npmInstall();
     this.configUser();
     this.getBranch(branch);
 
@@ -158,7 +160,6 @@ export class MakeCogGithub extends Github {
 
     // Clone the basemaps-config repo and checkout branch
     this.clone();
-    this.npmInstall();
     this.configUser();
     this.getBranch(branch);
 

--- a/packages/cli/src/cli/github/make.cog.pr.ts
+++ b/packages/cli/src/cli/github/make.cog.pr.ts
@@ -19,12 +19,19 @@ export class MakeCogGithub extends Github {
     this.imagery = imagery;
   }
 
+
+  /**
+   * Install the dependencies for the cloned repo
+   */
+  npmInstall(): void {
+    this.logger.info({ repository: this.repo }, 'GitHub: Npm Install');
+    execFileSync('npm', ['install', '--include=dev'], { cwd: this.repoName });
+  }
+
   /**
    * Format the config files by prettier
    */
   formatConfigFile(path = './config/'): void {
-    this.logger.info({ repository: this.repo }, 'GitHub: Npm Install');
-    execFileSync('npm', ['install', '--include=dev'], { cwd: this.repoName });
     this.logger.info({ repository: this.repo }, 'GitHub: Prettier');
     execFileSync('npx', ['prettier', '-w', path], { cwd: this.repoName });
   }
@@ -42,6 +49,7 @@ export class MakeCogGithub extends Github {
 
     // Clone the basemaps-config repo and checkout branch
     this.clone();
+    this.npmInstall();
     this.configUser();
     this.getBranch(branch);
 
@@ -151,6 +159,7 @@ export class MakeCogGithub extends Github {
 
     // Clone the basemaps-config repo and checkout branch
     this.clone();
+    this.npmInstall();
     this.configUser();
     this.getBranch(branch);
 

--- a/packages/cli/src/cli/github/make.cog.pr.ts
+++ b/packages/cli/src/cli/github/make.cog.pr.ts
@@ -19,7 +19,6 @@ export class MakeCogGithub extends Github {
     this.imagery = imagery;
   }
 
-
   /**
    * Install the dependencies for the cloned repo
    */

--- a/packages/cli/src/cli/github/make.cog.pr.ts
+++ b/packages/cli/src/cli/github/make.cog.pr.ts
@@ -23,6 +23,8 @@ export class MakeCogGithub extends Github {
    * Format the config files by prettier
    */
   formatConfigFile(path = './config/'): void {
+    this.logger.info({ repository: this.repo }, 'GitHub: Npm Install');
+    execFileSync('npm', ['install', '--include=dev'], { cwd: this.repoName });
     this.logger.info({ repository: this.repo }, 'GitHub: Prettier');
     execFileSync('npx', ['prettier', '-w', path], { cwd: this.repoName });
   }
@@ -72,9 +74,9 @@ export class MakeCogGithub extends Github {
 
     // Commit and push the changes
     const message = `config(raster): Add imagery ${this.imagery} to ${filename} config file.`;
-    this.commit(message);
-    this.push();
-    await this.createPullRequests(branch, message, false);
+    // this.commit(message);
+    // this.push();
+    // await this.createPullRequests(branch, message, false);
   }
 
   /**


### PR DESCRIPTION
### Why?
When we make changes to config file in the basemaps-config repo, we need to format it before commit. Current way of using prettier is broken because we need to install @linzjs/style into the cli docker container. A better solution is just run prettier in the config directory before commit the changes.

#### Issue Link: [BM-810](https://toitutewhenua.atlassian.net/browse/BM-810)

### Description of Changes:
- Remove all the prettier stuff from cli
- Run npx prettier in the chirld process in config repo.

#### Author Checklist:
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in PR title

[BM-810]: https://toitutewhenua.atlassian.net/browse/BM-810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ