### PR TITLE
feat(cli): Allow bundle to guess the imagery ID from the url with slash ending.

### DIFF
--- a/packages/config/src/json/json.config.ts
+++ b/packages/config/src/json/json.config.ts
@@ -33,7 +33,8 @@ const Q = PLimit(10);
 
 export function guessIdFromUri(uri: string): string | null {
   const parts = uri.split('/');
-  const id = parts.pop();
+  let id = parts.pop();
+  if (uri.endsWith('/')) id = parts.pop();
 
   if (id == null) return null;
   try {

--- a/packages/config/src/json/json.config.ts
+++ b/packages/config/src/json/json.config.ts
@@ -33,7 +33,7 @@ const Q = PLimit(10);
 
 export function guessIdFromUri(uri: string): string | null {
   const parts = uri.split('/');
-  const id = uri.endsWith('/') ? parts.at(-2) : parts.at(-1)
+  const id = uri.endsWith('/') ? parts.at(-2) : parts.at(-1);
 
   if (id == null) return null;
   try {

--- a/packages/config/src/json/json.config.ts
+++ b/packages/config/src/json/json.config.ts
@@ -33,8 +33,7 @@ const Q = PLimit(10);
 
 export function guessIdFromUri(uri: string): string | null {
   const parts = uri.split('/');
-  let id = parts.pop();
-  if (uri.endsWith('/')) id = parts.pop();
+  const id = uri.endsWith('/') ? parts.at(-2) : parts.at(-1)
 
   if (id == null) return null;
   try {


### PR DESCRIPTION
#### Motivation
We are trying to add slash at the end of all the urls in the basemaps-configs. 
https://github.com/linz/basemaps-config/pull/809

#### Modification

This will fix the bundle to find the correct imagery id from the both new and old url.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
