### PR TITLE
feat(config): disable the empty tiff checker

### DIFF
--- a/packages/config/src/json/json.config.ts
+++ b/packages/config/src/json/json.config.ts
@@ -49,11 +49,6 @@ export function guessIdFromUri(uri: string): string | null {
 }
 
 /**
- * If a tiff is smaller than this size, Validate that the tiff actually has meaningful amounts of data
- */
-const SmallTiffSizeBytes = 256 * 1024;
-
-/**
  * Check to see if this tiff has any data
  *
  * This looks at tiff tile offset arrays see if any internal tiff tiles contain any data

--- a/packages/config/src/json/json.config.ts
+++ b/packages/config/src/json/json.config.ts
@@ -297,7 +297,8 @@ export class ConfigJson {
       }
     } else {
       for (const t of tiffTiles) {
-        const tileName = basename(t.tiff.path);
+        // TODO add the .tiff extension back in once the new basemaps-config workflow has been merged
+        const tileName = basename(t.tiff.path).replace('.tiff', '');
 
         const tile = tileMatrix.tileToSourceBounds(t.tile);
         // Expand the total bounds to cover this tile

--- a/packages/config/src/json/json.config.ts
+++ b/packages/config/src/json/json.config.ts
@@ -296,28 +296,15 @@ export class ConfigJson {
         imageList.push({ ...imgBounds, name: tileName });
       }
     } else {
-      await Promise.all(
-        tiffTiles.map((t) => {
-          return Q(async () => {
-            if (t.tiff.size != null && t.tiff.size < SmallTiffSizeBytes) {
-              const isEmpty = await isEmptyTiff(t.tiff.path);
-              if (isEmpty) {
-                this.logger.warn({ uri: t.tiff.path, imageId: id, size: t.tiff.size }, 'Imagery:Empty');
-                return;
-              } else {
-                this.logger.trace({ uri: t.tiff.path, imageId: id, size: t.tiff.size }, 'Imagery:CheckSmall:NotEmpty');
-              }
-            }
-            const tileName = basename(t.tiff.path);
+      for (const t of tiffTiles) {
+        const tileName = basename(t.tiff.path);
 
-            const tile = tileMatrix.tileToSourceBounds(t.tile);
-            // Expand the total bounds to cover this tile
-            if (bounds == null) bounds = Bounds.fromJson(tile);
-            else bounds = bounds.union(Bounds.fromJson(tile));
-            imageList.push({ ...tile, name: tileName });
-          });
-        }),
-      );
+        const tile = tileMatrix.tileToSourceBounds(t.tile);
+        // Expand the total bounds to cover this tile
+        if (bounds == null) bounds = Bounds.fromJson(tile);
+        else bounds = bounds.union(Bounds.fromJson(tile));
+        imageList.push({ ...tile, name: tileName });
+      }
     }
 
     // Sort the files by Z, X, Y


### PR DESCRIPTION
#### Motivation

The empty tiff checker was designed to remove empty tiffs from the configuration as we had 9,000 tiffs that were empty. It greatly slows down the build pipeline. 

We have since deleted the tiffs and have added logic to prevent them being uploaded in future.


#### Modification

remove the `isEmpty` check when creating config from tiffs.


#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
