### PR TITLE
fix(landing): reduce bounds for nztm BM-394

### DIFF
--- a/packages/landing/src/components/map.tsx
+++ b/packages/landing/src/components/map.tsx
@@ -87,7 +87,7 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
     const style = tileGrid.getStyle(Config.map.layerId, Config.map.style, undefined, Config.map.filter.date);
     this.map.setStyle(style);
 
-    if (Config.map.tileMatrix !== GoogleTms) this.map.setMaxBounds([-180, -85.06, 180, 85.06]);
+    if (Config.map.tileMatrix !== GoogleTms) this.map.setMaxBounds([-179.9, -85, 179.9, 85]);
     else this.map.setMaxBounds();
     // TODO check and only update when Config.map.layer changes.
     this.forceUpdate();


### PR DESCRIPTION
#### Motivation

The upgrade of maplibre broke the bounds check for NZTM.

#### Modification

Reduces the bounds slightly to fix what looks to be a rounding error.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
