### PR TITLE
fix(tiler-sharp): do not multiply imagery with the background color BM-885

### DIFF
--- a/packages/tiler-sharp/src/index.ts
+++ b/packages/tiler-sharp/src/index.ts
@@ -1,15 +1,14 @@
-import Sharp from 'sharp';
+import { ImageFormat } from '@basemaps/geo';
 import {
+  Composition,
+  CompositionCotar,
+  CompositionTiff,
   TileMaker,
   TileMakerContext,
-  Composition,
   TileMakerResizeKernel,
-  CompositionTiff,
-  CompositionCotar,
 } from '@basemaps/tiler';
 import { Metrics } from '@linzjs/metrics';
-import sharp from 'sharp';
-import { ImageFormat } from '@basemaps/geo';
+import Sharp from 'sharp';
 
 function notEmpty<T>(value: T | null | undefined): value is T {
   return value != null;
@@ -61,7 +60,7 @@ export class TileMakerSharp implements TileMaker {
    * @throws if unsupported image format is used
    * @returns image as the supplied image format
    */
-  toImage(format: ImageFormat, pipeline: sharp.Sharp): Promise<Buffer> {
+  toImage(format: ImageFormat, pipeline: Sharp.Sharp): Promise<Buffer> {
     switch (format) {
       case ImageFormat.Jpeg:
         return pipeline.jpeg().toBuffer();
@@ -193,7 +192,7 @@ export class TileMakerSharp implements TileMaker {
       input: ret.data,
       top: comp.y,
       left: comp.x,
-      raw: ret.info,
+      raw: { width: ret.info.width, height: ret.info.height, channels: ret.info.channels },
     };
   }
 


### PR DESCRIPTION
#### Description

Some imagery is being combined with the background image causing white lines around the imagery when a background color is used.


![dce9ed_22_4173290_2576669](https://github.com/linz/basemaps/assets/1082761/3bbbbbae-6e78-4c10-80fa-33888b69f9ec)

When using a transparent background the problem goes away

![transparent_22_4173290_2576669](https://github.com/linz/basemaps/assets/1082761/4f39935e-d5da-44f4-a79d-e709edbd43e4)

This is caused by the imagery being mixed with the background as part of the composition process.


#### Intention

`ret.info.*` contains extra metadata which can change how imagery is overlayed into the output file, by only allowing the metadata we want `height`, `width` and `channels` this restricts the output image creation process to how we want.


#### Checklist
*If not applicable, provide explanation of why.*
- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
