### PR TITLE
ci: rename enviroments to be consistent with the rest of linz BM-923

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,7 +31,7 @@ jobs:
           cp packages/landing/node_modules/@linzjs/lui/dist/assets/images/linz-motif.svg docs/
           npx typedoc
           docker run --rm -v ${PWD}:/docs squidfunk/mkdocs-material:9.4 build
-      
+
       - name: Store docs artifact
         uses: actions/upload-artifact@v3
         with:
@@ -90,7 +90,10 @@ jobs:
 
       - name: Build docs
         run: |
+          # dist folder must exist or it will be owned by root
+          mkdir -p packages/landing/dist 
           cp packages/landing/node_modules/@linzjs/lui/dist/assets/images/linz-motif.svg docs/
+
           npx typedoc
           docker run --rm -v ${PWD}:/docs squidfunk/mkdocs-material:9.4 build
         env:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -76,7 +76,7 @@ jobs:
     if: github.ref == 'refs/heads/master' && github.repository == 'linz/basemaps'
 
     environment:
-      name: dev
+      name: nonprod
       url: https://dev.basemaps.linz.govt.nz
 
     permissions:
@@ -130,7 +130,7 @@ jobs:
     if: github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'release:')
 
     environment:
-      name: production
+      name: prod
       url: https://basemaps.linz.govt.nz
 
     permissions:


### PR DESCRIPTION
#### Motivation

To be consistent with the rest of LINZ rename our environments to `nonprod` and `prod`

#### Modification

Rename environments to `prod` and `nonprod`

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
