### PR TITLE
fix(config): do not use "rgb" or projection codes for imagery names

### DIFF
--- a/packages/config/src/json/tiff.config.ts
+++ b/packages/config/src/json/tiff.config.ts
@@ -134,25 +134,28 @@ const IgnoredTitles = new Set([
 ]);
 
 /**
- * Guess a better imagery name from a target
+ * Guess a better imagery name from a target URL
  *
  * A lot of our source paths include the type of imagery eg "rgb", "rgbi" or "dem_1m",
  * these names are not super helpful and often there are better names further up the pathname
  *
  * @example
  * ```typescript
- * getImageryName('s3://linz-imagery/auckland/auckland_sn5600_1979_0.375m/2193/rgb/') // auckland_sn5600_1979_0.375m
+ * getImageryName('s3://linz-imagery/auckland/auckland_sn5600_1979_0.375m/2193/rgb/')
+ * // auckland_sn5600_1979_0.375m
  * ```
+ *
+ * The list of paths ignored are from
  *
  * @see {IgnoredTitles}
  *
- * For more common paths see:
- * https://github.com/linz/imagery
- * https://github.com/linz/elevation
+ * For common imagery paths see:
+ *
+ * @see {@link https://github.com/linz/imagery}
+ * @see {@link https://github.com/linz/elevation}
  */
 export function getImageryName(target: URL): string {
-  const pathName = target.pathname;
-  const parts = target.pathname.split('/');
+  const parts = target.pathname.split('/'); // URL folders are always "/"
 
   for (let i = parts.length - 1; i >= 0; i--) {
     const part = parts[i];
@@ -162,7 +165,7 @@ export function getImageryName(target: URL): string {
   }
 
   // Everything is ignored just use basename
-  return basename(pathName);
+  return basename(target.pathname);
 }
 
 /**
@@ -223,14 +226,14 @@ export async function initImageryFromTiffUrl(
  *
  * Given the following folder structure
  *
- * ```
- * /imagery/invercargill_2022_0.05m/*.tiff
- * /imagery/wellington_2022_0.05/*.tiff
+ * ```typescript
+ * "/imagery/invercargill_2022_0.05m/*.tiff"
+ * "/imagery/wellington_2022_0.05/*.tiff"
  * ```
  *
  * A. A single imagery datasets
  *
- * ```
+ * ```typescript
  * target = ["/imagery/invercargill_2022_0.05m/"]
  * ```
  *
@@ -238,8 +241,8 @@ export async function initImageryFromTiffUrl(
  *
  * B: A tree of imagery datasets
  *
- * ```
- * target = ["/imagery/invercargill_2022_0.05m/", "/imagery/wellington_2022_0.05/*.tiff"]
+ * ```typescript
+ * target = ["/imagery/invercargill_2022_0.05m/*.tiff", "/imagery/wellington_2022_0.05/*.tiff"]
  * ```
  *
  * will load all tiffs from all folders targets into a single tile set "aerial",

--- a/packages/config/src/json/tiff.config.ts
+++ b/packages/config/src/json/tiff.config.ts
@@ -189,14 +189,14 @@ export async function initImageryFromTiffUrl(
     if (stac == null) log?.warn({ target: targetPath }, 'Tiff:StacNotFound');
     const params = computeTiffSummary(target, tiffs);
 
-    const folderName = getImageryName(target);
-    const title = stac?.title ?? folderName;
+    const imageryName = getImageryName(target);
+    const title = stac?.title ?? imageryName;
     const tileMatrix =
       params.projection === EpsgCode.Nztm2000 ? Nztm2000QuadTms : TileMatrixSets.tryGet(params.projection);
 
     const imagery: ConfigImageryTiff = {
       id: provider.Imagery.id(sha256base58(target.href)),
-      name: folderName,
+      name: imageryName,
       title,
       updatedAt: Date.now(),
       projection: params.projection,
@@ -209,7 +209,7 @@ export async function initImageryFromTiffUrl(
       collection: stac ?? undefined,
     };
     imagery.overviews = await ConfigJson.findImageryOverviews(imagery);
-    log?.info({ title, files: imagery.files.length }, 'Tiff:Loaded');
+    log?.info({ title, imageryName, files: imagery.files.length }, 'Tiff:Loaded');
     provider.put(imagery);
 
     return imagery;


### PR DESCRIPTION
#### Description

Most of LINZs imagery is currently stored in S3 with the format `'s3://linz-imagery/:rgion/:name/:projection/:imageryType/` this structure means basmeaps guesses the imagery name as `:imageryType` so all imagery is called "rgb" 

This makes a ignore list of common folder structures LINZ uses which do not make sense as imagery names, eg "rgb", "dem_1m" or "3857" 

Instead it traverses up the imagery path to see if there is a better name, 

before this change a imagery path of `'s3://linz-imagery/auckland/auckland_sn5600_1979_0.375m/2193/rgb/` would be called "rgb" after this change it is called "auckland_sn5600_1979_0.375m"


#### Checklist
*If not applicable, provide explanation of why.*
- [x] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
