### PR TITLE
feat(cli): include urlPreview for preview links

### DIFF
--- a/packages/cogify/src/cogify/cli/cli.config.ts
+++ b/packages/cogify/src/cogify/cli/cli.config.ts
@@ -51,18 +51,20 @@ export const BasemapsCogifyConfigCommand = command({
 
     const configPath = base58.encode(Buffer.from(outputPath));
     const location = getImageryCenterZoom(im);
+    const targetZoom = location.zoom;
     const lat = location.lat.toFixed(7);
     const lon = location.lon.toFixed(7);
-    const locationHash = `#@${lat},${lon},z${location.zoom}`;
-    const url = `https://basemaps.linz.govt.nz/?config=${configPath}&i=${im.name}&tileMatrix=${im.tileMatrix}&debug${locationHash}`;
-    const preview = `https://basemaps.linz.govt.nz/v1/preview/${im.name}/${im.tileMatrix}/${location.zoom}/${lon}/${lat}.webp?config=${configPath}`;
+    const locationHash = `@${lat},${lon},z${location.zoom}`;
+
+    const url = `https://basemaps.linz.govt.nz/${locationHash}?i=${im.name}&tileMatrix=${im.tileMatrix}&debug&config=${configPath}`;
+    const urlPreview = `https://basemaps.linz.govt.nz/v1/preview/${im.name}/${im.tileMatrix}/${targetZoom}/${lon}/${lat}?config=${configPath}`;
 
     logger.info(
       {
         imageryId: im.id,
         path: outputPath,
         url,
-        urlPreview: preview,
+        urlPreview,
         config: configPath,
         title: im.title,
         tileMatrix: im.tileMatrix,


### PR DESCRIPTION
#### Description
adds a `urlPreview` to all logs about imagery being created


#### Intention
When slack generates a alert for new imagery it needs to know how to make a preview thumbnail, this adds a log key `urlPreview` that can be used to make a pretty thumbnail for new imagery.


![image](https://github.com/linz/basemaps/assets/1082761/6b79d9b6-d5cb-4716-8602-fa193267b595)



#### Checklist
*If not applicable, provide explanation of why.*
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
