### PR TITLE
fix(server): create missing all tileset and stac lookup locations

### DIFF
--- a/packages/config/src/json/__tests__/tiff.config.test.ts
+++ b/packages/config/src/json/__tests__/tiff.config.test.ts
@@ -1,0 +1,37 @@
+import { fsa } from '@chunkd/fs';
+import { FsMemory } from '@chunkd/source-memory';
+import o from 'ospec';
+import { loadStacFromURL } from '../tiff.config.js';
+
+o.spec('loadStacFromURL', () => {
+  const mem = new FsMemory();
+  o.beforeEach(() => fsa.register('memory://', mem));
+  o.afterEach(() => mem.files.clear());
+  o('should load a json document', async () => {
+    await mem.write('memory://foo/imagery/collection.json', JSON.stringify({ hello: 'world' }));
+
+    const result = await loadStacFromURL(new URL('memory://foo/imagery/'));
+    o(result as unknown).deepEquals({ hello: 'world' });
+  });
+
+  o('should load from trailing slash', async () => {
+    await mem.write('memory://foo/imagery/collection.json', JSON.stringify({ hello: 'world' }));
+
+    const result = await loadStacFromURL(new URL('memory://foo/imagery'));
+    o(result as unknown).deepEquals({ hello: 'world' });
+  });
+
+  o('should load from prefixes', async () => {
+    await mem.write('memory://foo/collection.json', JSON.stringify({ foo: 'bar' }));
+
+    const result = await loadStacFromURL(new URL('memory://foo/imagery'));
+    o(result as unknown).deepEquals({ foo: 'bar' });
+  });
+  o('should prioritize loading from more specific locations', async () => {
+    await mem.write('memory://foo/imagery/collection.json', JSON.stringify({ hello: 'world' }));
+    await mem.write('memory://foo/collection.json', JSON.stringify({ hello: 'Bar' }));
+
+    const result = await loadStacFromURL(new URL('memory://foo/imagery'));
+    o(result as unknown).deepEquals({ hello: 'world' });
+  });
+});

--- a/packages/config/src/json/tiff.config.ts
+++ b/packages/config/src/json/tiff.config.ts
@@ -93,7 +93,9 @@ function computeTiffSummary(target: URL, tiffs: CogTiff[]): TiffSummary {
   return res as TiffSummary;
 }
 
-/** Convert a path to a relative path
+/**
+ * Convert a path to a relative path
+ *
  * @param base the path to be relative to
  * @param other the path to convert
  */
@@ -117,8 +119,8 @@ export async function loadStacFromURL(target: URL): Promise<StacCollection | nul
   /**
    * If the target location does not end with a "/" it could be
    *
-   * a mistake "/imagery/otago_2017-2019_0.3m"
-   * a prefix "/imagery/otago_2017-2019_0.3m/CB_"
+   * - A mistake "/imagery/otago_2017-2019_0.3m"
+   * - A prefix "/imagery/otago_2017-2019_0.3m/CB_"
    *
    * So we need to check for both locations
    */
@@ -155,7 +157,7 @@ const IgnoredTitles = new Set([
   'dsm_1m',
   // Argo folders
   'flat',
-  //Projections
+  // Projections
   '2193',
   '3857',
 ]);

--- a/packages/config/src/json/tiff.config.ts
+++ b/packages/config/src/json/tiff.config.ts
@@ -110,17 +110,19 @@ function urlToString(u: URL): string {
   return u.href;
 }
 
-/** Attempt to read a stac collection.json from the target path if it exists or return null if anything goes wrong. */
-async function loadStacFromURL(target: URL): Promise<StacCollection | null> {
+/**
+ * Attempt to read a stac collection.json from the target path if it exists or return null if anything goes wrong.
+ */
+export async function loadStacFromURL(target: URL): Promise<StacCollection | null> {
+  /**
+   * If the target location does not end with a "/" it could be
+   *
+   * a mistake "/imagery/otago_2017-2019_0.3m"
+   * a prefix "/imagery/otago_2017-2019_0.3m/CB_"
+   *
+   * So we need to check for both locations
+   */
   if (!target.pathname.endsWith('/')) {
-    /**
-     * If the target location does not end with a "/" it could be
-     *
-     * a mistake "/imagery/otago_2017-2019_0.3m"
-     * a prefix "/imagery/otago_2017-2019_0.3m/CB_"
-     *
-     * So we need to check for both locations
-     */
     const pathWithSlash = new URL('collection.json', target.href + '/');
     const pathWithoutSlash = new URL('collection.json', target.href);
 
@@ -128,6 +130,7 @@ async function loadStacFromURL(target: URL): Promise<StacCollection | null> {
       fsa.readJson(urlToString(pathWithSlash)),
       fsa.readJson(urlToString(pathWithoutSlash)),
     ]);
+
     // Collection path with the `/` should take priority as it is a more specific location
     if (resWithSlash.status === 'fulfilled') return resWithSlash.value;
     if (resWithoutSlash.status === 'fulfilled') return resWithoutSlash.value;

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -41,8 +41,10 @@ export async function loadConfig(opts: ServerOptions, logger: LogType): Promise<
         'Imagery:Loaded',
       );
     }
+    mem.createVirtualTileSets();
     return mem;
   }
+
   const configPath = opts.config;
   // Load config from dynamodb table
   if (configPath.startsWith('dynamodb://')) {

--- a/packages/shared/src/__tests__/util.test.ts
+++ b/packages/shared/src/__tests__/util.test.ts
@@ -12,7 +12,7 @@ o.spec('util', () => {
     o(extractYearRangeFromName('2013')).deepEquals([2013, 2014]);
     o(extractYearRangeFromName('abc2017def')).deepEquals([2017, 2018]);
     o(extractYearRangeFromName('2019_abc')).deepEquals([2019, 2020]);
-    o(extractYearRangeFromName('12019_abc')).deepEquals([-1, -1]);
+    o(extractYearRangeFromName('12019_abc')).deepEquals(null);
     o(extractYearRangeFromName('2019_abc2020')).deepEquals([2019, 2021]);
     o(extractYearRangeFromName('2020_abc2019')).deepEquals([2019, 2021]);
     o(extractYearRangeFromName('2020-23abc')).deepEquals([2020, 2024]);

--- a/packages/shared/src/__tests__/util.test.ts
+++ b/packages/shared/src/__tests__/util.test.ts
@@ -23,7 +23,7 @@ o.spec('util', () => {
     // o(extractYearRangeFromName('otago_0_375m_sn3806_1975')).deepEquals([1975, 1976]);
   });
 
-  o.only('extractYearRangeFromTitle', () => {
+  o('extractYearRangeFromTitle', () => {
     o(extractYearRangeFromTitle('Banks Peninsula 0.075m Urban Aerial Photos (2019-2020)')).deepEquals([2019, 2020]);
     o(extractYearRangeFromTitle('Manawatu 0.125m Urban Aerial Photos (2019)')).deepEquals([2019]);
 


### PR DESCRIPTION
#### Motivation

When starting a server directly from tiffs we need both the `all` tileset so the UI finds imagery, we also need to allow for both `/imagery/otago` and `/imagery/otago/` to be supplied to the STAC loader.


#### Modification

Search two locations for STAC collection.json if the target is not a folder
Create the virtual `all` tileset for servers started from imagery

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
