### PR TITLE
fix: macosx sometimes timesout when running filesystem tests

### DIFF
--- a/packages/config/src/json/__tests__/config.loader.test.ts
+++ b/packages/config/src/json/__tests__/config.loader.test.ts
@@ -22,6 +22,8 @@ o.spec('config import', () => {
   o.beforeEach(() => fsMemory.files.clear());
 
   o('should load tiff from filesystem', async () => {
+    o.timeout(1000);
+
     const buf = await fsa.read(fileURLToPath(simpleTiff));
     await fsa.write('memory://tiffs/tile-tiff-name/tiff-a.tiff', buf);
 
@@ -35,6 +37,8 @@ o.spec('config import', () => {
   });
 
   o('should skip empty tiffs from filesystem', async () => {
+    o.timeout(1000);
+
     const buf = await fsa.read(fileURLToPath(simpleTiff));
     await fsa.write('memory://tiffs/tile-tiff-name/tiff-a.tiff', buf);
     const tiff = await CogTiff.create(new SourceMemory('memory://', buf));
@@ -61,6 +65,8 @@ o.spec('config import', () => {
   });
 
   o('should create multiple imagery layers from multiple folders', async () => {
+    o.timeout(1000);
+
     const buf = await fsa.read(fileURLToPath(simpleTiff));
     await fsa.write('memory://tiffs/tile-tiff-a/tiff-a.tiff', buf);
     await fsa.write('memory://tiffs/tile-tiff-b/tiff-b.tiff', buf);
@@ -86,6 +92,8 @@ o.spec('config import', () => {
   });
 
   o('should load tiff from filesystem with projection and imagery type in name', async () => {
+    o.timeout(1000);
+
     const buf = await fsa.read(fileURLToPath(simpleTiff));
     await fsa.write('memory://tiffs/tile-tiff-name/2193/rgb/tiff-a.tiff', buf);
 


### PR DESCRIPTION
#### Motivation

MacOSX sometimes fails to run the unit tests as it times out, see https://github.com/linz/basemaps/actions/runs/6805045858/job/18503816927#step:2:889

#### Modification

Update the unit test timeouts to 1 second.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
