### PR TITLE
feat: allow configuration of output tile types base of tileset configuration BM-932

### DIFF
--- a/packages/config/src/config/tile.set.ts
+++ b/packages/config/src/config/tile.set.ts
@@ -70,6 +70,36 @@ export interface ConfigTileSetRaster extends ConfigTileSetBase {
 
   /** When scaling tiles in the rendering process what kernel to use */
   resizeKernel?: { in: TileResizeKernel; out: TileResizeKernel };
+
+  /**
+   * Configure how the tile set is rendered,
+   * if this is not defined a default RGBA output will be generated
+   */
+  outputs?: ConfigTileSetRasterOutput[];
+}
+
+export interface ConfigTileSetRasterOutput {
+  /** Human friendly description of the output */
+  title: string;
+  /**
+   * URL extensions to separate this output from others, Must be unique per tile set.
+   *
+   * @example "terrain-rgb.webp"
+   */
+  extension: string;
+
+  /** Raster output format */
+  output: {
+    /** Output file format to use */
+    type: ImageFormat;
+    /** should the output be lossless */
+    lossless: boolean;
+    /**
+     *  Background to render for areas where there is no data, falls back to
+     *  {@link ConfigTileSetRaster.background} if not defined
+     */
+    background?: { r: number; g: number; b: number; alpha: number };
+  };
 }
 
 export interface ConfigTileSetVector extends ConfigTileSetBase {

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -17,6 +17,7 @@ export {
   ConfigLayer,
   ConfigTileSet,
   ConfigTileSetRaster,
+  ConfigTileSetRasterOutput,
   ConfigTileSetVector,
   TileResizeKernel,
   TileSetType,

--- a/packages/lambda-tiler/src/index.ts
+++ b/packages/lambda-tiler/src/index.ts
@@ -73,7 +73,7 @@ handler.router.get('/v1/tiles/:tileSet/:tileMatrix/style/:styleName.json', style
 handler.router.get('/v1/tiles/:tileSet/:tileMatrix/tile.json', tileJsonGet);
 
 // Tiles
-handler.router.get('/v1/tiles/:tileSet/:tileMatrix/:z/:x/:y.:tileType', tileXyzGet);
+handler.router.get('/v1/tiles/:tileSet/:tileMatrix/:z(^\\d+)/:x(^\\d+)/:y(^\\d+):tileType', tileXyzGet);
 
 // Preview
 handler.router.get('/v1/preview/:tileSet/:tileMatrix/:z/:lon/:lat', tilePreviewGet);

--- a/packages/lambda-tiler/src/routes/__tests__/xyz.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/xyz.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import { ConfigProviderMemory } from '@basemaps/config';
+import { ImageFormat } from '@basemaps/geo';
 import { LogConfig } from '@basemaps/shared';
 import { round } from '@basemaps/test/build/rounding.js';
 
@@ -135,7 +136,7 @@ describe('/v1/tiles', () => {
     const elevation = FakeData.tileSetRaster('elevation');
 
     elevation.outputs = [
-      { title: 'Terrain RGB', extension: 'terrain-rgb.webp', output: { type: 'webp', lossless: true } },
+      { title: 'Terrain RGB', extension: 'terrain-rgb.webp', output: { type: ImageFormat.Webp, lossless: true } },
     ];
     config.put(elevation);
 

--- a/packages/lambda-tiler/src/util/__test__/validate.test.ts
+++ b/packages/lambda-tiler/src/util/__test__/validate.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { GoogleTms, ImageFormat, Nztm2000QuadTms, Nztm2000Tms, VectorFormat } from '@basemaps/geo';
+import { GoogleTms, ImageFormat, Nztm2000QuadTms, Nztm2000Tms } from '@basemaps/geo';
 
 import { mockUrlRequest } from '../../__tests__/xyz.util.js';
 import { Validate } from '../validate.js';
@@ -56,22 +56,4 @@ describe('getTileMatrixSet', () => {
   it('should be case sensitive', () => {
     assert.equal(Validate.getTileMatrixSet('Nztm2000Quad')?.identifier, undefined);
   });
-});
-
-describe('getTileFormat', () => {
-  for (const ext of Object.values(ImageFormat)) {
-    it('should support image format:' + ext, () => {
-      assert.equal(Validate.getTileFormat(ext), ext);
-    });
-  }
-
-  it('should support vector format: mvt', () => {
-    assert.equal(Validate.getTileFormat('pbf'), VectorFormat.MapboxVectorTiles);
-  });
-
-  for (const fmt of ['FAKE', /* 'JPEG' // TODO should this be case sensitive ,*/ 'mvt', 'json']) {
-    it('should not support format:' + fmt, () => {
-      assert.equal(Validate.getTileFormat(fmt), null);
-    });
-  }
 });

--- a/packages/lambda-tiler/src/util/validate.ts
+++ b/packages/lambda-tiler/src/util/validate.ts
@@ -90,7 +90,7 @@ export const Validate = {
 
     if (req.params.tileType == null) throw new LambdaHttpResponse(404, 'Tile extension not found');
 
-    // trim ".webp" to "webp" and "-terrain-rgb.webp" to "terrain-rgb"
+    // trim ".webp" to "webp" and "-terrain-rgb.webp" to "terrain-rgb.webp"
     // so that it is easier to match latter
     if (req.params.tileType.startsWith('.') || req.params.tileType.startsWith('-')) {
       req.params.tileType = req.params.tileType.slice(1);

--- a/packages/lambda-tiler/src/util/validate.ts
+++ b/packages/lambda-tiler/src/util/validate.ts
@@ -1,4 +1,4 @@
-import { ImageFormat, LatLon, Projection, TileMatrixSet, TileMatrixSets, VectorFormat } from '@basemaps/geo';
+import { ImageFormat, LatLon, Projection, TileMatrixSet, TileMatrixSets } from '@basemaps/geo';
 import { Const, isValidApiKey, truncateApiKey } from '@basemaps/shared';
 import { getImageFormat } from '@basemaps/tiler';
 import { LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambda';

--- a/packages/lambda-tiler/src/util/validate.ts
+++ b/packages/lambda-tiler/src/util/validate.ts
@@ -6,10 +6,14 @@ import { LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambda';
 import { TileXyzGet } from '../routes/tile.xyz.js';
 
 export interface TileXyz {
+  /** Tile XYZ location */
   tile: { x: number; y: number; z: number };
+  /** Name of the tile set to use */
   tileSet: string;
+  /** TileMatrix that is requested */
   tileMatrix: TileMatrixSet;
-  tileType: VectorFormat | ImageFormat;
+  /** Output tile format */
+  tileType: string;
 }
 
 export interface TileMatrixRequest {
@@ -19,6 +23,7 @@ export interface TileMatrixRequest {
 export const Validate = {
   /**
    * Validate that the api key exists and is valid
+   *
    * @throws if api key is not valid
    */
   apiKey(req: LambdaHttpRequest): string {
@@ -48,13 +53,6 @@ export const Validate = {
     }
     if (output.size === 0) return null;
     return [...output.values()];
-  },
-
-  getTileFormat(tileType: string): ImageFormat | VectorFormat | null {
-    const ext = getImageFormat(tileType);
-    if (ext) return ext;
-    if (tileType === VectorFormat.MapboxVectorTiles) return VectorFormat.MapboxVectorTiles;
-    return null;
   },
 
   /** Validate that a lat and lon are between -90/90 and -180/180 */
@@ -90,9 +88,14 @@ export const Validate = {
     req.set('tileMatrix', tileMatrix.identifier);
     req.set('projection', tileMatrix.projection.code);
 
-    const tileType = Validate.getTileFormat(req.params.tileType);
-    if (tileType == null) throw new LambdaHttpResponse(404, 'Tile extension not found');
-    req.set('extension', tileType);
+    if (req.params.tileType == null) throw new LambdaHttpResponse(404, 'Tile extension not found');
+
+    // trim ".webp" to "webp" and "-terrain-rgb.webp" to "terrain-rgb"
+    // so that it is easier to match latter
+    if (req.params.tileType.startsWith('.') || req.params.tileType.startsWith('-')) {
+      req.params.tileType = req.params.tileType.slice(1);
+    }
+    req.set('extension', req.params.tileType);
 
     if (isNaN(z) || z > tileMatrix.maxZoom || z < 0) throw new LambdaHttpResponse(404, `Zoom not found: ${z}`);
 
@@ -100,7 +103,7 @@ export const Validate = {
     if (isNaN(x) || x < 0 || x > zoom.matrixWidth) throw new LambdaHttpResponse(404, `X not found: ${x}`);
     if (isNaN(y) || y < 0 || y > zoom.matrixHeight) throw new LambdaHttpResponse(404, `Y not found: ${y}`);
 
-    const xyzData = { tile: { x, y, z }, tileSet: req.params.tileSet, tileMatrix, tileType };
+    const xyzData = { tile: { x, y, z }, tileSet: req.params.tileSet, tileMatrix, tileType: req.params.tileType };
     req.set('xyz', xyzData.tile);
 
     const latLon = Projection.tileCenterToLatLon(tileMatrix, xyzData.tile);


### PR DESCRIPTION
#### Motivation

when rendering more complex raster data types there needs to be a configuration on how to convert the source raster images into a RGBA output to be consumed. This is needed so that DEM and DSM can be configured into TerrainRGB and other formats such as color ramps.

#### Modification

Allows configuration of how output tiles are created on a per tileset basis

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
