### PR TITLE
fix(cogify): remove tiff caching while creating tile covering

### DIFF
--- a/packages/cogify/src/bin.ts
+++ b/packages/cogify/src/bin.ts
@@ -1,9 +1,14 @@
 Error.stackTraceLimit = 100;
 
 import { LogConfig } from '@basemaps/shared';
+import { fsa } from '@basemaps/shared';
 import { run } from 'cmd-ts';
 
 import { CogifyCli } from './cogify/cli.js';
+
+// remove the source caching / chunking as it is not needed for cogify, cogify only reads tiffs once so caching the result is not helpful
+fsa.middleware = fsa.middleware.filter((f) => f.name !== 'source:chunk');
+fsa.middleware = fsa.middleware.filter((f) => f.name !== 'source:cache');
 
 run(CogifyCli, process.argv.slice(2)).catch((err) => {
   const logger = LogConfig.get();

--- a/packages/config-loader/src/json/json.config.ts
+++ b/packages/config-loader/src/json/json.config.ts
@@ -58,6 +58,7 @@ export function guessIdFromUri(uri: string): string | null {
   }
 }
 
+const IsEmptyCheckSizeBytes = 512 * 1024;
 /**
  * Check to see if this tiff has any data
  *
@@ -68,6 +69,10 @@ export function guessIdFromUri(uri: string): string | null {
  */
 export async function isEmptyTiff(toCheck: URL | Tiff): Promise<boolean> {
   const tiff = toCheck instanceof URL ? await Tiff.create(fsa.source(toCheck)) : toCheck;
+
+  // Only check the tiff for empty if the size is less than IsEmptyCheckSizeBytes
+  const tiffSize = tiff.source.metadata?.size ?? 0;
+  if (tiffSize > IsEmptyCheckSizeBytes) return false;
 
   // Starting the smallest tiff overview greatly reduces the amount of data needing to be read
   // if the tiff contains data.

--- a/packages/shared/src/file.system.ts
+++ b/packages/shared/src/file.system.ts
@@ -57,7 +57,6 @@ export const FsaLog = {
     );
     this.requests.push(requestId);
     const startTime = performance.now();
-
     const res = await next(req);
     LogConfig.get().debug(
       {
@@ -79,9 +78,6 @@ export const FsaLog = {
 };
 fsa.middleware.push(FsaLog);
 
-// FIXME add middleware to cache requests
-
-// FIXME add tests / docs
 /**
  * When chunkd moves to URLs this can be removed
  *


### PR DESCRIPTION
#### Motivation

Reduce the memory usage and number of requests made when loading tiff information from 10,000s of tiffs

#### Modification

removes the tiff caching/chunking logic from cogify and reduces the number of reuqests needed to check if a tiff is empty.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
