### PR TITLE
fix(landing): correct broken tileset name

### DIFF
--- a/packages/landing/src/config.map.ts
+++ b/packages/landing/src/config.map.ts
@@ -317,7 +317,7 @@ function addDefaultLayers(output: Map<string, LayerInfo>): void {
     },
 
     {
-      id: 'scanned-aerial-imagery-post-1989-12-31"',
+      id: 'scanned-aerial-imagery-post-1989-12-31',
       name: 'Scanned Aerial Imagery post 31 December 1989',
       projections: new Set([EpsgCode.Nztm2000, EpsgCode.Google]),
       category: 'Scanned Aerial Imagery Basemaps',


### PR DESCRIPTION
#### Motivation
Fixes a broken tileset link name


#### Modification
a extra " was added to the tileset name.



#### Checklist
*If not applicable, provide explanation of why.*
- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
