### PR TITLE
ci: fix permissions of dist folder as it can end up being owned by root

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,7 +31,7 @@ jobs:
           cp packages/landing/node_modules/@linzjs/lui/dist/assets/images/linz-motif.svg docs/
           npx typedoc
           docker run --rm -v ${PWD}:/docs squidfunk/mkdocs-material:9.4 build
-      
+
       - name: Store docs artifact
         uses: actions/upload-artifact@v3
         with:
@@ -90,7 +90,10 @@ jobs:
 
       - name: Build docs
         run: |
+          # dist folder must exist or it will be owned by root
+          mkdir -p packages/landing/dist 
           cp packages/landing/node_modules/@linzjs/lui/dist/assets/images/linz-motif.svg docs/
+
           npx typedoc
           docker run --rm -v ${PWD}:/docs squidfunk/mkdocs-material:9.4 build
         env:


### PR DESCRIPTION
#### Motivation

Build is failing due to a folder being owned by root

#### Modification

create the folder early so the docker container does not create it, which causes it to be owned by root.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
