### PR TITLE
docs: Document the gdal command to re-project gebco into 2193.

### DIFF
--- a/docs/operator-guide/gebco.md
+++ b/docs/operator-guide/gebco.md
@@ -25,6 +25,8 @@ docker run
     --workdir $PWD ghcr.io/osgeo/gdal:ubuntu-small-3.8.3
     gdalwarp
     -of VRT
+    -r bilinear 
+    -ot float32
     -multi
     -s_srs EPSG:4326
     -t_srs EPSG:2193

--- a/docs/operator-guide/gebco.md
+++ b/docs/operator-guide/gebco.md
@@ -30,8 +30,8 @@ docker run
     -multi
     -s_srs EPSG:4326
     -t_srs EPSG:2193
-    geotiff_out/gebco_2023.vrt
-    geotiff_out/wrapped_gebco_2023.vrt
+    geotiff_output/gebco_2023.vrt
+    geotiff_output/wrapped_gebco_2023.vrt
 
 ```
 

--- a/docs/operator-guide/gebco.md
+++ b/docs/operator-guide/gebco.md
@@ -9,11 +9,11 @@ Download the lastest [Gebco gridded bathymetry data](https://www.gebco.net/data_
 Build VRT first with the Gdal command.
 
 ```bash
-docker run
-    --rm -it -v $PWD:$PWD
-    --workdir $PWD ghcr.io/osgeo/gdal:ubuntu-small-3.8.3
-    gdalbuildvrt
-    geotiff_output/gebco_2023.vrt
+docker run \
+    --rm -it -v $PWD:$PWD \
+    --workdir $PWD ghcr.io/osgeo/gdal:ubuntu-small-3.8.3 \
+    gdalbuildvrt \
+    geotiff_output/gebco_2023.vrt \
     gebco_2023_geotiff/*.tif
 ```
 

--- a/docs/operator-guide/gebco.md
+++ b/docs/operator-guide/gebco.md
@@ -9,6 +9,10 @@ Download the lastest [Gebco gridded bathymetry data](https://www.gebco.net/data_
 Build VRT first with the Gdal command.
 
 ```bash
+mkdir geotiff_output -p
+```
+
+```bash
 docker run \
     --rm -it -v $PWD:$PWD \
     --workdir $PWD ghcr.io/osgeo/gdal:ubuntu-small-3.8.3 \
@@ -20,17 +24,17 @@ docker run \
 Wrap VRT and re-project into 2193 projection
 
 ```bash
-docker run
-    --rm -it -v $PWD:$PWD
-    --workdir $PWD ghcr.io/osgeo/gdal:ubuntu-small-3.8.3
-    gdalwarp
-    -of VRT
-    -r bilinear 
-    -ot float32
-    -multi
-    -s_srs EPSG:4326
-    -t_srs EPSG:2193
-    geotiff_output/gebco_2023.vrt
+docker run \
+    --rm -it -v $PWD:$PWD \
+    --workdir $PWD ghcr.io/osgeo/gdal:ubuntu-small-3.8.3 \
+    gdalwarp \
+    -of VRT \
+    -r bilinear \
+    -ot float32 \
+    -multi \
+    -s_srs EPSG:4326 \
+    -t_srs EPSG:2193 \
+    geotiff_output/gebco_2023.vrt \
     geotiff_output/wrapped_gebco_2023.vrt
 
 ```
@@ -38,14 +42,14 @@ docker run
 GDAL translate to process the source file into NZTM2000 (EPSG:2193) COG within the [NZTM2000Quad Extents](https://github.com/linz/NZTM2000TileMatrixSet/blob/master/raw/NZTM2000Quad.json#L7)
 
 ```bash
-docker run
-    --rm -it -v $PWD:$PWD
-    --workdir $PWD ghcr.io/osgeo/gdal:ubuntu-small-3.8.3
-    gdal_translate
-    -of COG
-    -co TARGET_SRS=EPSG:2193
-    -co EXTENT=-3260586.7284,419435.9938,6758167.443,10438190.1652
-    geotiff_output/wrapped_gebco_2023.vrt
+docker run \
+    --rm -it -v $PWD:$PWD \
+    --workdir $PWD ghcr.io/osgeo/gdal:ubuntu-small-3.8.3 \
+    gdal_translate \
+    -of COG \
+    -co TARGET_SRS=EPSG:2193 \
+    -co EXTENT=-3260586.7284,419435.9938,6758167.443,10438190.1652 \
+    geotiff_output/wrapped_gebco_2023.vrt \
     geotiff_output/gebco_2023.tiff
 
 ```

--- a/docs/operator-guide/gebco.md
+++ b/docs/operator-guide/gebco.md
@@ -33,7 +33,7 @@ docker run
 
 ```
 
-Gdal_translate to process the source file into 2193 cog within the [NZTM2000Quad Extents](https://github.com/linz/NZTM2000TileMatrixSet/blob/master/raw/NZTM2000Quad.json#L7)
+GDAL translate to process the source file into NZTM2000 (EPSG:2193) COG within the [NZTM2000Quad Extents](https://github.com/linz/NZTM2000TileMatrixSet/blob/master/raw/NZTM2000Quad.json#L7)
 
 ```bash
 docker run

--- a/docs/operator-guide/gebco.md
+++ b/docs/operator-guide/gebco.md
@@ -1,0 +1,49 @@
+# Gebco re-project to NZTM2000Quad cog file
+
+[GEBCO](https://www.gebco.net/) grid data are based on WGS84 which required to re-project into NZTM2000Quad tilematrix before importing into Basemaps. This instruction include the process of re-project [Gebco data](https://www.gebco.net/data_and_products/gridded_bathymetry_data/) into NZTM2000Quad tiff file by using gdal commands. Then we can process the output by [cogify](https://github.com/linz/basemaps/tree/master/packages/cogify) commands to import into LINZ Basemaps.
+
+## Process
+
+Download the lastest [Gebco gridded bathymetry data](https://www.gebco.net/data_and_products/gridded_bathymetry_data/).
+
+Build VRT first with the Gdal command.
+
+```bash
+docker run
+    --rm -it -v $PWD:$PWD
+    --workdir $PWD ghcr.io/osgeo/gdal:ubuntu-small-3.8.3
+    gdalbuildvrt
+    geotiff_output/gebco_2023.vrt
+    gebco_2023_geotiff/*.tif
+```
+
+Wrap VRT and re-project into 2193 projection
+
+```bash
+docker run
+    --rm -it -v $PWD:$PWD
+    --workdir $PWD ghcr.io/osgeo/gdal:ubuntu-small-3.8.3
+    gdalwarp
+    -of VRT
+    -multi
+    -s_srs EPSG:4326
+    -t_srs EPSG:2193
+    geotiff_out/gebco_2023.vrt
+    geotiff_out/wrapped_gebco_2023.vrt
+
+```
+
+Gdal_translate to process the source file into 2193 cog within the [NZTM2000Quad Extents](https://github.com/linz/NZTM2000TileMatrixSet/blob/master/raw/NZTM2000Quad.json#L7)
+
+```bash
+docker run
+    --rm -it -v $PWD:$PWD
+    --workdir $PWD ghcr.io/osgeo/gdal:ubuntu-small-3.8.3
+    gdal_translate
+    -of COG
+    -co TARGET_SRS=EPSG:2193
+    -co EXTENT=-3260586.7284,419435.9938,6758167.443,10438190.1652
+    geotiff_out/wrapped_gebco_2023.vrt
+    geotiff_out/gebco_2023.tiff
+
+```

--- a/docs/operator-guide/gebco.md
+++ b/docs/operator-guide/gebco.md
@@ -45,7 +45,7 @@ docker run
     -of COG
     -co TARGET_SRS=EPSG:2193
     -co EXTENT=-3260586.7284,419435.9938,6758167.443,10438190.1652
-    geotiff_out/wrapped_gebco_2023.vrt
-    geotiff_out/gebco_2023.tiff
+    geotiff_output/wrapped_gebco_2023.vrt
+    geotiff_output/gebco_2023.tiff
 
 ```


### PR DESCRIPTION
#### Motivation

We need process gebco data into basemaps once a year once gebco get new updates. But there is a bug in cogify (BM-935) when deal with NZTM2000Quad on Wsg84 source within the whole world scale, as the out put extent is not clipped as expected multi-polygons. 

This bug is only happens when the source file is too large that crossing the whole world, and existing the logic is very complex, so if trying to fix it might have a high risk to broke some existing process. As a result, we decide to using gdal to reproject he gebco into 2193 before using cogify importing the data. 

This PR contains the documents of dgal commands that using to re-project gebco data.

#### Modification

Add docs for the gdal commands.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
