### PR TITLE
feat(landing): track when the map switcher is clicked

### DIFF
--- a/packages/landing/src/components/map.switcher.tsx
+++ b/packages/landing/src/components/map.switcher.tsx
@@ -1,6 +1,6 @@
 import maplibre from 'maplibre-gl';
 import { Component, ReactNode } from 'react';
-import { Config } from '../config.js';
+import { Config, GaEvent, gaEvent } from '../config.js';
 import { MapConfig } from '../config.map.js';
 import { getTileGrid } from '../tile.matrix.js';
 import { onMapLoaded } from './map.js';
@@ -79,6 +79,9 @@ export class MapSwitcher extends Component {
   };
 
   switchLayer = (): void => {
+    // Both a click event and layer switch even will be fired from this action
+    gaEvent(GaEvent.Ui, 'map-switcher:click');
+
     const target = this.getStyleType();
     Config.map.setLayerId(target.layerId, target.style);
     this.updateMap();


### PR DESCRIPTION
#### Description
The map switcher button in the bottom right switches the layers as well as the layer dropdown, we currently only track that a layer is switched and not which source is clicked

#### Intention

Start tracking when the map-switcher is used to switch layers

#### Checklist
*If not applicable, provide explanation of why.*
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
