### PR TITLE
fix(cogify): prevent empty tiffs from being stored

### DIFF
--- a/packages/cogify/src/cogify/stac.ts
+++ b/packages/cogify/src/cogify/stac.ts
@@ -73,6 +73,16 @@ export type CogifyStacItem = StacItem & {
       datetime: string;
       /** version of GDAL used to create the COG */
       gdal?: string;
+
+      /**
+       * is the tiff invalid
+       *
+       * If the tiff was generated but then determined to be invalid this property explains why the tiff was rejected.
+       *
+       * Reasons:
+       * - "empty" - No data was produced by GDAL when creating the tiff
+       */
+      invalid?: 'empty';
     };
     'linz_basemaps:options': CogifyCreationOptions;
   };

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -3,7 +3,7 @@ export {
   BasemapsConfigObject,
   BasemapsConfigProvider,
   ConfigId,
-  getAllImagery,
+  getAllImagery
 } from './base.config.js';
 export { base58, isBase58 } from './base58.js';
 export { ensureBase58, sha256base58 } from './base58.node.js';
@@ -19,10 +19,11 @@ export {
   ConfigTileSetRaster,
   ConfigTileSetVector,
   TileResizeKernel,
-  TileSetType,
+  TileSetType
 } from './config/tile.set.js';
 export { ConfigVectorStyle, Layer, Sources, StyleJson } from './config/vector.style.js';
-export { ConfigJson, zoomLevelsFromWmts } from './json/json.config.js';
+export { ConfigJson, isEmptyTiff, zoomLevelsFromWmts } from './json/json.config.js';
 export { standardizeLayerName } from './json/name.convertor.js';
 export { ConfigBundled, ConfigProviderMemory } from './memory/memory.config.js';
 export { TileSetNameComponents, TileSetNameParser } from './tile.set.name.js';
+

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -3,7 +3,7 @@ export {
   BasemapsConfigObject,
   BasemapsConfigProvider,
   ConfigId,
-  getAllImagery
+  getAllImagery,
 } from './base.config.js';
 export { base58, isBase58 } from './base58.js';
 export { ensureBase58, sha256base58 } from './base58.node.js';
@@ -19,11 +19,10 @@ export {
   ConfigTileSetRaster,
   ConfigTileSetVector,
   TileResizeKernel,
-  TileSetType
+  TileSetType,
 } from './config/tile.set.js';
 export { ConfigVectorStyle, Layer, Sources, StyleJson } from './config/vector.style.js';
 export { ConfigJson, isEmptyTiff, zoomLevelsFromWmts } from './json/json.config.js';
 export { standardizeLayerName } from './json/name.convertor.js';
 export { ConfigBundled, ConfigProviderMemory } from './memory/memory.config.js';
 export { TileSetNameComponents, TileSetNameParser } from './tile.set.name.js';
-


### PR DESCRIPTION
#### Motivation

As cogify does not  have the exact bounding polygon of the data inside the tiff, there are occasions where a tiff is created outside the extent of the data. this tiff is empty and gdal will create a empty sparse tiff.

These tiffs are useless and should be ignored/deleted.


#### Modification

Check the output tiff to see if its empty before uploading it.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
