### PR TITLE
ci: publish the correct container for major and major.minor tags

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -93,7 +93,7 @@ jobs:
       - name: '@basemaps/server - Build and push Major/Minor'
         uses: docker/build-push-action@v3
         with:
-          context: packages/cli
+          context: packages/server
           platforms: linux/arm64,linux/amd64
           # Publish :v6 and :v6.38 tags when publishing a release
           tags: |


### PR DESCRIPTION
#### Motivation

CLI containers are currently being published as basemaps/server for major `server:v6` and major.minor `server:v6.20` tags.

#### Modification

correct the tag name for server

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
