### PR TITLE
fix(cogify): Fix the broken log for invalid cog with no assets defined.

### DIFF
--- a/packages/cogify/src/cogify/cli/cli.cog.ts
+++ b/packages/cogify/src/cogify/cli/cli.cog.ts
@@ -97,21 +97,20 @@ export const BasemapsCogifyCreateCommand = command({
 
       const cogAsset = f.item.assets['cog'];
       if (cogAsset == null && invalidReason == null) return true;
-      const asset = cogAsset ? cogAsset['herl'] : 'null';
 
       // Force overwrite existing COGs
       if (args.force) {
-        logger.warn({ item: f.item.id, asset: cogAsset.href }, 'Cog:Create:Overwrite');
+        logger.warn({ item: f.item.id, asset: cogAsset?.href }, 'Cog:Create:Overwrite');
         return true;
       }
 
       // The cog was already created but deemed invalid
       if (invalidReason) {
-        logger.warn({ item: f.item.id, asset, reason: invalidReason }, 'Cog:Create:Exists:invalid');
+        logger.warn({ item: f.item.id, asset: cogAsset?.href, reason: invalidReason }, 'Cog:Create:Exists:invalid');
         return false;
       }
 
-      logger.info({ item: f.item.id, asset }, 'Cog:Create:Exists');
+      logger.info({ item: f.item.id, asset: cogAsset?.href }, 'Cog:Create:Exists');
       return false;
     }) as CogItem[];
 

--- a/packages/cogify/src/cogify/cli/cli.cog.ts
+++ b/packages/cogify/src/cogify/cli/cli.cog.ts
@@ -97,6 +97,7 @@ export const BasemapsCogifyCreateCommand = command({
 
       const cogAsset = f.item.assets['cog'];
       if (cogAsset == null && invalidReason == null) return true;
+      const asset = cogAsset ? cogAsset['herl'] : 'null';
 
       // Force overwrite existing COGs
       if (args.force) {
@@ -106,11 +107,11 @@ export const BasemapsCogifyCreateCommand = command({
 
       // The cog was already created but deemed invalid
       if (invalidReason) {
-        logger.warn({ item: f.item.id, asset: cogAsset.href, reason: invalidReason }, 'Cog:Create:Exists:invalid');
+        logger.warn({ item: f.item.id, asset, reason: invalidReason }, 'Cog:Create:Exists:invalid');
         return false;
       }
 
-      logger.info({ item: f.item.id, asset: cogAsset.href }, 'Cog:Create:Exists');
+      logger.info({ item: f.item.id, asset }, 'Cog:Create:Exists');
       return false;
     }) as CogItem[];
 


### PR DESCRIPTION
#### Motivation

Cog creation got a type error when asset is not defined for invalid cog. 
```
"type":"TypeError","message":"Cannot read properties of undefined (reading 'href')"
```

#### Modification

Log "null" when type is not defined.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
