### PR TITLE
feat(cogify): skip creating any tiles that are below 1 pixel in coverage

### DIFF
--- a/packages/cogify/src/tile.cover.ts
+++ b/packages/cogify/src/tile.cover.ts
@@ -91,6 +91,7 @@ export async function createTileCover(ctx: TileCoverContext): Promise<TileCoverR
     baseZoom: targetBaseZoom,
     cutline: ctx.cutline,
     metrics: ctx.metrics,
+    logger: ctx.logger,
   });
   ctx.metrics?.end('covering:create');
 


### PR DESCRIPTION
#### Description
skip creating output tiles with <1 pixel of coverage


#### Intention

When reprojecting imagery sometimes tiny slithers of overlaps are detected the cogify command would attempt to create a tiff which sometimes has no actual data in it. 



#### Checklist
*If not applicable, provide explanation of why.*
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
