### PR TITLE
feat(config)!: remove unused format tag

### DIFF
--- a/packages/config-loader/src/json/json.config.ts
+++ b/packages/config-loader/src/json/json.config.ts
@@ -3,6 +3,7 @@ import {
   ConfigBundled,
   ConfigId,
   ConfigImagery,
+  ConfigImageryOverview,
   ConfigLayer,
   ConfigPrefix,
   ConfigProvider,
@@ -14,17 +15,7 @@ import {
   StyleJson,
   TileSetType,
 } from '@basemaps/config';
-import { ConfigImageryOverview } from '@basemaps/config';
-import {
-  Bounds,
-  GoogleTms,
-  ImageFormat,
-  NamedBounds,
-  Nztm2000QuadTms,
-  TileMatrixSet,
-  TileMatrixSets,
-  VectorFormat,
-} from '@basemaps/geo';
+import { Bounds, GoogleTms, NamedBounds, Nztm2000QuadTms, TileMatrixSet, TileMatrixSets } from '@basemaps/geo';
 import { Cotar, fsa, stringToUrlFolder, Tiff, TiffTag } from '@basemaps/shared';
 import PLimit from 'p-limit';
 import { basename } from 'path';
@@ -242,12 +233,6 @@ export class ConfigJson {
     if (ts.maxZoom) tileSet.maxZoom = ts.maxZoom;
     if (ts.background && tileSet.type === TileSetType.Raster) {
       tileSet.background = parseRgba(ts.background);
-    }
-
-    if (ts.format) {
-      tileSet.format = ts.format as ImageFormat | VectorFormat;
-    } else {
-      tileSet.format = ts.type === TileSetType.Vector ? 'pbf' : 'webp';
     }
 
     return tileSet as ConfigTileSet;

--- a/packages/config-loader/src/json/tiff.config.ts
+++ b/packages/config-loader/src/json/tiff.config.ts
@@ -323,7 +323,6 @@ export async function initConfigFromUrls(
     title: 'Basemaps',
     category: 'Basemaps',
     type: TileSetType.Raster,
-    format: 'webp',
     layers: [],
   };
 

--- a/packages/config/src/config/tile.set.ts
+++ b/packages/config/src/config/tile.set.ts
@@ -1,4 +1,4 @@
-import { EpsgCode, ImageFormat, VectorFormat } from '@basemaps/geo';
+import { EpsgCode, ImageFormat } from '@basemaps/geo';
 
 import { ConfigBase } from './base.js';
 
@@ -62,8 +62,6 @@ export interface ConfigTileSetBase extends ConfigBase {
 
 export interface ConfigTileSetRaster extends ConfigTileSetBase {
   type: TileSetType.Raster;
-  /** Preferred imagery format to use */
-  format: ImageFormat;
 
   /** Background to render for areas where there is no data */
   background?: { r: number; g: number; b: number; alpha: number };
@@ -104,7 +102,6 @@ export interface ConfigTileSetRasterOutput {
 
 export interface ConfigTileSetVector extends ConfigTileSetBase {
   type: TileSetType.Vector;
-  format: VectorFormat;
 }
 
 export type ConfigTileSet = ConfigTileSetVector | ConfigTileSetRaster;

--- a/packages/config/src/memory/memory.config.ts
+++ b/packages/config/src/memory/memory.config.ts
@@ -154,7 +154,6 @@ export class ConfigProviderMemory extends BasemapsConfigProvider {
       name: 'all',
       title: 'All Imagery',
       category: 'Basemaps',
-      format: 'webp',
       layers: Array.from(layerByName.values()).sort((a, b) => a.name.localeCompare(b.name)),
     };
     this.put(allTileset);
@@ -172,7 +171,6 @@ export class ConfigProviderMemory extends BasemapsConfigProvider {
         title: i.title,
         category: i.category,
         name: targetName,
-        format: 'webp',
         layers: [{ name: targetName, title: i.title, minZoom: 0, maxZoom: 32 }],
         background: { r: 0, g: 0, b: 0, alpha: 0 },
         updatedAt: Date.now(),
@@ -202,7 +200,6 @@ export class ConfigProviderMemory extends BasemapsConfigProvider {
       id: ConfigId.prefix(ConfigPrefix.TileSet, ConfigId.unprefix(ConfigPrefix.Imagery, i.id)),
       name: i.name,
       title: i.title,
-      format: 'webp',
       layers: [{ [i.projection]: i.id, name: i.name, minZoom: 0, maxZoom: 32, title: i.title }],
       background: { r: 0, g: 0, b: 0, alpha: 0 },
       updatedAt: Date.now(),

--- a/packages/geo/src/formats.ts
+++ b/packages/geo/src/formats.ts
@@ -3,3 +3,6 @@ export type ImageFormat = 'webp' | 'png' | 'jpeg' | 'avif';
 
 /** Vector tile formats supported by basemaps */
 export type VectorFormat = 'pbf';
+
+/** Supported output formats */
+export type OutputFormat = ImageFormat | VectorFormat;

--- a/packages/geo/src/index.ts
+++ b/packages/geo/src/index.ts
@@ -1,6 +1,6 @@
 export { BoundingBox, Bounds, NamedBounds, Point, Size } from './bounds.js';
 export { Epsg, EpsgCode } from './epsg.js';
-export { ImageFormat, VectorFormat } from './formats.js';
+export { ImageFormat, OutputFormat, VectorFormat } from './formats.js';
 export * from './proj/projection.js';
 export { ProjectionLoader } from './proj/projection.loader.js';
 export { TileSetName, TileSetNameValues } from './proj/tile.set.name.js';

--- a/packages/lambda-tiler/src/__tests__/config.data.ts
+++ b/packages/lambda-tiler/src/__tests__/config.data.ts
@@ -14,7 +14,6 @@ export const TileSetAerial: ConfigTileSetRaster = {
   id: 'ts_aerial',
   name: 'aerial',
   type: TileSetType.Raster,
-  format: 'webp',
   description: 'aerial__description',
   title: 'Aerial Imagery',
   category: 'Basemap',
@@ -35,7 +34,6 @@ export const TileSetVector: ConfigTileSetVector = {
   description: 'topotgrpahic__description',
   title: 'topotgrpahic Imagery',
   category: 'Basemap',
-  format: 'pbf',
   layers: [
     {
       3857: 's3://linz-basemaps/01G7WQMGHB7V946M0YWJJBZ6DW/topopgraphic.tar.co',

--- a/packages/lambda-tiler/src/routes/__tests__/attribution.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/attribution.test.ts
@@ -312,12 +312,12 @@ describe('/v1/attribution', () => {
 
   it('should 304 with etag match', async () => {
     const request = mockUrlRequest(`/v1/attribution/aerial/EPSG:3857/summary.json`, 'get', {
-      [HttpHeader.IfNoneMatch]: 'E5HGpTqF8AiJ7VgGVKLehYnVfLN9jaVw8Sy6UafJRh2f',
+      [HttpHeader.IfNoneMatch]: 'AFV7dcchHkfyFvmmyXwpkxuAPb5BuVXLkLzzYgeB3mFy',
     });
 
     const res = await handler.router.handle(request);
 
-    if (res.status === 200) assert.equal(res.header('etag'), 'E5HGpTqF8AiJ7VgGVKLehYnVfLN9jaVw8Sy6UafJRh2f');
+    if (res.status === 200) assert.equal(res.header('etag'), 'AFV7dcchHkfyFvmmyXwpkxuAPb5BuVXLkLzzYgeB3mFy');
 
     console.log(res.header('etag'));
     assert.equal(res.status, 304);

--- a/packages/lambda-tiler/src/routes/tile.json.ts
+++ b/packages/lambda-tiler/src/routes/tile.json.ts
@@ -1,4 +1,5 @@
-import { GoogleTms, TileJson, TileMatrixSet } from '@basemaps/geo';
+import { ConfigTileSet, TileSetType } from '@basemaps/config';
+import { GoogleTms, OutputFormat, TileJson, TileMatrixSet } from '@basemaps/geo';
 import { Env, toQueryString } from '@basemaps/shared';
 import { HttpHeader, LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambda';
 
@@ -14,6 +15,11 @@ export interface TileJsonGet {
   };
 }
 
+function defaultOutputFormat(tileSet: ConfigTileSet): OutputFormat[] {
+  if (tileSet.type === TileSetType.Vector) return ['pbf'];
+  return ['webp'];
+}
+
 export async function tileJsonGet(req: LambdaHttpRequest<TileJsonGet>): Promise<LambdaHttpResponse> {
   const tileMatrix = Validate.getTileMatrixSet(req.params.tileMatrix);
   if (tileMatrix == null) return NotFound();
@@ -27,7 +33,7 @@ export async function tileJsonGet(req: LambdaHttpRequest<TileJsonGet>): Promise<
   req.timer.end('tileset:load');
   if (tileSet == null) return NotFound();
 
-  const format = Validate.getRequestedFormats(req) ?? [tileSet.format];
+  const format: OutputFormat[] = Validate.getRequestedFormats(req) ?? defaultOutputFormat(tileSet);
 
   const host = Env.get(Env.PublicUrlBase) ?? '';
 


### PR DESCRIPTION
#### Motivation

Format was meant to be used to allow imagery configuration to specify the output configuration, this has been superceeded by "outputs" and was never actually used.

#### Modification

Removes "format" from imagery configuration

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
