### PR TITLE
feat(server): layer preview page for local debugging

### DIFF
--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -60,6 +60,6 @@ export const BasemapsServerCommand = command({
     const server = await createServer(serverOptions, logger);
 
     await server.listen({ port: args.port, host: '0.0.0.0' });
-    logger.info({ url: ServerUrl }, 'ServerStarted');
+    logger.info({ url: ServerUrl + '/layers' }, 'ServerStarted');
   },
 });

--- a/packages/server/src/route.layers.ts
+++ b/packages/server/src/route.layers.ts
@@ -1,0 +1,111 @@
+import { BasemapsConfigProvider, ConfigImagery, getAllImagery, standardizeLayerName } from '@basemaps/config';
+import { ConfigImageryTiff } from '@basemaps/config/src/json/tiff.config.js';
+import { Epsg, GoogleTms, Projection, TileMatrixSets } from '@basemaps/geo';
+import { V } from '@basemaps/shared';
+
+const previewSize = { width: 1200, height: 630 };
+
+function getImageryCenterZoom(im: ConfigImagery): { lat: number; lon: number; zoom: number } {
+  const center = { x: im.bounds.x + im.bounds.width / 2, y: im.bounds.y + im.bounds.height / 2 };
+
+  // Find a approximate GSD needed to show most of the imagery
+  const aspectWidth = im.bounds.width / previewSize.width;
+  const aspectHeight = im.bounds.height / previewSize.height;
+  const bestAspect = Math.min(aspectHeight, aspectWidth);
+
+  const tms = TileMatrixSets.find(im.tileMatrix);
+  if (tms == null) throw new Error(`Failed to lookup tileMatrix: ${im.tileMatrix}`);
+  const proj = Projection.get(tms);
+  const centerLatLon = proj.toWgs84([center.x, center.y]);
+  const targetZoom = Math.max(tms.findBestZoom(bestAspect) - 7, 0);
+  return { lat: centerLatLon[1], lon: centerLatLon[0], zoom: targetZoom };
+}
+
+export function getPreviewUrl(im: ConfigImagery): {
+  url: string;
+  name: string;
+  locationHash: string;
+  location: { lat: number; lon: number; zoom: number };
+} {
+  const location = getImageryCenterZoom(im);
+  const targetZoom = location.zoom;
+  const lat = location.lat.toFixed(7);
+  const lon = location.lon.toFixed(7);
+  const locationHash = `@${lat},${lon},z${location.zoom}`;
+
+  const name = standardizeLayerName(im.name);
+  return {
+    name,
+    location,
+    locationHash,
+    url: `/v1/preview/${name}/${im.tileMatrix}/${targetZoom}/${lon}/${lat}`,
+  };
+}
+
+export async function createLayersHtml(mem: BasemapsConfigProvider): Promise<string> {
+  const allLayers = await mem.TileSet.get('ts_all');
+  if (allLayers == null) return 'No layers found.';
+
+  const allImagery = await getAllImagery(mem, allLayers.layers, [...Epsg.Codes.values()]);
+
+  const cards = [];
+
+  const layers = [...allImagery.values()].sort((a, b) => a.title.localeCompare(b.title));
+
+  const showPreview = allImagery.size < 10;
+  for (const img of layers) {
+    let tileMatrix = TileMatrixSets.find(img.tileMatrix);
+    if (tileMatrix == null) tileMatrix = GoogleTms;
+    const ret = getPreviewUrl(img as ConfigImageryTiff);
+
+    const els = [
+      V('div', { class: `layer-header`, style: 'display:flex; justify-content: space-around;' }, [
+        V('div', { class: 'layer-title' }, img.title),
+        V('div', { class: 'layer-tile-matrix' }, `TileMatrix: ${img.tileMatrix}`),
+        V('div', { class: 'layer-tile-epsg' }, tileMatrix.projection.toEpsgString()),
+      ]),
+    ];
+
+    if (showPreview) els.push(V('img', { width: '600px', height: '315px', src: ret.url }));
+    cards.push(
+      V(
+        'a',
+        { class: `layer layer-${img.id}`, href: `/?p=${tileMatrix.projection.code}&i=${ret.name}#${ret.locationHash}` },
+        els,
+      ),
+    );
+  }
+
+  const style = `
+body {
+    font-family: 'Fira Sans';
+}
+.layer {
+    margin: auto;
+    margin-top: 32px;
+    width: 600px;
+    display: flex;
+    flex-direction: column;
+    padding: 16px;
+    box-shadow: 0px 2px 3px 0px rgba(0,0,0,.2509803922), 0px 0px 3px 0px rgba(0,0,0,.1490196078);
+}
+.layer:hover {
+    box-shadow: 0px 2px 3px 0px rgba(255,0,255,.2509803922), 0px 0px 3px 0px rgba(255,0,255,.1490196078);
+    outline: 2px solid #FF00FF;
+    cursor: pointer;
+}
+.layer-header {
+    padding-bottom: 16px;
+    display: flex;
+    flex-direction: column;
+    line-height: 1.5em;
+}
+.layer-title {
+    font-weight: bold;
+}
+`;
+
+  return V('html', [V('head', [V('style', '__STYLE_TEXT__')]), V('body', cards)])
+    .toString()
+    .replace('__STYLE_TEXT__', style); // CSS gets escaped be escaped
+}

