### PR TITLE
feat(lambda-tiler): suggest filenames when tiles are downloaded

### DIFF
--- a/packages/lambda-tiler/src/routes/__tests__/xyz.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/xyz.test.ts
@@ -74,6 +74,7 @@ o.spec('/v1/tiles', () => {
       o(res.header('content-type')).equals(`image/${fmt}`);
       o(res.header('etag')).notEquals(undefined);
       o(res.header('cache-control')).equals('public, max-age=604800, stale-while-revalidate=86400');
+      o(res.header('content-disposition')).equals(`inline; filename=\"aerial_0_0_0.${fmt}\"`);
     });
   });
 
@@ -110,6 +111,7 @@ o.spec('/v1/tiles', () => {
     o(res.header('content-type')).equals('image/png');
     o(res.header('etag')).notEquals(undefined);
     o(res.header('cache-control')).equals('public, max-age=604800, stale-while-revalidate=86400');
+    o(res.header('content-disposition')).equals('inline; filename="🦄 🌈_0_0_0.png"');
   });
 
   ['/favicon.ico', '/index.html', '/foo/bar'].forEach((path) => {

--- a/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
+++ b/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
@@ -1,5 +1,5 @@
 import { getAllImagery, ConfigTileSetRaster } from '@basemaps/config';
-import { Bounds, Epsg, TileMatrixSet, TileMatrixSets, VectorFormat } from '@basemaps/geo';
+import { Bounds, Epsg, ImageFormat, TileMatrixSet, TileMatrixSets, VectorFormat } from '@basemaps/geo';
 import { Env, fsa } from '@basemaps/shared';
 import { Tiler } from '@basemaps/tiler';
 import { TileMakerSharp } from '@basemaps/tiler-sharp';
@@ -116,9 +116,12 @@ export const TileXyzRaster = {
     req.set('layersUsed', res.layers);
     req.set('bytes', res.buffer.byteLength);
 
+    const suggestedFilename = [tileSet.name, xyz.tile.z, xyz.tile.x, xyz.tile.y].join('_') + `.${xyz.tileType}`;
+
     const response = new LambdaHttpResponse(200, 'ok');
     response.header(HttpHeader.ETag, cacheKey);
     response.header(HttpHeader.CacheControl, 'public, max-age=604800, stale-while-revalidate=86400');
+    response.header('Content-Disposition', `inline; filename="${suggestedFilename}"`);
     response.buffer(res.buffer, 'image/' + xyz.tileType);
     return response;
   },

--- a/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
+++ b/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
@@ -1,5 +1,5 @@
-import { getAllImagery, ConfigTileSetRaster } from '@basemaps/config';
-import { Bounds, Epsg, ImageFormat, TileMatrixSet, TileMatrixSets, VectorFormat } from '@basemaps/geo';
+import { ConfigTileSetRaster, getAllImagery } from '@basemaps/config';
+import { Bounds, Epsg, TileMatrixSet, TileMatrixSets, VectorFormat } from '@basemaps/geo';
 import { Env, fsa } from '@basemaps/shared';
 import { Tiler } from '@basemaps/tiler';
 import { TileMakerSharp } from '@basemaps/tiler-sharp';


### PR DESCRIPTION
#### Description

Adds a `Content-Disposition` for all xyz tile URLS to provide nicer filenames


#### Intention

When debugging tiles I often download a tile but the filename is just the `:y.png` this adds a suggested filename to all xyz raster tiles in the format `:tileSet_:z_:x_:y.:ext` to make it easier to filter through downloaded tiles.


#### Checklist
*If not applicable, provide explanation of why.*
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
