### PR TITLE
fix(cli): Fix the installiation of node js in the cli container. BM-916

### DIFF
--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -4,10 +4,14 @@ ENV NODE_ENV=PRODUCTION
 
 WORKDIR /app/
 
-# RUN apt-get update
-# RUN apt-get install -y openssl ca-certificates > /dev/null 2>&1
-# RUN update-ca-certificates
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
+RUN apt-get update
+RUN apt-get install -y ca-certificates curl gnupg
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+ENV NODE_MAJOR=18
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+
+RUN apt-get update
 RUN apt-get install -y nodejs git
 
 # Install sharp TODO update this when we change sharp versions


### PR DESCRIPTION
#### Motivation

The old node js installation in docker is deprecated. Update to use the new one based on https://github.com/nodesource/distributions#installation-instructions

#### Modification

#### Checklist

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
