### PR TITLE
feat(config): detect empty images and ignore them

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@basemaps/geo": "^6.43.0",
     "@cotar/core": "^5.4.0",
+    "@cogeotiff/core": "^7.2.0",
     "base-x": "^4.0.0",
     "zod": "^3.17.3"
   }

--- a/packages/config/src/json/json.config.ts
+++ b/packages/config/src/json/json.config.ts
@@ -59,7 +59,7 @@ const SmallTiffSizeBytes = 256 * 1024;
 async function isEmptyTiff(path: string): Promise<boolean> {
   const tiff = await CogTiff.create(fsa.source(path));
 
-  // Starting the smallest tiff overview greatly reduces teh amount of data needing to be read
+  // Starting the smallest tiff overview greatly reduces the amount of data needing to be read
   // if the tiff contains data.
   for (const img of tiff.images.reverse()) {
     const tileOffsets = img.tileOffset;

--- a/packages/config/src/json/json.config.ts
+++ b/packages/config/src/json/json.config.ts
@@ -59,13 +59,16 @@ const SmallTiffSizeBytes = 256 * 1024;
 async function isEmptyTiff(path: string): Promise<boolean> {
   const tiff = await CogTiff.create(fsa.source(path));
 
+  // Starting the smallest tiff overview greatly reduces teh amount of data needing to be read
+  // if the tiff contains data.
   for (const img of tiff.images.reverse()) {
     const tileOffsets = img.tileOffset;
     await tileOffsets.load();
-    const values = tileOffsets.value ?? [];
+    const offsets = tileOffsets.value ?? [];
     // If any tile offset is above 0 then there is data at that offset.
-    for (const v of values) {
-      if (v > 0) return false;
+    for (const offset of offsets) {
+      // There exists a tile that contains some data, so this tiff is not empty
+      if (offset > 0) return false;
     }
   }
   return true;

--- a/packages/config/src/json/json.config.ts
+++ b/packages/config/src/json/json.config.ts
@@ -49,20 +49,20 @@ export function guessIdFromUri(uri: string): string | null {
 const SmallTiffSizeBytes = 256 * 1024;
 
 /**
- * Check to see if this tiff has any meaninful amounts of data
+ * Check to see if this tiff has any data
  *
- * This looks at the first few overview levels to see if any internal tiff tiles contain data
+ * This looks at tiff tile offset arrays see if any internal tiff tiles contain any data
  *
- * @param path path to check
+ * @param toCheck Path or tiff check
  * @returns true if the tiff is empty, false otherwise
  */
-async function isEmptyTiff(path: string): Promise<boolean> {
-  const tiff = await CogTiff.create(fsa.source(path));
+export async function isEmptyTiff(toCheck: string | CogTiff): Promise<boolean> {
+  const tiff = typeof toCheck === 'string' ? await CogTiff.create(fsa.source(toCheck)) : toCheck;
 
   // Starting the smallest tiff overview greatly reduces the amount of data needing to be read
   // if the tiff contains data.
-  for (const img of tiff.images.reverse()) {
-    const tileOffsets = img.tileOffset;
+  for (let i = tiff.images.length - 1; i >= 0; i--) {
+    const tileOffsets = tiff.images[i].tileOffset;
     await tileOffsets.load();
     const offsets = tileOffsets.value ?? [];
     // If any tile offset is above 0 then there is data at that offset.


### PR DESCRIPTION
#### Description

Sometimes when tiffs are create they are created outside the bounds of where the source tiff actually has data. 

`gdal_translate` will then create a completly empty tiff, as the tiffs are created with `sparse_ok=true` the internal tiff tag `TileOffsets`  which contains the file offsets for all the internal tiles will contain offsets of `0` with byte length of `0`.

If all the offsets are `0` then there is no data inside the tiff.

#### Intention

We are seeing a large number of empty tiffs being imported into our configuration and until we can clean out the source locations it is easier to check the tiff to see if it contains data, when we are creating the configuration.

I have tested this with the current [linz/basemaps-config](https://github.com/linz/basemaps-config) configs and it found 4,548 empty tiff files ranging in size from 1KB to 250KB.

#### Checklist
*If not applicable, provide explanation of why.*
- [x] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
