### PR TITLE
fix: skip creating cog when no source files BM-860

### DIFF
--- a/packages/cogify/src/cogify/cli/cli.cog.ts
+++ b/packages/cogify/src/cogify/cli/cli.cog.ts
@@ -137,6 +137,13 @@ export const BasemapsCogifyCreateCommand = command({
         const tileMatrix = TileMatrixSets.find(options.tileMatrix);
         if (tileMatrix == null) throw new Error('Failed to find tileMatrix: ' + options.tileMatrix);
         const sourceFiles = extractSourceFiles(item, url);
+
+        // Skip creating the COG if the item STAC contains no source tiffs
+        if (sourceFiles.length === 0) {
+          logger.error({ stacPath: itemStacPath, target: tiffPath }, 'Cog:NoSourceFiles');
+          return;
+        }
+
         // Create the tiff concurrently
         const outputTiffPath = await Q(async () => {
           metrics.start(tileId); // Only start the timer when the cog is actually being processed


### PR DESCRIPTION
#### Description

Skips creating a COG in the `cogify create` command if an input item STAC (from `cogify cover`) does not contain any source tiffs.

#### Intention

`cogify cover` can currently create instructions to create a target COGs from no source tiffs. When this happens, the `cogify create` command crashes. To allow in progress Argo workflows to complete, we need to allow the `cogify create` command to skips any of these item STAC files which have been created by `cogify cover`.

#### Checklist

- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in title
