### PR TITLE
feat(landing): increase visual prominence of category in layer dropdown

### DIFF
--- a/packages/landing/src/components/layer.switcher.dropdown.tsx
+++ b/packages/landing/src/components/layer.switcher.dropdown.tsx
@@ -69,7 +69,19 @@ export class LayerSwitcherDropdown extends Component<unknown, LayerSwitcherDropd
     return (
       <div className="LuiDeprecatedForms">
         <h6>Layers</h6>
-        <Select<Option> options={ret.options} onChange={this.onLayerChange} value={ret.current} />
+        <Select<Option>
+          options={ret.options}
+          onChange={this.onLayerChange}
+          value={ret.current}
+          styles={{
+            groupHeading: (baseStyles) => ({
+              ...baseStyles,
+              fontSize: '90%',
+              color: '#00425d',
+              letterSpacing: '1px',
+            }),
+          }}
+        />
         <div className="lui-input-group-wrapper">
           <div className="lui-checkbox-container">
             <input type="checkbox" onChange={this.onZoomExtentChange} checked={this.state.zoomToExtent} />

--- a/packages/landing/src/components/layer.switcher.dropdown.tsx
+++ b/packages/landing/src/components/layer.switcher.dropdown.tsx
@@ -73,14 +73,8 @@ export class LayerSwitcherDropdown extends Component<unknown, LayerSwitcherDropd
           options={ret.options}
           onChange={this.onLayerChange}
           value={ret.current}
-          styles={{
-            groupHeading: (baseStyles) => ({
-              ...baseStyles,
-              fontSize: '90%',
-              color: '#00425d',
-              letterSpacing: '1px',
-            }),
-          }}
+          classNamePrefix="layer-selector"
+          id="layer-selector"
         />
         <div className="lui-input-group-wrapper">
           <div className="lui-checkbox-container">

--- a/packages/landing/static/index.css
+++ b/packages/landing/static/index.css
@@ -222,3 +222,14 @@ button {
 .date-range p {
   margin-top: 16px;
 }
+
+/*
+The additional #layer-selector id selector is needed to ensure these styles
+have higher specifity than the default styles of the react-select component
+*/
+#layer-selector .layer-selector__group-heading {
+  font-size: 90%;
+  color: #00425d;
+  letter-spacing: 1px;
+}
+


### PR DESCRIPTION
#### Description

Increase the visual prominence of the category heading in the layer dropdown on the landing page. It does this by:

- Increasing the size, from 75% layer name size to 90% layer name size.
- Darkening the colour, from a light grey `#999999` to  LUI teal `#00425d`
- Adding 1px of letterspacing, common typographic practice for all caps text to improve legibility.

**Before**:
![Screenshot from 2023-08-25 15-51-58](https://github.com/linz/basemaps/assets/1960802/5b955b05-4b61-42e5-ac2c-4bde61624062)

**After:**
![Screenshot from 2023-08-25 15-52-30](https://github.com/linz/basemaps/assets/1960802/57334ccf-864f-4795-948b-777d8aa7cf51)


#### Intention

After adding the georeferenced historical imagery layers to Basemaps, there are many more layers in the dropdown than before. The category of these layers is also more important than before when searching, thus increasing the visual prominence of the category header will improve the UX when searching for a layer in the dropdown.

~~The method of inserting styles into the `react-select` `Select` component feels very non-ideal, but seems to be the necessary way currently to modify the styles of the dropdown. Future work to refactor the frontend should include looking at a more comprehensive approach for styling components.~~

PR updated with new commit which swaps to using basic CSS styles in index.css, and adding `classNamePrefix` and `id` props to the `Select` component to allow the CSS selectors to have consistent names to target.

#### Checklist
*If not applicable, provide explanation of why.*
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in title
