### PR TITLE
fix(cli): assets are optional

### DIFF
--- a/packages/cli/src/cli/config/action.bundle.ts
+++ b/packages/cli/src/cli/config/action.bundle.ts
@@ -33,7 +33,6 @@ export class CommandBundle extends CommandLineAction {
       argumentName: 'ASSETS',
       parameterLongName: '--assets',
       description: 'Add assets location into the config bundle file',
-      required: true,
     });
   }
 
@@ -44,8 +43,7 @@ export class CommandBundle extends CommandLineAction {
     const mem = await ConfigJson.fromPath(config, logger);
     const configJson = mem.toJson();
     const assets = this.assets.value;
-    if (assets == null) throw new Error('Please provide a asset path.');
-    configJson.assets = assets;
+    if (assets) configJson.assets = assets;
     await fsa.writeJson(bundle, configJson);
     logger.info({ path: bundle }, 'ConfigBundled');
     return;

--- a/packages/config/src/config/config.bundle.ts
+++ b/packages/config/src/config/config.bundle.ts
@@ -8,5 +8,5 @@ export interface ConfigBundle extends BaseConfig {
   hash: string;
 
   /** Path of the asset file */
-  assets: string;
+  assets?: string;
 }


### PR DESCRIPTION
#### Motivation

Assests are optional and should not be required to make a configuration bundle

#### Modification

ensure the assets are set as optional remove the required flag from the bundler cli

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
