### PR TITLE
fix: head can throw "NotFound"

### DIFF
--- a/packages/cli/src/cli/util.ts
+++ b/packages/cli/src/cli/util.ts
@@ -61,6 +61,7 @@ export async function getHash(Bucket: string, Key: string): Promise<string | nul
     return obj.Metadata?.[HashKey] ?? null;
   } catch (e: any) {
     if (e.code === 'NoSuchKey') return null;
+    if (e.code === 'NotFound') return null;
     throw e;
   }
 }

--- a/packages/landing/scripts/deploy.js
+++ b/packages/landing/scripts/deploy.js
@@ -20,9 +20,10 @@ async function deploy() {
   const invalidationPaths = new Set();
 
   const fileList = await fsa.toArray(fsa.list(basePath));
-  const promises = fileList.map((filePath) =>
-    Q(async () => {
-      const targetKey = filePath.slice(basePath.length);
+  const promises = fileList.map((filePath) => {
+    const targetKey = filePath.slice(basePath.length);
+
+    return Q(async () => {
       const isVersioned = HasVersionRe.test(basename(filePath));
       const contentType = mime.contentType(extname(filePath));
 
@@ -50,8 +51,11 @@ async function deploy() {
       } else {
         invalidationPaths.add(targetKey);
       }
-    }),
-  );
+    }).catch((e) => {
+      console.error('UploadFailed', { targetKey, error: String(e) });
+      throw e;
+    });
+  });
 
   await Promise.all(promises);
 

--- a/packages/landing/scripts/deploy.js
+++ b/packages/landing/scripts/deploy.js
@@ -66,4 +66,7 @@ async function deploy() {
   }
 }
 
-deploy().catch(console.error);
+deploy().catch((e) => {
+  console.log(e);
+  process.exit(1);
+});


### PR DESCRIPTION
#### Motivation

Deployment crashed with "NotFound" error, which can be thrown from a head object

#### Modification

Fix the deployment failure.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
