### PR TITLE
feat(cogify): ensure cogify path-like args have trailing slashes. BM-858

### DIFF
--- a/packages/cogify/src/cogify/cli/cli.config.ts
+++ b/packages/cogify/src/cogify/cli/cli.config.ts
@@ -9,7 +9,7 @@ import pLimit from 'p-limit';
 import { isArgo } from '../../argo.js';
 import { urlToString } from '../../download.js';
 import { getLogger, logArguments } from '../../log.js';
-import { Url } from '../parsers.js';
+import { UrlFolder } from '../parsers.js';
 
 export const BasemapsCogifyConfigCommand = command({
   name: 'cogify-config',
@@ -18,7 +18,7 @@ export const BasemapsCogifyConfigCommand = command({
   args: {
     ...logArguments,
     target: option({
-      type: optional(Url),
+      type: optional(UrlFolder),
       long: 'target',
       description: 'Where to write the config json, Defaults to imagery path',
     }),
@@ -29,7 +29,7 @@ export const BasemapsCogifyConfigCommand = command({
       defaultValue: () => 25,
       defaultValueIsSerializable: true,
     }),
-    path: positional({ type: Url, displayName: 'path', description: 'Path to imagery' }),
+    path: positional({ type: UrlFolder, displayName: 'path', description: 'Path to imagery' }),
   },
 
   async handler(args) {

--- a/packages/cogify/src/cogify/parsers.ts
+++ b/packages/cogify/src/cogify/parsers.ts
@@ -3,8 +3,9 @@ import { Type } from 'cmd-ts';
 import { pathToFileURL } from 'node:url';
 
 /**
- * Parse a input parameter as a URL,
- * if it looks like a file path convert it using `pathToFileURL`
+ * Parse a input parameter as a URL.
+ *
+ * If it looks like a file path, it will be converted using `pathToFileURL`.
  **/
 export const Url: Type<string, URL> = {
   async from(str) {
@@ -13,6 +14,23 @@ export const Url: Type<string, URL> = {
     } catch (e) {
       return pathToFileURL(str);
     }
+  },
+};
+
+/**
+ * Parse a input parameter as a URL which represents a folder.
+ *
+ * If it looks like a file path, it will be converted using `pathToFileURL`.
+ * Any search parameters or hash will be removed, and a trailing slash added
+ * to the path section if it's not present.
+ **/
+export const UrlFolder: Type<string, URL> = {
+  async from(str) {
+    const url = await Url.from(str);
+    url.search = '';
+    url.hash = '';
+    if (!url.pathname.endsWith('/')) url.pathname += '/';
+    return url;
   },
 };
 

--- a/packages/cogify/src/tile.cover.ts
+++ b/packages/cogify/src/tile.cover.ts
@@ -14,6 +14,7 @@ import {
   createFileStats,
 } from './cogify/stac.js';
 import { CutlineOptimizer } from './cutline.js';
+import { urlToString } from './download.js';
 import { Presets } from './preset.js';
 
 export interface TileCoverContext {
@@ -168,7 +169,7 @@ export async function createTileCover(ctx: TileCoverContext): Promise<TileCoverR
     // Add the cutline as a STAC Link if it exists
     if (ctx.cutline.path) {
       const cutLink: CogifyLinkCutline = {
-        href: ctx.cutline.path,
+        href: urlToString(ctx.cutline.path),
         rel: 'linz_basemaps:cutline',
         blend: ctx.cutline.blend,
       };


### PR DESCRIPTION
#### Description
*What does this change aim to achieve?*

Updates the cogify CLI commands to ensure that arguments representing folder paths have trailing slashes. Adds a `UrlFolder` parser for cmd-ts which parses the input string as a URL, and appends a trailing slash if it's missing. Changing the type from `string` to `URL` (via the `Url` or new `UrlFolder` parsers) involved changing places that use these values to construct other paths. Where these are passed to `fsa` functions, these are converted back to strings using `urlToString`.

#### Intention
*Why is this change being made? What implications or other considerations are there?*

Parts of the cogify commands were using strings for paths, while other parts were using URLs. This led to a situation where a string path was created by `fsa.joinAll()` which did not have a trailing slash, which was then passed to the URL constructor, resulting in a URL one directory higher than intended being created, which prevented finding the STAC collection.json file.

The calls to `urlToString` will be unnecessary once we upgrade to chunkd v11 which swaps to receiving URLs directly, however that is a much larger piece of work so for the time being we'll continue to gradually migrate to using URLs and use `urlToString` as needed when passing values to `fsa` functions.

#### Checklist
*If not applicable, provide explanation of why.*
- [ ] Tests updated, N/A: no existing tests to update.
- [x] Docs updated
- [x] Issue linked in Title