### PR TITLE
feat(cli): compare config bundles using --target config.json

### DIFF
--- a/packages/cli/src/cli/config/action.bundle.ts
+++ b/packages/cli/src/cli/config/action.bundle.ts
@@ -41,9 +41,8 @@ export class CommandBundle extends CommandLineAction {
     const config = this.config.value ?? DefaultConfig;
     const bundle = this.output.value ?? DefaultOutput;
     const mem = await ConfigJson.fromPath(config, logger);
+    if (this.assets.value) mem.assets = this.assets.value;
     const configJson = mem.toJson();
-    const assets = this.assets.value;
-    if (assets) configJson.assets = assets;
     await fsa.writeJson(bundle, configJson);
     logger.info({ path: bundle }, 'ConfigBundled');
     return;

--- a/packages/cli/src/cli/config/action.import.ts
+++ b/packages/cli/src/cli/config/action.import.ts
@@ -63,7 +63,7 @@ export class CommandImport extends CommandLineAction {
     this.target = this.defineStringParameter({
       argumentName: 'TARGET',
       parameterLongName: '--target',
-      description: 'import location',
+      description: 'Target config file to compare',
     });
     this.commit = this.defineFlagParameter({
       parameterLongName: '--commit',

--- a/packages/cli/src/cli/config/action.import.ts
+++ b/packages/cli/src/cli/config/action.import.ts
@@ -94,7 +94,6 @@ export class CommandImport extends CommandLineAction {
       logger.info({ config: this.target.value }, 'Import:Target:Load');
       const configJson = await fsa.readJson<ConfigBundled>(this.target.value);
       const mem = ConfigProviderMemory.fromJson(configJson);
-      mem.createVirtualTileSets();
       cfg = mem;
     }
 
@@ -110,7 +109,6 @@ export class CommandImport extends CommandLineAction {
     logger.info({ config }, 'Import:Load');
     const configJson = await fsa.readJson<ConfigBundled>(config);
     const mem = ConfigProviderMemory.fromJson(configJson);
-    mem.createVirtualTileSets();
 
     logger.info({ config }, 'Import:Start');
     for (const config of mem.objects.values()) this.update(config, commit);
@@ -132,6 +130,8 @@ export class CommandImport extends CommandLineAction {
         // Update the cb_latest record
         configBundle.id = cfg.ConfigBundle.id('latest');
         await cfg.ConfigBundle.put(configBundle);
+      } else {
+        logger.error("Import:NotWriteable")
       }
     }
 

--- a/packages/cli/src/cli/config/action.import.ts
+++ b/packages/cli/src/cli/config/action.import.ts
@@ -78,7 +78,7 @@ export class CommandImport extends CommandLineAction {
       const configJson = await fsa.readJson<ConfigBundled>(this.target.value);
       const mem = ConfigProviderMemory.fromJson(configJson);
       setDefaultConfig(mem);
-      return mem
+      return mem;
     }
     return getDefaultConfig();
   }
@@ -113,13 +113,13 @@ export class CommandImport extends CommandLineAction {
     for (const config of mem.objects.values()) {
       const objectType = ConfigId.getPrefix(config.id);
       if (objectType) {
-        objectTypes[objectType] = (objectTypes[objectType] ?? 0) + 1
+        objectTypes[objectType] = (objectTypes[objectType] ?? 0) + 1;
       }
       this.update(config, cfg, commit);
     }
     await Promise.all(this.promises);
 
-    logger.info({ objects: mem.objects.size, types: objectTypes }, 'Import:Compare:Done')
+    logger.info({ objects: mem.objects.size, types: objectTypes }, 'Import:Compare:Done');
 
     if (commit) {
       const configBundle: ConfigBundle = {
@@ -138,7 +138,7 @@ export class CommandImport extends CommandLineAction {
         configBundle.id = cfg.ConfigBundle.id('latest');
         await cfg.ConfigBundle.put(configBundle);
       } else {
-        logger.error("Import:NotWriteable")
+        logger.error('Import:NotWriteable');
       }
     }
 

--- a/packages/cli/src/cli/config/config.diff.ts
+++ b/packages/cli/src/cli/config/config.diff.ts
@@ -2,7 +2,7 @@ import { LogType } from '@basemaps/shared';
 import c from 'ansi-colors';
 import diff from 'deep-diff';
 
-export const IgnoredProperties = ['id', 'createdAt', 'updatedAt', 'year', 'resolution'];
+export const IgnoredProperties = new Set(['id', 'createdAt', 'updatedAt', 'year', 'resolution']);
 
 export class ConfigDiff {
   static getDiff<T>(changes: diff.Diff<T, T>[]): string {
@@ -32,7 +32,7 @@ export class ConfigDiff {
   }
 
   static showDiff<T extends { id: string }>(type: string, oldData: T, newData: T, logger: LogType): boolean {
-    const changes = diff.diff(oldData, newData, (_path: string[], key: string) => IgnoredProperties.indexOf(key) >= 0);
+    const changes = diff.diff(oldData, newData, (_path: string[], key: string) => IgnoredProperties.has(key));
     if (changes) {
       const changeDif = ConfigDiff.getDiff(changes);
       logger.info({ type, record: newData.id }, 'Changes');

--- a/packages/cli/src/cli/config/config.update.ts
+++ b/packages/cli/src/cli/config/config.update.ts
@@ -72,6 +72,7 @@ export class Updater<S extends BaseConfig = BaseConfig> {
     const newData = this.getConfig();
     const db = this.getDB();
     const oldData = await this.getOldData();
+
     if (oldData == null || ConfigDiff.showDiff(db.prefix, oldData, newData, this.logger)) {
       const operation = oldData == null ? 'Insert' : 'Update';
       this.logger.info({ type: db.prefix, record: newData.id, commit: this.isCommit }, `Change:${operation}`);

--- a/packages/cli/src/cli/config/config.update.ts
+++ b/packages/cli/src/cli/config/config.update.ts
@@ -1,14 +1,15 @@
 import {
   BaseConfig,
+  BasemapsConfigObject,
   BasemapsConfigProvider,
+  ConfigId,
   ConfigImagery,
   ConfigPrefix,
   ConfigProvider,
   ConfigTileSet,
   ConfigVectorStyle,
 } from '@basemaps/config';
-import { BasemapsConfigObject, ConfigId } from '@basemaps/config';
-import { ConfigDynamoBase, getDefaultConfig, LogConfig, LogType } from '@basemaps/shared';
+import { ConfigDynamoBase, LogConfig, LogType } from '@basemaps/shared';
 import PLimit from 'p-limit';
 
 import { ConfigDiff } from './config.diff.js';
@@ -27,9 +28,9 @@ export class Updater<S extends BaseConfig = BaseConfig> {
    * Class to apply an TileSetConfig source to the tile metadata db
    * @param config a string or TileSetConfig to use
    */
-  constructor(config: S, isCommit: boolean) {
+  constructor(config: S, oldConfig: BasemapsConfigProvider, isCommit: boolean) {
     this.config = config;
-    this.cfg = getDefaultConfig();
+    this.cfg = oldConfig;
     const prefix = ConfigId.getPrefix(config.id);
     if (prefix == null) throw new Error(`Incorrect Config Id ${config.id}`);
     this.prefix = prefix;

--- a/packages/config/src/json/json.config.ts
+++ b/packages/config/src/json/json.config.ts
@@ -30,7 +30,6 @@ import { zProviderConfig } from './parse.provider.js';
 import { zStyleJson } from './parse.style.js';
 import { TileSetConfigSchemaLayer, zTileSetConfig } from './parse.tile.set.js';
 import { loadTiffsFromPaths } from './tiff.config.js';
-import { ConfigBundle } from '../config/config.bundle.js';
 
 const Q = PLimit(10);
 

--- a/packages/config/src/json/json.config.ts
+++ b/packages/config/src/json/json.config.ts
@@ -24,12 +24,13 @@ import { ConfigPrefix } from '../config/prefix.js';
 import { ConfigProvider } from '../config/provider.js';
 import { ConfigLayer, ConfigTileSet, TileSetType } from '../config/tile.set.js';
 import { ConfigVectorStyle, StyleJson } from '../config/vector.style.js';
-import { ConfigProviderMemory } from '../memory/memory.config.js';
+import { ConfigBundled, ConfigProviderMemory } from '../memory/memory.config.js';
 import { LogType } from './log.js';
 import { zProviderConfig } from './parse.provider.js';
 import { zStyleJson } from './parse.style.js';
 import { TileSetConfigSchemaLayer, zTileSetConfig } from './parse.tile.set.js';
 import { loadTiffsFromPaths } from './tiff.config.js';
+import { ConfigBundle } from '../config/config.bundle.js';
 
 const Q = PLimit(10);
 
@@ -93,6 +94,14 @@ export class ConfigJson {
 
   /** Import configuration from a base path */
   static async fromPath(basePath: string, log: LogType): Promise<ConfigProviderMemory> {
+    if (basePath.endsWith('.json') || basePath.endsWith('.json.gz')) {
+      const config = await fsa.readJson<BaseConfig>(basePath);
+      if (config.id && config.id.startsWith('cb_')) {
+        // We have been given a config bundle just load that instead!
+        return ConfigProviderMemory.fromJson(config as unknown as ConfigBundled);
+      }
+    }
+
     const cfg = new ConfigJson(basePath, log);
 
     const files = await fsa.toArray(fsa.list(basePath));


### PR DESCRIPTION
#### Motivation

It is useful to compare configuration bundles, but they contain too many ids and values that could rotate. The import command can compare two configurations while ignoring the changes in ids.

#### Modification

compare config bundles using `--target config.json`


#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
