### PR TITLE
feat(landing): Hide the topo grid layers from the layer drop down list.

### DIFF
--- a/packages/landing/src/components/layer.switcher.dropdown.tsx
+++ b/packages/landing/src/components/layer.switcher.dropdown.tsx
@@ -18,7 +18,7 @@ export interface LayerSwitcherDropdownState {
   currentLayer: string;
 }
 
-const ignoredLayers = new Set(['all']);
+const ignoredLayers = new Set(['all', 'topo50-gridless-2020-4.23m', 'topo250-2020-21.17m']);
 
 export class LayerSwitcherDropdown extends Component<unknown, LayerSwitcherDropdownState> {
   _events: (() => boolean)[] = [];


### PR DESCRIPTION
#### Description
*After imagery configuration refactoring, the topo grid layers been bundle into layer drop down, which is not related. We should hide it.*

#### Intention
*We don't want to provide public access for the topo grid layers in the drop down list.*

#### Checklist
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
