### PR TITLE
Fix(cli): Import config to get target zoom from covering.json

### DIFF
--- a/packages/cli/src/cli/config/action.import.ts
+++ b/packages/cli/src/cli/config/action.import.ts
@@ -261,9 +261,11 @@ export class CommandImport extends CommandLineAction {
     const aerialId = 'ts_aerial';
     const newData = await mem.TileSet.get(aerialId);
     const oldData = await cfg.TileSet.get(aerialId);
+    const aerialLayers: Set<string> = new Set<string>();
     if (newData == null || oldData == null) throw new Error('Failed to fetch aerial config data.');
     for (const layer of newData.layers) {
-      if (layer.name === 'chatham-islands_digital-globe_2014-2019_0-5m') continue; // Ignore duplicated layer.
+      aerialLayers.add(layer.name);
+      if (layer.name === 'chatham-islands-digital-globe-2014-2019-0.5m') continue; // Ignore duplicated layer.
       const existing = oldData.layers.find((l) => l.name === layer.name);
       if (existing) await this.outputUpdatedLayers(mem, layer, existing, updates, true);
       else await this.outputNewLayers(mem, layer, inserts, true);
@@ -275,6 +277,7 @@ export class CommandImport extends CommandLineAction {
     for (const config of mem.objects.values()) {
       if (!config.id.startsWith(ConfigPrefix.TileSet)) continue;
       if (config.id === 'ts_aerial' || config.id === 'ts_topographic') continue;
+      if (aerialLayers.has(config.name)) continue;
       const tileSet = config as ConfigTileSet;
       if (tileSet.layers.length > 1) continue; // Not an individual layer
       const existing = await cfg.TileSet.get(config.id);

--- a/packages/cli/src/cli/config/action.import.ts
+++ b/packages/cli/src/cli/config/action.import.ts
@@ -320,11 +320,13 @@ export class CommandImport extends CommandLineAction {
   async _loadJob(path: string): Promise<CogStacJob | undefined> {
     const existing = this._jobs.get(path);
     if (existing) return existing;
-    const exist = await fsa.exists(path);
-    if (!exist) return;
-    const job = await fsa.readJson<CogStacJob>(path);
-    this._jobs.set(path, job);
-    return job;
+    try {
+      const job = await fsa.readJson<CogStacJob>(path);
+      this._jobs.set(path, job);
+      return job;
+    } catch {
+      return;
+    }
   }
 
   _coverings: Map<string, FeatureCollection> = new Map<string, FeatureCollection>();


### PR DESCRIPTION
#### Description
The new cogify workflow deprecate the old job.json and use covering.json to prepare jobs. We need fix the import to be able to support both job.json and covering.json. 


#### Intention
We try to get gsd from job.json first, if not exist we loop for covering.json. Also, I have moved the prepare url inside the if condition to stop these s3 read and only try to get job.json if there is a change in config. 



#### Checklist
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
