### PR TITLE
fix(lambda-tiler): fixup up bundling of arm libvips

### DIFF
--- a/packages/lambda-tiler/bundle.sh
+++ b/packages/lambda-tiler/bundle.sh
@@ -8,4 +8,4 @@ cd dist
 # Make the new package a commonjs module
 cp -r ../static .
 # @see https://sharp.pixelplumbing.com/en/stable/install/#aws-lambda
-npm install --arch=arm64 --platform=linux --production
+npm install --cpu=arm64 --arch=arm64 --platform=linux --omit=dev


### PR DESCRIPTION
#### Motivation

the arm lambda function is not getting the correct build of the new libvips

#### Modification

force arm install

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
