### PR TITLE
feat(cogify): add --concurrency to allow concurrent gdal_translates

### DIFF
--- a/packages/cogify/src/cogify/cli/cli.cog.ts
+++ b/packages/cogify/src/cogify/cli/cli.cog.ts
@@ -124,7 +124,7 @@ export const BasemapsCogifyCreateCommand = command({
 
     try {
       await mkdir(tmpFolder, { recursive: true });
-      // TODO should COG creation be run concurrently?
+
       const promises = filtered.map(async (f) => {
         const { item, url } = f;
         const cutlineLink = getCutline(item.links);


### PR DESCRIPTION
#### Description

Adds `--concurrency` to all multiple `gdal_translate` to run at the same time.


#### Intention
In COG Creation `gdal_translate` often has peaks of CPU usage across all cores and then goes down to 1 core for long periods, by running multiple `gdal_translates` on the same machine we can increase the usage of the CPU



#### Checklist
*If not applicable, provide explanation of why.*
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
