### PR TITLE
fix: Fix the path of the deploy script to use the URL path

### DIFF
--- a/packages/landing/scripts/deploy.mjs
+++ b/packages/landing/scripts/deploy.mjs
@@ -52,16 +52,16 @@ async function deploy() {
 
   const invalidationPaths = new Set();
 
-  const fileList = await fsa.toArray(fsa.list(basePath));
+  const fileList = await fsa.toArray(fsa.list(fsa.toUrl(basePath)));
   const promises = fileList.map((filePath) => {
     // Ignore the files that don't need to be deployed.
-    if (ignoredFiles.has(basename(filePath))) return;
+    if (ignoredFiles.has(basename(filePath.pathname))) return;
     // targetKey will always start with "/" eg: "/index.html" "/docs/index.html"
-    const targetKey = filePath.slice(basePath.length);
+    const targetKey = filePath.href.slice(basePath.length);
 
     return Q(async () => {
-      const isVersioned = HasVersionRe.test(basename(filePath));
-      const contentType = mime.contentType(extname(filePath));
+      const isVersioned = HasVersionRe.test(basename(filePath.pathname));
+      const contentType = mime.contentType(extname(filePath.pathname));
 
       const cacheControl = isVersioned
         ? // Set cache control for versioned files to immutable


### PR DESCRIPTION
#### Motivation

The latest fsa using URL instead of string path. We need fix the deploy script as well.

#### Modification

Fix the filePath as URL type.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
