### PR TITLE
fix(cli): virtual tilesets are required for importing into dynamo

### DIFF
--- a/packages/cli/src/cli/config/action.import.ts
+++ b/packages/cli/src/cli/config/action.import.ts
@@ -77,6 +77,8 @@ export class CommandImport extends CommandLineAction {
       logger.info({ config: this.target.value }, 'Import:Target:Load');
       const configJson = await fsa.readJson<ConfigBundled>(this.target.value);
       const mem = ConfigProviderMemory.fromJson(configJson);
+      mem.createVirtualTileSets();
+
       setDefaultConfig(mem);
       return mem;
     }
@@ -107,6 +109,7 @@ export class CommandImport extends CommandLineAction {
     logger.info({ config }, 'Import:Load');
     const configJson = await fsa.readJson<ConfigBundled>(config);
     const mem = ConfigProviderMemory.fromJson(configJson);
+    mem.createVirtualTileSets();
 
     logger.info({ config }, 'Import:Start');
     const objectTypes: Partial<Record<ConfigPrefix, number>> = {};


### PR DESCRIPTION
#### Motivation

Virtual tile sets such as `ts_all` are needed when importing into dynamodb as they are materialized and stored into dynamo.

#### Modification

re-adds virtual tileset creation before applying the diff. 

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
