### PR TITLE
feat(cogify): add 1m preset

### DIFF
--- a/packages/cogify/src/preset.ts
+++ b/packages/cogify/src/preset.ts
@@ -47,5 +47,16 @@ const lerc1mm: Preset = {
     overviewResampling: 'bilinear',
   },
 };
+const lerc1m: Preset = {
+  name: 'lerc_1m',
+  options: {
+    blockSize: 512,
+    compression: 'lerc',
+    maxZError: 1,
+    maxZErrorOverview: 4,
+    warpResampling: 'bilinear',
+    overviewResampling: 'bilinear',
+  },
+};
 
-export const Presets = { [webP.name]: webP, [lerc10mm.name]: lerc10mm, [lerc1mm.name]: lerc1mm };
+export const Presets = { [webP.name]: webP, [lerc10mm.name]: lerc10mm, [lerc1mm.name]: lerc1mm, [lerc1m.name]: lerc1m };


### PR DESCRIPTION
#### Motivation

Some of our elevation data is only accurate to around 1m (or more) so storing as 10mm uses a lot of space.

#### Modification

Creates a 1M LERC MaxZError overview configuration

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
