### PR TITLE
feat(landing): hard code scanned aerial imagery layers BM-892

### DIFF
--- a/packages/landing/src/components/layer.switcher.dropdown.tsx
+++ b/packages/landing/src/components/layer.switcher.dropdown.tsx
@@ -64,6 +64,7 @@ export class LayerSwitcherDropdown extends Component<unknown, LayerSwitcherDropd
       Config.map.layers.then((f) => {
         const layer = f.get(layerId);
         if (layer == null) return;
+        if (layer.upperLeft == null || layer.lowerRight == null) return;
         Config.map.emit('bounds', [layer.upperLeft, layer.lowerRight]);
       });
     }

--- a/packages/landing/src/components/layer.switcher.dropdown.tsx
+++ b/packages/landing/src/components/layer.switcher.dropdown.tsx
@@ -5,16 +5,17 @@ import { LayerInfo, MapConfig } from '../config.map.js';
 
 type CategoryMap = Map<string, { label: string; options: { label: string; value: string }[] }>;
 
-const CategoryOrder = new Map<string, number>([
-  ['Basemaps', 1],
-  ['Satellite Imagery', 2],
-  ['Urban Aerial Photos', 3],
-  ['Rural Aerial Photos', 4],
-  ['Scanned Aerial Imagery', 5],
-  ['Event', 6],
-  ['Bathymetry', 7],
-  ['Elevation', 8],
-]);
+const Categories = [
+  'Basemaps',
+  'Satellite Imagery',
+  'Urban Aerial Photos',
+  'Rural Aerial Photos',
+  'Scanned Aerial Imagery Basemaps',
+  'Scanned Aerial Imagery',
+  'Event',
+  'Bathymetry',
+  'Elevation',
+];
 
 export interface GroupedOptions {
   label: string;
@@ -118,12 +119,11 @@ export class LayerSwitcherDropdown extends Component<unknown, LayerSwitcherDropd
     }
     const orderedCategories: CategoryMap = new Map(
       [...categories].sort((a, b) => {
-        const fallbackOrder = 999;
-        const orderA = CategoryOrder.get(a[0]) ?? fallbackOrder;
-        const orderB = CategoryOrder.get(b[0]) ?? fallbackOrder;
-        if (orderA > orderB) return 1;
-        if (orderA < orderB) return -1;
-        return a[0].localeCompare(b[0]);
+        const orderA = Categories.indexOf(a[0]);
+        const orderB = Categories.indexOf(b[0]);
+        if (orderA === orderB) return a[0].localeCompare(b[0]);
+        if (orderA === -1 || orderA < orderB) return -1;
+        return 1;
       }),
     );
     return { options: [...orderedCategories.values()], current: current };

--- a/packages/landing/src/components/map.switcher.tsx
+++ b/packages/landing/src/components/map.switcher.tsx
@@ -1,6 +1,6 @@
 import maplibre from 'maplibre-gl';
 import { Component, ReactNode } from 'react';
-import { Config } from '../config.js';
+import { Config, GaEvent, gaEvent } from '../config.js';
 import { MapConfig } from '../config.map.js';
 import { getTileGrid } from '../tile.matrix.js';
 import { onMapLoaded } from './map.js';
@@ -79,6 +79,9 @@ export class MapSwitcher extends Component {
   };
 
   switchLayer = (): void => {
+    // Both a click event and layer switch even will be fired from this action
+    gaEvent(GaEvent.Ui, 'map-switcher:click');
+
     const target = this.getStyleType();
     Config.map.setLayerId(target.layerId, target.style);
     this.updateMap();

--- a/packages/landing/src/config.map.ts
+++ b/packages/landing/src/config.map.ts
@@ -229,8 +229,8 @@ export interface LayerInfo {
   /** Layer category */
   category?: string;
   /* Bounding box */
-  upperLeft: [number, number];
-  lowerRight: [number, number];
+  upperLeft?: [number, number];
+  lowerRight?: [number, number];
   /** What projections are enabled for this layer */
   projections: Set<EpsgCode>;
 }
@@ -287,20 +287,44 @@ async function loadAllLayers(): Promise<Map<string, LayerInfo>> {
   return output;
 }
 
+/**
+ * The server currently has no way of telling the client the full list of tilesets it could use
+ * so hard code a few default tilesets with their projections
+ *
+ * @param output layers list to add to
+ */
 function addDefaultLayers(output: Map<string, LayerInfo>): void {
-  output.set('aerial', {
-    id: 'aerial',
-    name: 'Aerial Imagery',
-    projections: new Set([EpsgCode.Nztm2000, EpsgCode.Google]),
-    category: 'Basemaps',
-  } as LayerInfo);
+  const layers: LayerInfo[] = [
+    {
+      id: 'aerial',
+      name: 'Aerial Imagery',
+      projections: new Set([EpsgCode.Nztm2000, EpsgCode.Google]),
+      category: 'Basemaps',
+    },
 
-  output.set('topographic::topographic', {
-    id: 'topographic::topographic',
-    name: 'Topographic',
-    projections: new Set([EpsgCode.Google]),
-    category: 'Basemaps',
-  } as LayerInfo);
+    {
+      id: 'topographic::topographic',
+      name: 'Topographic',
+      projections: new Set([EpsgCode.Google]),
+      category: 'Basemaps',
+    },
+
+    {
+      id: 'scanned-aerial-imagery-pre-1990-01-01',
+      name: 'Scanned Aerial Imagery pre 1 January 1990',
+      projections: new Set([EpsgCode.Nztm2000, EpsgCode.Google]),
+      category: 'Scanned Aerial Imagery',
+    },
+
+    {
+      id: 'scanned-aerial-imagery-post-1989-12-31"',
+      name: 'Scanned Aerial Imagery post 31 December 1989',
+      projections: new Set([EpsgCode.Nztm2000, EpsgCode.Google]),
+      category: 'Scanned Aerial Imagery',
+    },
+  ];
+
+  for (const l of layers) output.set(l.id, l);
 }
 /** Lookup a projection from either "EPSG:3857" or "WebMercatorQuad" */
 function tmsIdToEpsg(id: string): Epsg | null {

--- a/packages/landing/src/config.map.ts
+++ b/packages/landing/src/config.map.ts
@@ -313,14 +313,14 @@ function addDefaultLayers(output: Map<string, LayerInfo>): void {
       id: 'scanned-aerial-imagery-pre-1990-01-01',
       name: 'Scanned Aerial Imagery pre 1 January 1990',
       projections: new Set([EpsgCode.Nztm2000, EpsgCode.Google]),
-      category: 'Scanned Aerial Imagery',
+      category: 'Scanned Aerial Imagery Basemaps',
     },
 
     {
       id: 'scanned-aerial-imagery-post-1989-12-31"',
       name: 'Scanned Aerial Imagery post 31 December 1989',
       projections: new Set([EpsgCode.Nztm2000, EpsgCode.Google]),
-      category: 'Scanned Aerial Imagery',
+      category: 'Scanned Aerial Imagery Basemaps',
     },
   ];
 


### PR DESCRIPTION
#### Description

The server currently does not provide a full list of tilesets to the client, so some layers need to be hard coded into the layer switcher. 

#### Intention
Adds the new new historical imagery tilesets into the layer switcher dropdown



#### Checklist
*If not applicable, provide explanation of why.*
- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
