### PR TITLE
fix(lambda-tiler): generate previews from config urls too

### DIFF
--- a/packages/lambda-tiler/src/routes/preview.index.ts
+++ b/packages/lambda-tiler/src/routes/preview.index.ts
@@ -99,6 +99,9 @@ export async function previewIndexGet(req: LambdaHttpRequest<PreviewIndexGet>): 
   const short = LocationUrl.truncateLatLon(loc);
   const shortLocation = [short.zoom, short.lon, short.lat].join('/');
 
+  const cfg = ConfigLoader.extract(req);
+  const queryParams = cfg == null ? '' : `?config=${cfg}`;
+
   // Include tile matrix name eg "[NZTM2000Quad]" in the title if its not WebMercatorQuad
   const tileMatrixId = tileMatrix.identifier === GoogleTms.identifier ? '' : ` [${tileMatrix.identifier}]`;
   // List of tags to replace in the index.html
@@ -111,7 +114,7 @@ export async function previewIndexGet(req: LambdaHttpRequest<PreviewIndexGet>): 
     ],
     [
       'og:image',
-      `<meta name="twitter:image" property="og:image" content="/v1/preview/${tileSet.name}/${tileMatrix.identifier}/${shortLocation}" />`,
+      `<meta name="twitter:image" property="og:image" content="/v1/preview/${tileSet.name}/${tileMatrix.identifier}/${shortLocation}${queryParams}" />`,
     ],
   ]);
 


### PR DESCRIPTION
#### Description
Start forwarding the config location to the preview images if a config  exists

#### Intention
To preview external imagery from a config location, the preview url needs to include the `?config` without it, the preview imagery will not be able to create a preview of the imagery.



#### Checklist
*If not applicable, provide explanation of why.*
- [x] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
