### PR TITLE
fix(cogify): ignore existing overviews so they are not recompressed

### DIFF
--- a/packages/cogify/src/cogify/gdal.command.ts
+++ b/packages/cogify/src/cogify/gdal.command.ts
@@ -63,6 +63,11 @@ export function gdalBuildCog(id: string, sourceVrt: string, opt: CogifyCreationO
       ['--config', 'GDAL_NUM_THREADS', 'all_cpus'], // Also required to NUM_THREADS till gdal 3.7.x
       ['-co', 'BIGTIFF=IF_NEEDED'], // BigTiff is somewhat slower and most (All?) of the COGS should be well below 4GB
       ['-co', 'ADD_ALPHA=YES'],
+      /**
+       *  GDAL will recompress existing overviews if they exist which will compound
+       *  any lossly compression on the overview, so compute new overviews instead
+       */
+      ['-co', 'OVERVIEWS=IGNORE_EXISTING'],
       ['-co', `BLOCKSIZE=${cfg.blockSize}`],
       ['-co', `WARP_RESAMPLING=${cfg.warpResampling}`],
       ['-co', `OVERVIEW_RESAMPLING=${cfg.overviewResampling}`],


### PR DESCRIPTION
#### Description

To create the highest quality overviews, tell GDAL to create new overviews directly from the source imagery


#### Intention

Because we are mostly importing RGBA imagery from webp COGs now instead of straight geotiffs, overviews now exist and GDAL is starting to automatically use them.

The overviews are generally lossly already so using them as a base to create more overviews means we are compounding the lossy compression.


#### Checklist
*If not applicable, provide explanation of why.*
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
