### PR TITLE
fix(docs): Ignore the .DS_Store file generated from swagger mkdocs plug in.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ dist
 cdk.out
 cdk.context.json
 *.tgz
-.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 cdk.out
 cdk.context.json
 *.tgz
+.DS_Store

--- a/packages/landing/scripts/deploy.mjs
+++ b/packages/landing/scripts/deploy.mjs
@@ -10,6 +10,8 @@ const Q = pLimit(10);
 
 const DistDir = './dist';
 
+const ignoredFiles = new Set(['.DS_Store']);
+
 // match a string containing a version number
 const HasVersionRe = /-\d+\.\d+\.\d+-/;
 
@@ -50,7 +52,7 @@ async function deploy() {
 
   const invalidationPaths = new Set();
 
-  const fileList = await fsa.toArray(fsa.list(basePath));
+  const fileList = await fsa.toArray(fsa.list(basePath).filter((f)=> !ignoredFiles.has(basename(f))));
   const promises = fileList.map((filePath) => {
     // targetKey will always start with "/" eg: "/index.html" "/docs/index.html"
     const targetKey = filePath.slice(basePath.length);


### PR DESCRIPTION
#### Motivation

A .DS_Store file generated after we adding swagger into the mkdocs, this cause the deploy failure. We should remove and ignore that.

#### Modification

Update the landing deploy script to add filter to ignore files.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
