### PR TITLE
feat(cli): Add imagery id in the create config done log for slack notifications.

### DIFF
--- a/packages/cli/src/cli/config/action.imagery.config.ts
+++ b/packages/cli/src/cli/config/action.imagery.config.ts
@@ -139,7 +139,7 @@ export class CommandImageryConfig extends CommandLineAction {
       const configPath = base58.encode(Buffer.from(outputPath));
       const url = `https://basemaps.linz.govt.nz/?config=${configPath}&i=${tileSet.name}&tileMatrix=NZTM2000Quad&debug${location}`;
       logger.info(
-        { id, path: output, url, tileMatrix: Nztm2000QuadTms.identifier, config: configPath, title },
+        { imageryId: id, path: output, url, tileMatrix: Nztm2000QuadTms.identifier, config: configPath, title },
         'ImageryConfig:Done',
       );
       if (output != null) await fsa.write(output, url);

--- a/packages/cli/src/cli/config/action.imagery.config.ts
+++ b/packages/cli/src/cli/config/action.imagery.config.ts
@@ -139,7 +139,7 @@ export class CommandImageryConfig extends CommandLineAction {
       const configPath = base58.encode(Buffer.from(outputPath));
       const url = `https://basemaps.linz.govt.nz/?config=${configPath}&i=${tileSet.name}&tileMatrix=NZTM2000Quad&debug${location}`;
       logger.info(
-        { path: output, url, tileMatrix: Nztm2000QuadTms.identifier, config: configPath, title },
+        { id, path: output, url, tileMatrix: Nztm2000QuadTms.identifier, config: configPath, title },
         'ImageryConfig:Done',
       );
       if (output != null) await fsa.write(output, url);

--- a/packages/cogify/src/cogify/cli/cli.config.ts
+++ b/packages/cogify/src/cogify/cli/cli.config.ts
@@ -55,7 +55,7 @@ export const BasemapsCogifyConfigCommand = command({
     const url = `https://basemaps.linz.govt.nz/?config=${configPath}&i=${im.name}&tileMatrix=${im.tileMatrix}&debug${locationHash}`;
     logger.info(
       {
-        id: im.id,
+        imageryId: im.id,
         path: outputPath,
         url,
         config: configPath,

--- a/packages/cogify/src/cogify/cli/cli.config.ts
+++ b/packages/cogify/src/cogify/cli/cli.config.ts
@@ -55,6 +55,7 @@ export const BasemapsCogifyConfigCommand = command({
     const url = `https://basemaps.linz.govt.nz/?config=${configPath}&i=${im.name}&tileMatrix=${im.tileMatrix}&debug${locationHash}`;
     logger.info(
       {
+        id: im.id,
         path: outputPath,
         url,
         config: configPath,


### PR DESCRIPTION
#### Description
*Cloudwatch logs not capture the imagery id, which can't output id into the slack notifications for create-config.*

#### Intention
*Fix the log add imagery id*

#### Checklist
*Log change not required*
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title