### PR TITLE
fix!: remove ImageFormat and VectorFormat due to linting errors

### DIFF
--- a/packages/config-loader/src/json/json.config.ts
+++ b/packages/config-loader/src/json/json.config.ts
@@ -117,7 +117,7 @@ export class ConfigJson {
 
     const todo = files.map(async (filePath) => {
       if (!filePath.pathname.endsWith('.json')) return;
-      const bc: BaseConfig = (await fsa.readJson(filePath)) as BaseConfig;
+      const bc: BaseConfig = await fsa.readJson(filePath);
       const prefix = ConfigId.getPrefix(bc.id);
       if (prefix) {
         log.debug({ path: filePath, type: prefix, config: bc.id }, 'Config:Load');
@@ -247,7 +247,7 @@ export class ConfigJson {
     if (ts.format) {
       tileSet.format = ts.format as ImageFormat | VectorFormat;
     } else {
-      tileSet.format = ts.type === TileSetType.Vector ? VectorFormat.MapboxVectorTiles : ImageFormat.Webp;
+      tileSet.format = ts.type === TileSetType.Vector ? 'pbf' : 'webp';
     }
 
     return tileSet as ConfigTileSet;

--- a/packages/config-loader/src/json/json.config.ts
+++ b/packages/config-loader/src/json/json.config.ts
@@ -117,7 +117,7 @@ export class ConfigJson {
 
     const todo = files.map(async (filePath) => {
       if (!filePath.pathname.endsWith('.json')) return;
-      const bc: BaseConfig = await fsa.readJson(filePath);
+      const bc: BaseConfig = await fsa.readJson<BaseConfig>(filePath);
       const prefix = ConfigId.getPrefix(bc.id);
       if (prefix) {
         log.debug({ path: filePath, type: prefix, config: bc.id }, 'Config:Load');

--- a/packages/config-loader/src/json/parse.tile.set.ts
+++ b/packages/config-loader/src/json/parse.tile.set.ts
@@ -1,5 +1,4 @@
 import { parseRgba, TileSetType } from '@basemaps/config';
-import { ImageFormat, VectorFormat } from '@basemaps/geo';
 import { z } from 'zod';
 
 export function validateColor(str: string): boolean {
@@ -51,7 +50,7 @@ export const zTileSetConfig = z.object({
   layers: z.array(zLayerConfig),
   minZoom: zZoom.optional(),
   maxZoom: zZoom.optional(),
-  format: z.union([z.nativeEnum(ImageFormat), z.nativeEnum(VectorFormat)]).optional(),
+  format: z.string().optional(),
 });
 
 export type TileSetConfigSchemaLayer = z.infer<typeof zLayerConfig>;

--- a/packages/config-loader/src/json/tiff.config.ts
+++ b/packages/config-loader/src/json/tiff.config.ts
@@ -1,13 +1,5 @@
 import { ConfigImagery, ConfigProviderMemory, ConfigTileSetRaster, sha256base58, TileSetType } from '@basemaps/config';
-import {
-  BoundingBox,
-  Bounds,
-  EpsgCode,
-  ImageFormat,
-  NamedBounds,
-  Nztm2000QuadTms,
-  TileMatrixSets,
-} from '@basemaps/geo';
+import { BoundingBox, Bounds, EpsgCode, NamedBounds, Nztm2000QuadTms, TileMatrixSets } from '@basemaps/geo';
 import { fsa, Tiff } from '@basemaps/shared';
 import pLimit, { LimitFunction } from 'p-limit';
 import { basename } from 'path';
@@ -331,7 +323,7 @@ export async function initConfigFromUrls(
     title: 'Basemaps',
     category: 'Basemaps',
     type: TileSetType.Raster,
-    format: ImageFormat.Webp,
+    format: 'webp',
     layers: [],
   };
 

--- a/packages/config/src/memory/memory.config.ts
+++ b/packages/config/src/memory/memory.config.ts
@@ -1,4 +1,4 @@
-import { EpsgCode, ImageFormat } from '@basemaps/geo';
+import { EpsgCode } from '@basemaps/geo';
 import { decodeTime, ulid } from 'ulid';
 
 import { BasemapsConfigObject, BasemapsConfigProvider, ConfigId } from '../base.config.js';
@@ -154,7 +154,7 @@ export class ConfigProviderMemory extends BasemapsConfigProvider {
       name: 'all',
       title: 'All Imagery',
       category: 'Basemaps',
-      format: ImageFormat.Webp,
+      format: 'webp',
       layers: Array.from(layerByName.values()).sort((a, b) => a.name.localeCompare(b.name)),
     };
     this.put(allTileset);
@@ -172,7 +172,7 @@ export class ConfigProviderMemory extends BasemapsConfigProvider {
         title: i.title,
         category: i.category,
         name: targetName,
-        format: ImageFormat.Webp,
+        format: 'webp',
         layers: [{ name: targetName, title: i.title, minZoom: 0, maxZoom: 32 }],
         background: { r: 0, g: 0, b: 0, alpha: 0 },
         updatedAt: Date.now(),
@@ -202,7 +202,7 @@ export class ConfigProviderMemory extends BasemapsConfigProvider {
       id: ConfigId.prefix(ConfigPrefix.TileSet, ConfigId.unprefix(ConfigPrefix.Imagery, i.id)),
       name: i.name,
       title: i.title,
-      format: ImageFormat.Webp,
+      format: 'webp',
       layers: [{ [i.projection]: i.id, name: i.name, minZoom: 0, maxZoom: 32, title: i.title }],
       background: { r: 0, g: 0, b: 0, alpha: 0 },
       updatedAt: Date.now(),

--- a/packages/geo/src/formats.ts
+++ b/packages/geo/src/formats.ts
@@ -1,12 +1,5 @@
 /** Image formats supported by basemaps */
-export enum ImageFormat {
-  Png = 'png',
-  Jpeg = 'jpeg',
-  Webp = 'webp',
-  Avif = 'avif',
-}
+export type ImageFormat = 'webp' | 'png' | 'jpeg' | 'avif';
 
 /** Vector tile formats supported by basemaps */
-export enum VectorFormat {
-  MapboxVectorTiles = 'pbf',
-}
+export type VectorFormat = 'pbf';

--- a/packages/lambda-tiler/src/__tests__/config.data.ts
+++ b/packages/lambda-tiler/src/__tests__/config.data.ts
@@ -8,14 +8,13 @@ import {
   ConfigTileSetVector,
   TileSetType,
 } from '@basemaps/config';
-import { ImageFormat, VectorFormat } from '@basemaps/geo';
 import { fsa, FsMemory } from '@basemaps/shared';
 
 export const TileSetAerial: ConfigTileSetRaster = {
   id: 'ts_aerial',
   name: 'aerial',
   type: TileSetType.Raster,
-  format: ImageFormat.Webp,
+  format: 'webp',
   description: 'aerial__description',
   title: 'Aerial Imagery',
   category: 'Basemap',
@@ -36,7 +35,7 @@ export const TileSetVector: ConfigTileSetVector = {
   description: 'topotgrpahic__description',
   title: 'topotgrpahic Imagery',
   category: 'Basemap',
-  format: VectorFormat.MapboxVectorTiles,
+  format: 'pbf',
   layers: [
     {
       3857: 's3://linz-basemaps/01G7WQMGHB7V946M0YWJJBZ6DW/topopgraphic.tar.co',

--- a/packages/lambda-tiler/src/__tests__/wmts.capability.test.ts
+++ b/packages/lambda-tiler/src/__tests__/wmts.capability.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
 import { ConfigImagery } from '@basemaps/config';
-import { GoogleTms, ImageFormat, Nztm2000QuadTms } from '@basemaps/geo';
+import { GoogleTms, Nztm2000QuadTms } from '@basemaps/geo';
 import { V, VNodeElement } from '@basemaps/shared';
 import { roundNumbersInString } from '@basemaps/test/build/rounding.js';
 
@@ -32,7 +32,7 @@ describe('WmtsCapabilities', () => {
 
     wmts.addTileMatrix(GoogleTms);
     for (const im of allImagery.values()) wmts.addImagery(im);
-    wmts.addFormats(ImageFormat.Avif);
+    wmts.addFormats('avif');
     wmts.addProvider(Provider);
     wmts.addTileSet(TileSetAerial);
     const wmtsCapability = wmts.toVNode();
@@ -55,7 +55,7 @@ describe('WmtsCapabilities', () => {
 
     wmts.addTileMatrix(GoogleTms);
     for (const im of allImagery.values()) wmts.addImagery(im);
-    wmts.addFormats(ImageFormat.Avif);
+    wmts.addFormats('avif');
     wmts.addProvider(Provider);
     wmts.addTileSet(TileSetAerial);
     const wmtsCapability = wmts.toVNode();
@@ -80,7 +80,7 @@ describe('WmtsCapabilities', () => {
       tileMatrix: [GoogleTms],
       tileSet: TileSetAerial,
       imagery: allImagery,
-      formats: [ImageFormat.Avif],
+      formats: ['avif'],
     });
     const xml = wmts.toXml();
 
@@ -100,7 +100,7 @@ describe('WmtsCapabilities', () => {
 
     wmts.addTileMatrix(GoogleTms);
     for (const im of allImagery.values()) wmts.addImagery(im);
-    wmts.addFormats(ImageFormat.Avif);
+    wmts.addFormats('avif');
     wmts.addProvider(Provider);
     wmts.addTileSet(tileSet);
     const wmtsCapability = wmts.toVNode();
@@ -292,7 +292,7 @@ describe('WmtsCapabilities', () => {
       tileSet: TileSetAerial,
       imagery,
       layers: TileSetAerial.layers,
-      formats: [ImageFormat.Png],
+      formats: ['png'],
     });
 
     const raw = wmts.toVNode();
@@ -338,7 +338,7 @@ describe('WmtsCapabilities', () => {
       tileMatrix: [GoogleTms, Nztm2000QuadTms],
       tileSet: TileSetAerial,
       imagery: imagery,
-      formats: [ImageFormat.Png],
+      formats: ['png'],
     });
 
     const raw = wmts.toVNode();
@@ -404,7 +404,7 @@ describe('WmtsCapabilities', () => {
       tileMatrix: [Nztm2000QuadTms],
       tileSet: TileSetAerial,
       imagery: imagery,
-      formats: [ImageFormat.Png],
+      formats: ['png'],
       layers: TileSetAerial.layers,
     });
 
@@ -422,7 +422,7 @@ describe('WmtsCapabilities', () => {
       tileMatrix: [Nztm2000QuadTms],
       tileSet: TileSetAerial,
       imagery: imagery,
-      formats: [ImageFormat.Png],
+      formats: ['png'],
       layers: TileSetAerial.layers,
     });
 
@@ -458,7 +458,7 @@ describe('WmtsCapabilities', () => {
       tileMatrix: [GoogleTms],
       tileSet,
       imagery,
-      formats: [ImageFormat.Png],
+      formats: ['png'],
       layers: tileSet.layers,
     });
 
@@ -501,7 +501,7 @@ describe('WmtsCapabilities', () => {
       tileMatrix: [GoogleTms],
       tileSet,
       imagery,
-      formats: [ImageFormat.Png],
+      formats: ['png'],
       layers: tileSet.layers,
     });
 

--- a/packages/lambda-tiler/src/cli/render.preview.ts
+++ b/packages/lambda-tiler/src/cli/render.preview.ts
@@ -1,6 +1,6 @@
 import { ConfigProviderMemory } from '@basemaps/config';
 import { initConfigFromUrls } from '@basemaps/config-loader';
-import { ImageFormat, TileMatrixSet, TileMatrixSets } from '@basemaps/geo';
+import { TileMatrixSet, TileMatrixSets } from '@basemaps/geo';
 import { fsa, LogConfig, setDefaultConfig } from '@basemaps/shared';
 import { LambdaHttpRequest, LambdaUrlRequest, UrlEvent } from '@linzjs/lambda';
 import { Context } from 'aws-lambda';
@@ -11,7 +11,7 @@ const target = fsa.toUrl(`/home/blacha/tmp/basemaps/bm-724/test-north-island_202
 const location = { lat: -39.0852555, lon: 177.3998405 };
 const z = 12;
 
-const outputFormat = ImageFormat.Webp;
+const outputFormat = 'webp';
 let tileMatrix: TileMatrixSet | null = null;
 
 async function main(): Promise<void> {

--- a/packages/lambda-tiler/src/cli/render.tile.ts
+++ b/packages/lambda-tiler/src/cli/render.tile.ts
@@ -1,6 +1,6 @@
 import { ConfigProviderMemory } from '@basemaps/config';
 import { initConfigFromUrls } from '@basemaps/config-loader';
-import { ImageFormat, Tile, TileMatrixSet, TileMatrixSets } from '@basemaps/geo';
+import { Tile, TileMatrixSet, TileMatrixSets } from '@basemaps/geo';
 import { fsa, LogConfig, setDefaultConfig } from '@basemaps/shared';
 import { LambdaHttpRequest, LambdaUrlRequest, UrlEvent } from '@linzjs/lambda';
 import { Context } from 'aws-lambda';
@@ -10,7 +10,7 @@ import { TileXyzRaster } from '../routes/tile.xyz.raster.js';
 const target = fsa.toUrl(`/home/blacha/tmp/imagery/southland-0.25-rural-2023/`);
 const tile = fromPath('/18/117833/146174.webp');
 
-const outputFormat = ImageFormat.Webp;
+const outputFormat = 'webp';
 let tileMatrix: TileMatrixSet | null = null;
 
 /** Convert a tile path /:z/:x/:y.png into a tile */

--- a/packages/lambda-tiler/src/routes/__tests__/xyz.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/xyz.test.ts
@@ -2,7 +2,6 @@ import assert from 'node:assert';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import { ConfigProviderMemory } from '@basemaps/config';
-import { ImageFormat } from '@basemaps/geo';
 import { LogConfig } from '@basemaps/shared';
 import { round } from '@basemaps/test/build/rounding.js';
 
@@ -136,7 +135,7 @@ describe('/v1/tiles', () => {
     const elevation = FakeData.tileSetRaster('elevation');
 
     elevation.outputs = [
-      { title: 'Terrain RGB', extension: 'terrain-rgb.webp', output: { type: ImageFormat.Webp, lossless: true } },
+      { title: 'Terrain RGB', extension: 'terrain-rgb.webp', output: { type: 'webp', lossless: true } },
     ];
     config.put(elevation);
 

--- a/packages/lambda-tiler/src/routes/health.ts
+++ b/packages/lambda-tiler/src/routes/health.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 
 import { ConfigTileSetRaster } from '@basemaps/config';
-import { GoogleTms, ImageFormat, Nztm2000QuadTms } from '@basemaps/geo';
+import { GoogleTms, Nztm2000QuadTms } from '@basemaps/geo';
 import { HttpHeader, LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambda';
 import PixelMatch from 'pixelmatch';
 import Sharp from 'sharp';
@@ -15,8 +15,8 @@ interface TestTile extends TileXyz {
 }
 
 export const TestTiles: TestTile[] = [
-  { tileSet: 'health', tileMatrix: GoogleTms, tileType: ImageFormat.Png, tile: { x: 252, y: 156, z: 8 } },
-  { tileSet: 'health', tileMatrix: Nztm2000QuadTms, tileType: ImageFormat.Png, tile: { x: 30, y: 33, z: 6 } },
+  { tileSet: 'health', tileMatrix: GoogleTms, tileType: 'png', tile: { x: 252, y: 156, z: 8 } },
+  { tileSet: 'health', tileMatrix: Nztm2000QuadTms, tileType: 'png', tile: { x: 30, y: 33, z: 6 } },
 ];
 const TileSize = 256;
 

--- a/packages/lambda-tiler/src/routes/preview.ts
+++ b/packages/lambda-tiler/src/routes/preview.ts
@@ -24,7 +24,7 @@ export interface PreviewGet {
 const PreviewSize = { width: 1200, height: 630 };
 const TilerSharp = new TileMakerSharp(PreviewSize.width, PreviewSize.height);
 
-const OutputFormat = ImageFormat.Webp;
+const OutputFormat = 'webp';
 /** Slightly grey color for the checker background */
 const PreviewBackgroundFillColor = 0xef;
 /** Make th e checkered background 30x30px */

--- a/packages/lambda-tiler/src/routes/tile.style.json.ts
+++ b/packages/lambda-tiler/src/routes/tile.style.json.ts
@@ -1,5 +1,5 @@
 import { ConfigTileSetRaster, Layer, Sources, StyleJson, TileSetType } from '@basemaps/config';
-import { GoogleTms, ImageFormat, TileMatrixSets } from '@basemaps/geo';
+import { GoogleTms, TileMatrixSets } from '@basemaps/geo';
 import { Env, toQueryString } from '@basemaps/shared';
 import { HttpHeader, LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambda';
 import { URL } from 'url';
@@ -70,7 +70,7 @@ export async function tileSetToStyle(
 ): Promise<LambdaHttpResponse> {
   const tileMatrix = TileMatrixSets.find(req.query.get('tileMatrix') ?? GoogleTms.identifier);
   if (tileMatrix == null) return new LambdaHttpResponse(400, 'Invalid tile matrix');
-  const [tileFormat] = Validate.getRequestedFormats(req) ?? [ImageFormat.Webp];
+  const [tileFormat] = Validate.getRequestedFormats(req) ?? ['webp'];
   if (tileFormat == null) return new LambdaHttpResponse(400, 'Invalid image format');
 
   const configLocation = ConfigLoader.extract(req);

--- a/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
+++ b/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
@@ -1,5 +1,5 @@
 import { ConfigTileSetRaster, ConfigTileSetRasterOutput, getAllImagery } from '@basemaps/config';
-import { Bounds, Epsg, ImageFormat, TileMatrixSet, TileMatrixSets, VectorFormat } from '@basemaps/geo';
+import { Bounds, Epsg, TileMatrixSet, TileMatrixSets } from '@basemaps/geo';
 import { Cotar, Env, stringToUrlFolder, Tiff } from '@basemaps/shared';
 import { getImageFormat, Tiler } from '@basemaps/tiler';
 import { TileMakerSharp } from '@basemaps/tiler-sharp';
@@ -119,8 +119,6 @@ export const TileXyzRaster = {
   },
 
   async tile(req: LambdaHttpRequest, tileSet: ConfigTileSetRaster, xyz: TileXyz): Promise<LambdaHttpResponse> {
-    if (xyz.tileType === VectorFormat.MapboxVectorTiles) return NotFound();
-
     const tileOutput = getTileSetOutput(tileSet, xyz.tileType);
     if (tileOutput == null) return NotFound();
 
@@ -172,7 +170,7 @@ function getTileSetOutput(tileSet: ConfigTileSetRaster, tileType: string): Confi
     extension: tileType,
     output: {
       type: img,
-      lossless: img === ImageFormat.Png ? true : false,
+      lossless: img === 'png' ? true : false,
       background: tileSet.background,
     },
   } as ConfigTileSetRasterOutput;

--- a/packages/lambda-tiler/src/routes/tile.xyz.vector.ts
+++ b/packages/lambda-tiler/src/routes/tile.xyz.vector.ts
@@ -1,5 +1,5 @@
 import { ConfigTileSetVector } from '@basemaps/config';
-import { GoogleTms, VectorFormat } from '@basemaps/geo';
+import { GoogleTms } from '@basemaps/geo';
 import { fsa } from '@basemaps/shared';
 import { HttpHeader, LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambda';
 
@@ -12,7 +12,7 @@ import { TileXyz } from '../util/validate.js';
 export const tileXyzVector = {
   /** Serve a MVT vector tile */
   async tile(req: LambdaHttpRequest, tileSet: ConfigTileSetVector, xyz: TileXyz): Promise<LambdaHttpResponse> {
-    if (xyz.tileType !== VectorFormat.MapboxVectorTiles) return NotFound();
+    if (xyz.tileType !== 'pbf') return NotFound();
     if (xyz.tileMatrix.identifier !== GoogleTms.identifier) return NotFound();
 
     if (tileSet.layers.length > 1) return new LambdaHttpResponse(500, 'Too many layers in tileset');

--- a/packages/lambda-tiler/src/util/__test__/validate.test.ts
+++ b/packages/lambda-tiler/src/util/__test__/validate.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { GoogleTms, ImageFormat, Nztm2000QuadTms, Nztm2000Tms } from '@basemaps/geo';
+import { GoogleTms, Nztm2000QuadTms, Nztm2000Tms } from '@basemaps/geo';
 
 import { mockUrlRequest } from '../../__tests__/xyz.util.js';
 import { Validate } from '../validate.js';
@@ -10,7 +10,7 @@ describe('GetImageFormats', () => {
   it('should parse all formats', () => {
     const req = mockUrlRequest('/v1/blank', 'format=png&format=jpeg');
     const formats = Validate.getRequestedFormats(req);
-    assert.deepEqual(formats, [ImageFormat.Png, ImageFormat.Jpeg]);
+    assert.deepEqual(formats, ['png', 'jpeg']);
   });
 
   it('should ignore bad formats', () => {
@@ -22,19 +22,19 @@ describe('GetImageFormats', () => {
   it('should de-dupe formats', () => {
     const req = mockUrlRequest('/v1/blank', 'format=png&format=jpeg&format=png&format=jpeg&format=png&format=jpeg');
     const formats = Validate.getRequestedFormats(req);
-    assert.deepEqual(formats, [ImageFormat.Png, ImageFormat.Jpeg]);
+    assert.deepEqual(formats, ['png', 'jpeg']);
   });
 
   it('should support "tileFormat" Alias all formats', () => {
     const req = mockUrlRequest('/v1/blank', 'tileFormat=png&format=jpeg');
     const formats = Validate.getRequestedFormats(req);
-    assert.deepEqual(formats, [ImageFormat.Jpeg, ImageFormat.Png]);
+    assert.deepEqual(formats, ['jpeg', 'png']);
   });
 
   it('should not duplicate "tileFormat" alias all formats', () => {
     const req = mockUrlRequest('/v1/blank', 'tileFormat=jpeg&format=jpeg');
     const formats = Validate.getRequestedFormats(req);
-    assert.deepEqual(formats, [ImageFormat.Jpeg]);
+    assert.deepEqual(formats, ['jpeg']);
   });
 });
 

--- a/packages/landing/src/url.ts
+++ b/packages/landing/src/url.ts
@@ -1,5 +1,5 @@
 import { base58, isBase58 } from '@basemaps/config/build/base58.js';
-import { GoogleTms, ImageFormat, TileMatrixSet } from '@basemaps/geo';
+import { GoogleTms, TileMatrixSet } from '@basemaps/geo';
 import { toQueryString } from '@basemaps/shared/build/url.js';
 
 import { Config } from './config.js';
@@ -71,7 +71,7 @@ export const WindowUrl = {
     if (params.urlType === MapOptionType.Style) {
       if (params.tileMatrix.identifier !== GoogleTms.identifier)
         queryParams.set('tileMatrix', params.tileMatrix.identifier);
-      if (WindowUrl.ImageFormat !== ImageFormat.Webp) queryParams.set('format', WindowUrl.ImageFormat);
+      if (WindowUrl.ImageFormat !== 'webp') queryParams.set('format', WindowUrl.ImageFormat);
     }
 
     const q = '?' + queryParams.toString();

--- a/packages/tiler-sharp/src/__tests__/tile.benchmark.ts
+++ b/packages/tiler-sharp/src/__tests__/tile.benchmark.ts
@@ -1,4 +1,4 @@
-import { GoogleTms, ImageFormat } from '@basemaps/geo';
+import { GoogleTms } from '@basemaps/geo';
 import { fsa, Tiff } from '@basemaps/shared';
 import { TestTiff } from '@basemaps/test';
 import { Tiler } from '@basemaps/tiler';
@@ -29,7 +29,7 @@ async function main(): Promise<void> {
     const layers = await tiler.tile([tiff], CenterTile, CenterTile, Zoom);
 
     if (layers == null) throw new Error('Tile is null');
-    await tileMaker.compose({ layers, format: ImageFormat.Png, background, resizeKernel });
+    await tileMaker.compose({ layers, format: 'png', background, resizeKernel });
     await tiff.source.close?.();
   }
 }

--- a/packages/tiler-sharp/src/__tests__/tile.creation.test.ts
+++ b/packages/tiler-sharp/src/__tests__/tile.creation.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { Epsg, GoogleTms, ImageFormat, Nztm2000Tms, QuadKey, Tile } from '@basemaps/geo';
+import { Epsg, GoogleTms, Nztm2000Tms, QuadKey, Tile } from '@basemaps/geo';
 import { fsa, Tiff } from '@basemaps/shared';
 import { TestTiff } from '@basemaps/test';
 import { CompositionTiff, Tiler } from '@basemaps/tiler';
@@ -56,7 +56,7 @@ describe('TileCreation', () => {
 
   it('should generate webp', async () => {
     const tileMaker = new TileMakerSharp(256);
-    const res = await tileMaker.compose({ layers: [], format: ImageFormat.Webp, background, resizeKernel });
+    const res = await tileMaker.compose({ layers: [], format: 'webp', background, resizeKernel });
     // Image format `R I F F <fileSize (int32)> W E B P`
     const magicBytes = res.buffer.slice(0, 4);
     const magicWebP = res.buffer.slice(8, 12);
@@ -66,7 +66,7 @@ describe('TileCreation', () => {
 
   it('should generate jpeg', async () => {
     const tileMaker = new TileMakerSharp(256);
-    const res = await tileMaker.compose({ layers: [], format: ImageFormat.Jpeg, background, resizeKernel });
+    const res = await tileMaker.compose({ layers: [], format: 'jpeg', background, resizeKernel });
     const magicBytes = res.buffer.slice(0, 4);
     assert.deepEqual(magicBytes.toJSON().data, [0xff, 0xd8, 0xff, 0xdb]);
   });
@@ -129,7 +129,7 @@ describe('TileCreation', () => {
 
       const png = await tileMaker.compose({
         layers,
-        format: ImageFormat.Png,
+        format: 'png',
         background,
         resizeKernel,
       });

--- a/packages/tiler-sharp/src/index.ts
+++ b/packages/tiler-sharp/src/index.ts
@@ -62,13 +62,13 @@ export class TileMakerSharp implements TileMaker {
    */
   toImage(format: ImageFormat, pipeline: Sharp.Sharp): Promise<Buffer> {
     switch (format) {
-      case ImageFormat.Jpeg:
+      case 'jpeg':
         return pipeline.jpeg().toBuffer();
-      case ImageFormat.Png:
+      case 'png':
         return pipeline.png().toBuffer();
-      case ImageFormat.Webp:
+      case 'webp':
         return pipeline.webp().toBuffer();
-      case ImageFormat.Avif:
+      case 'avif':
         return pipeline.avif().toBuffer();
       default:
         throw new Error(`Invalid image format "${format}"`);
@@ -86,7 +86,7 @@ export class TileMakerSharp implements TileMaker {
     const firstLayer = ctx.layers[0];
     if (firstLayer.type !== 'cotar') return false;
     if (this.width !== 256 || this.height !== 256) return false; // TODO this should not be hard coded
-    if (ctx.format !== ImageFormat.Webp) return false; // TODO this should not be hard coded
+    if (ctx.format !== 'webp') return false; // TODO this should not be hard coded
     if (ctx.background.alpha !== 0) return false;
     return true;
   }

--- a/packages/tiler/src/raster.ts
+++ b/packages/tiler/src/raster.ts
@@ -53,15 +53,15 @@ export interface CompositionCotar {
   path: string;
 }
 
-export const ImageFormatOrder = [ImageFormat.Jpeg, ImageFormat.Webp, ImageFormat.Png];
+export const ImageFormatOrder: ImageFormat[] = ['jpeg', 'webp', 'png'];
 
 /** Guess the image format based on the file extension */
 export function getImageFormat(ext?: string): ImageFormat | null {
   if (ext == null) return null;
   const search = ext.toLowerCase();
-  if (search === ImageFormat.Png) return ImageFormat.Png;
-  if (search === ImageFormat.Webp) return ImageFormat.Webp;
-  if (search === ImageFormat.Jpeg || search === 'jpg') return ImageFormat.Jpeg;
-  if (search === ImageFormat.Avif) return ImageFormat.Avif;
+  if (search === 'png') return 'png';
+  if (search === 'webp') return 'webp';
+  if (search === 'jpeg' || search === 'jpg') return 'jpeg';
+  if (search === 'avif') return 'avif';
   return null;
 }


### PR DESCRIPTION
#### Motivation

Enum types causes issues with future eslint rules we want to introduce its easier to just remove the types.


#### Modification

Removes ImageFormat and VectorFormat enums and replaces them with string types.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