--- a/packages/server/src/route.layers.ts
+++ b/packages/server/src/route.layers.ts
@@ -1,5 +1,4 @@
 import { BasemapsConfigProvider, ConfigImagery, getAllImagery, standardizeLayerName } from '@basemaps/config';
-import { ConfigImageryTiff } from '@basemaps/config/src/json/tiff.config.js';
 import { Epsg, GoogleTms, Projection, TileMatrixSets } from '@basemaps/geo';
 import { V } from '@basemaps/shared';
 
@@ -56,7 +55,7 @@ export async function createLayersHtml(mem: BasemapsConfigProvider): Promise<str
   for (const img of layers) {
     let tileMatrix = TileMatrixSets.find(img.tileMatrix);
     if (tileMatrix == null) tileMatrix = GoogleTms;
-    const ret = getPreviewUrl(img as ConfigImageryTiff);
+    const ret = getPreviewUrl(img);
 
     const els = [
       V('div', { class: `layer-header`, style: 'display:flex; justify-content: space-around;' }, [

--- a/packages/server/src/route.layers.ts
+++ b/packages/server/src/route.layers.ts
@@ -4,6 +4,7 @@ import { V } from '@basemaps/shared';
 
 const previewSize = { width: 1200, height: 630 };
 
+// TODO this should be shared with all of the preview generation logic
 function getImageryCenterZoom(im: ConfigImagery): { lat: number; lon: number; zoom: number } {
   const center = { x: im.bounds.x + im.bounds.width / 2, y: im.bounds.y + im.bounds.height / 2 };
 
@@ -77,7 +78,7 @@ export async function createLayersHtml(mem: BasemapsConfigProvider): Promise<str
 
   const style = `
 body {
-    font-family: 'Fira Sans';
+    font-family: 'Fira Sans', 'Open Sans';
 }
 .layer {
     margin: auto;

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -10,6 +10,7 @@ import path from 'path';
 import ulid from 'ulid';
 import { URL } from 'url';
 import { loadConfig, ServerOptions } from './config.js';
+import { createLayersHtml } from './route.layers.js';
 
 const instanceId = ulid.ulid();
 
@@ -81,6 +82,14 @@ export async function createServer(opts: ServerOptions, logger: LogType): Promis
 
   BasemapsServer.all<{ Querystring: { api: string } }>('/v1/*', queryHandler);
   BasemapsServer.all<{ Querystring: { api: string } }>('/@*', queryHandler);
+
+  // Preview a list of layers
+  BasemapsServer.get('/layers', async (req: FastifyRequest, res: FastifyReply) => {
+    const doc = await createLayersHtml(cfg);
+    res.status(200);
+    res.header('Content-Type', 'text/html');
+    res.send(doc);
+  });
 
   return BasemapsServer;
 }


### PR DESCRIPTION
#### Motivation

When starting the server against local tiff imagery it is sometimes very hard to know what imagery was actually loaded

#### Modification

when running a local server adds a `/layers` URL to  give a preview of imagery

![preview](https://github.com/linz/basemaps/assets/1082761/a0733b0d-dce4-443b-b4dd-0ac8c554c82c)

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
