### PR TITLE
fix(cli): Fix the missing return in plimit queue.

### DIFF
--- a/packages/config/src/json/json.config.ts
+++ b/packages/config/src/json/json.config.ts
@@ -97,7 +97,7 @@ export class ConfigJson {
 
     const todo = files.map(async (filePath) => {
       if (!filePath.endsWith('.json')) return;
-      Q(async () => {
+      return Q(async () => {
         const bc: BaseConfig = (await fsa.readJson(filePath)) as BaseConfig;
         const prefix = ConfigId.getPrefix(bc.id);
         if (prefix) {


### PR DESCRIPTION
#### Description
The queue in config bundle never get await cause a empty config returned earlier before processed.



#### Intention
Fix the problem by adding return for the queue function.



#### Checklist
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
