### PR TITLE
fix(lambda-tiler): Catch the error code while reading the config file in api. BM-898

### DIFF
--- a/packages/lambda-tiler/src/util/__test__/config.loader.test.ts
+++ b/packages/lambda-tiler/src/util/__test__/config.loader.test.ts
@@ -82,8 +82,8 @@ o.spec('ConfigLoader', () => {
       .catch((e) => e);
 
     o(error instanceof LambdaHttpResponse).equals(true);
-    o((error as LambdaHttpResponse).status).equals(404);
-    o((error as LambdaHttpResponse).statusDescription).equals(`Config not found at ${location}`);
+    o((error as LambdaHttpResponse).status).equals(400);
+    o((error as LambdaHttpResponse).statusDescription).equals(`Invalid config location at ${location}`);
   });
 
   o('should get expected config file', async () => {
@@ -115,7 +115,7 @@ o.spec('ConfigLoader', () => {
   });
 
   const deletedLocation = 'memory://linz-basemaps/config-deleted.json';
-  o('should Error 404 if config file not exists', async () => {
+  o('should Error 400 if config file not exists', async () => {
     const error = await ConfigLoader.load(
       mockUrlRequest('/v1/tiles/🦄 🌈/NZTM2000Quad/tile.json', `?config=${deletedLocation}`, Api.header),
     )
@@ -123,7 +123,7 @@ o.spec('ConfigLoader', () => {
       .catch((e) => e);
 
     o(error instanceof LambdaHttpResponse).equals(true);
-    o((error as LambdaHttpResponse).status).equals(404);
-    o((error as LambdaHttpResponse).statusDescription).equals(`Config not found at ${deletedLocation}`);
+    o((error as LambdaHttpResponse).status).equals(400);
+    o((error as LambdaHttpResponse).statusDescription).equals(`Invalid config location at ${deletedLocation}`);
   });
 });

--- a/packages/lambda-tiler/src/util/__test__/config.loader.test.ts
+++ b/packages/lambda-tiler/src/util/__test__/config.loader.test.ts
@@ -113,4 +113,17 @@ o.spec('ConfigLoader', () => {
 
     o(await provider.Imagery.get('topographic')).deepEquals(await expectedConfig.Imagery.get('topographic'));
   });
+
+  const deletedLocation = 'memory://linz-basemaps/config-deleted.json';
+  o('should Error 404 if config file not exists', async () => {
+    const error = await ConfigLoader.load(
+      mockUrlRequest('/v1/tiles/🦄 🌈/NZTM2000Quad/tile.json', `?config=${deletedLocation}`, Api.header),
+    )
+      .then(() => null)
+      .catch((e) => e);
+
+    o(error instanceof LambdaHttpResponse).equals(true);
+    o((error as LambdaHttpResponse).status).equals(404);
+    o((error as LambdaHttpResponse).statusDescription).equals(`Config not found at ${deletedLocation}`);
+  });
 });

--- a/packages/lambda-tiler/src/util/config.loader.ts
+++ b/packages/lambda-tiler/src/util/config.loader.ts
@@ -46,10 +46,14 @@ export class ConfigLoader {
 
     req.set('config', configLocation);
     req.timer.start('config:load');
-    return CachedConfig.get(configLocation).then((f) => {
-      req.timer.end('config:load');
-      if (f == null) throw new LambdaHttpResponse(404, `Config not found at ${configLocation}`);
-      return f;
-    });
+    return CachedConfig.get(configLocation)
+      .then((f) => {
+        req.timer.end('config:load');
+        if (f == null) throw new LambdaHttpResponse(404, `Config not found at ${configLocation}`);
+        return f;
+      })
+      .catch((e) => {
+        throw new LambdaHttpResponse(e.status, e.statusDescription);
+      });
   }
 }

--- a/packages/lambda-tiler/src/util/config.loader.ts
+++ b/packages/lambda-tiler/src/util/config.loader.ts
@@ -46,14 +46,10 @@ export class ConfigLoader {
 
     req.set('config', configLocation);
     req.timer.start('config:load');
-    return CachedConfig.get(configLocation)
-      .then((f) => {
-        req.timer.end('config:load');
-        if (f == null) throw new LambdaHttpResponse(404, `Config not found at ${configLocation}`);
-        return f;
-      })
-      .catch((e) => {
-        throw new LambdaHttpResponse(e.status, e.statusDescription);
-      });
+    return CachedConfig.get(configLocation).then((f) => {
+      req.timer.end('config:load');
+      if (f == null) throw new LambdaHttpResponse(400, `Invalid config location at ${configLocation}`);
+      return f;
+    });
   }
 }


### PR DESCRIPTION
#### Description
When failed to get config file from s3, return correct error code in logs and remove the 500 error in #proj-basemaps-alerts


#### Intention
Catch the error from `fsa.readJson(config)`, and throw correct error code and message.



#### Checklist
- [X] Tests updated
- [ ] Docs updated
- [X] Issue linked in Title
