### PR TITLE
fix(config): ignore the argo folder "flat/" in guessing imagery names

### DIFF
--- a/packages/cli/src/cli/config/action.imagery.config.ts
+++ b/packages/cli/src/cli/config/action.imagery.config.ts
@@ -120,7 +120,7 @@ export class CommandImageryConfig extends CommandLineAction {
       layers: [{ 2193: im.id, name: im.name, title: im.title }],
     };
     provider.put(aerialTileSet);
-    provider.imageryToTileSetByName(im);
+    const tileSet = provider.imageryToTileSetByName(im);
 
     const center = { x: bounds.x + bounds.width / 2, y: bounds.y + bounds.height / 2 };
     const proj = Projection.get(Nztm2000QuadTms);
@@ -135,8 +135,8 @@ export class CommandImageryConfig extends CommandLineAction {
       await fsa.writeJson(outputPath, configJson);
       const configPath = base58.encode(Buffer.from(outputPath));
 
-      const url = `https://basemaps.linz.govt.nz/${locationHash}?i=${im.name}&tileMatrix=${im.tileMatrix}&debug&config=${configPath}`;
-      const urlPreview = `https://basemaps.linz.govt.nz/v1/preview/${im.name}/${im.tileMatrix}/${targetZoom}/${lon}/${lat}?config=${configPath}`;
+      const url = `https://basemaps.linz.govt.nz/${locationHash}?i=${tileSet.name}&tileMatrix=${im.tileMatrix}&debug&config=${configPath}`;
+      const urlPreview = `https://basemaps.linz.govt.nz/v1/preview/${tileSet.name}/${im.tileMatrix}/${targetZoom}/${lon}/${lat}?config=${configPath}`;
 
       logger.info(
         {

--- a/packages/config/src/json/__tests__/config.loader.test.ts
+++ b/packages/config/src/json/__tests__/config.loader.test.ts
@@ -119,4 +119,10 @@ o.spec('config import', () => {
       'auckland_sn5600_1979_0.375m',
     );
   });
+
+  o('should ignore argo folder names', () => {
+    o(
+      getImageryName(new URL('s3://linz-workflow-artifacts/2023-09/05-ecan-banks-peninsula-original-9mjdj/flat/')),
+    ).equals('05-ecan-banks-peninsula-original-9mjdj');
+  });
 });

--- a/packages/config/src/json/tiff.config.ts
+++ b/packages/config/src/json/tiff.config.ts
@@ -128,6 +128,8 @@ const IgnoredTitles = new Set([
   // Elevation
   'dem_1m',
   'dsm_1m',
+  // Argo folders
+  'flat',
   //Projections
   '2193',
   '3857',


### PR DESCRIPTION
#### Description

When [topo-workflows](https://github.com/linz/topo-workflows) processes imagery, it puts all the resulting imagery tiffs into `flat/`, when we attempt to create a config from this folder it names the imagery "flat" this name  is not very helpful for determining what the imagery is of.

#### Modification

Ignores `flat/` from folder names when guessing imagery names.