### PR TITLE
fix(cogify): correct import path

### DIFF
--- a/packages/cogify/src/cutline.ts
+++ b/packages/cogify/src/cutline.ts
@@ -10,7 +10,7 @@ import {
   toFeatureMultiPolygon,
 } from '@linzjs/geojson';
 import { CogifyLinkCutline } from './cogify/stac';
-import { urlToString } from './download';
+import { urlToString } from './download.js';
 
 export async function loadCutline(path: URL): Promise<{ polygon: MultiPolygon; projection: EpsgCode }> {
   const buf = await fsa.read(urlToString(path));


### PR DESCRIPTION
#### Description
Fixing a import path, so that running the command from the console works



#### Intention
Imports need to include ".js" or nodejs cannot find the files.


#### Checklist
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
