### PR TITLE
ci: switch to "dev" as the main nonprod enviroment to be more consistent with JIRA

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -56,14 +56,14 @@ jobs:
       - name: Benchmark
         uses: blacha/hyperfine-action@v1
 
-  deploy-nonprod:
+  deploy-dev:
     runs-on: ubuntu-latest
-    concurrency: deploy-nonprod-${{ github.ref }}
+    concurrency: deploy-dev-${{ github.ref }}
     needs: [build-deploy]
     if: github.ref == 'refs/heads/master' && github.repository == 'linz/basemaps'
 
     environment:
-      name: nonprod
+      name: dev
       url: https://dev.basemaps.linz.govt.nz
 
     permissions:
@@ -78,14 +78,14 @@ jobs:
       # pulls all tags (needed for lerna to correctly version)
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* # see https://stackoverflow.com/a/60184319/9285308
 
-      - name: (NonProd) Configure AWS Credentials
+      - name: (Dev) Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2.0.0
         with:
           aws-region: ap-southeast-2
           mask-aws-account-id: true
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
 
-      - name: (NonProd) Deploy
+      - name: (Dev) Deploy
         run: |
           npx lerna run bundle --stream
           npx lerna run deploy:deploy --stream
@@ -93,7 +93,7 @@ jobs:
           GOOGLE_ANALYTICS: ${{secrets.GOOGLE_ANALYTICS_NON_PROD}}
           NODE_ENV: 'dev'
 
-      - name: (NonProd) After Deploy Smoke Test
+      - name: (Dev) After Deploy Smoke Test
         run: |
           cd packages/smoke
           node --test
@@ -101,7 +101,7 @@ jobs:
   deploy-prod:
     runs-on: ubuntu-latest
     concurrency: deploy-prod-${{ github.ref }}
-    needs: [deploy-nonprod]
+    needs: [deploy-dev]
     if: github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'release:')
 
     environment:


### PR DESCRIPTION
#### Motivation

JIRA is now tracking when our tickets transition between enviroments, but is currently not tracking nonprod very well

#### Modification

To better align with JIRA enviroment wording change "nonprod" to "dev"

