### PR TITLE
fix(cogify): validate that we have access to all the files before starting

### DIFF
--- a/packages/cogify/src/cogify/cli/cli.cog.ts
+++ b/packages/cogify/src/cogify/cli/cli.cog.ts
@@ -117,6 +117,16 @@ export const BasemapsCogifyCreateCommand = command({
       for (const src of files) sources.register(new URL(src.href, i.url), i.item.id);
     }
 
+    // Check that we have read access to all the hosts that have files that we need
+    // This prevents us assuming a multiple roles when file are attempted to download
+    await Promise.all(
+      [...sources.hosts].map(async ([hostName, url]) => {
+        logger.debug({ hostName }, 'Cog:Create:ValidateAccess');
+        await fsa.head(urlToString(url));
+        logger.info({ hostName, url }, 'Cog:Create:ValidateAccess:Ok');
+      }),
+    );
+
     const gdalVersion = await new GdalRunner({ command: 'gdal_translate', args: ['--version'], output: '' }).run();
 
     /** Limit the creation of COGs to concurrency at the same time */

--- a/packages/cogify/src/download.ts
+++ b/packages/cogify/src/download.ts
@@ -30,6 +30,12 @@ export class SourceDownloader {
   items: Map<string, SourceFile>;
   /** Local cache location */
   cachePath: string;
+
+  /**
+   * Unique set of hosts eg "s3://linz-basemaps",
+   * This has to be strings as each instance of a URL is unique.
+   */
+  hosts: Map<string, URL> = new Map();
   constructor(cachePath: string) {
     this.cachePath = cachePath;
     this.Q = pLimit(10);
@@ -41,6 +47,11 @@ export class SourceDownloader {
     const assets: SourceFile = this.items.get(url.href) ?? { items: [], url };
     assets.items.push(itemId);
     this.items.set(url.href, assets);
+    if (url.protocol !== 'file') {
+      const host = new URL(url.href);
+      host.pathname = '/'; // remove the file path;
+      this.hosts.set(host.href, url);
+    }
   }
 
   /** Once a item is done with a asset clean it up if no other items need it */


### PR DESCRIPTION
#### Description

As we download multiple files at the same time, the first collection of files will often fail with `403 Permission Denied` we will then attempt to find a new role to use with these files, but as we are downloading 10+ files at the same time, all of these will attempt to find a new role and assume it.

This can lead to a massive amount of role assumptions while trying to access files

#### Intention

This adds a check before we start processing imagery, to validate that we have read access to all the remote hosts by attempting to head one file from each remote host.


#### Checklist
*If not applicable, provide explanation of why.*
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
