### PR TITLE
build: Upgrade the cli container to use gdal 3.7.2

### DIFF
--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/osgeo/gdal:ubuntu-small-3.7.0
+FROM ghcr.io/osgeo/gdal:ubuntu-small-3.7.2
 
 ENV NODE_ENV=PRODUCTION
 

--- a/packages/cli/src/gdal/gdal.docker.ts
+++ b/packages/cli/src/gdal/gdal.docker.ts
@@ -51,7 +51,7 @@ export class GdalDocker extends GdalCommand {
   /** this could contain sensitive info like AWS access keys */
   private async getDockerArgs(): Promise<string[]> {
     const DOCKER_CONTAINER = Env.get(Env.Gdal.DockerContainer) ?? 'ghcr.io/osgeo/gdal';
-    const DOCKER_CONTAINER_TAG = Env.get(Env.Gdal.DockerContainerTag) ?? 'ubuntu-small-3.7.0';
+    const DOCKER_CONTAINER_TAG = Env.get(Env.Gdal.DockerContainerTag) ?? 'ubuntu-small-3.7.2';
     const userInfo = os.userInfo();
     const credentials = await this.getCredentials();
     return [

--- a/packages/cogify/src/cogify/gdal.runner.ts
+++ b/packages/cogify/src/cogify/gdal.runner.ts
@@ -15,7 +15,7 @@ export interface GdalCommand {
 
 function getDockerContainer(): string {
   const containerPath = process.env['GDAL_DOCKER_CONTAINER'] ?? 'ghcr.io/osgeo/gdal';
-  const tag = process.env['GDAL_DOCKER_CONTAINER_TAG'] ?? 'ubuntu-small-3.7.0';
+  const tag = process.env['GDAL_DOCKER_CONTAINER_TAG'] ?? 'ubuntu-small-3.7.2';
   return `${containerPath}:${tag}`;
 }
 


### PR DESCRIPTION
#### Motivation

Upgrade gdal to 3.7.2 to fix the webp CVE

#### Modification

Upgrade the cli docker container version to 3.7.2

#### Checklist

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
