### PR TITLE
fix(config-loader): close tiffs rather than letting the gc close them

### DIFF
--- a/packages/config-loader/src/json/tiff.config.ts
+++ b/packages/config-loader/src/json/tiff.config.ts
@@ -323,7 +323,10 @@ export async function loadTiffsFromPaths(sourceFiles: URL[], Q: LimitFunction): 
       sourceFiles.filter(isTiff).map((c) =>
         Q(async () => {
           const tiff = await new Tiff(fsa.source(c)).init();
-          if (await isEmptyTiff(tiff)) return null;
+          if (await isEmptyTiff(tiff)) {
+            await tiff.source.close?.()
+            return null;
+          }
           return tiff;
         }),
       ),

--- a/packages/config-loader/src/json/tiff.config.ts
+++ b/packages/config-loader/src/json/tiff.config.ts
@@ -324,7 +324,7 @@ export async function loadTiffsFromPaths(sourceFiles: URL[], Q: LimitFunction): 
         Q(async () => {
           const tiff = await new Tiff(fsa.source(c)).init();
           if (await isEmptyTiff(tiff)) {
-            await tiff.source.close?.()
+            await tiff.source.close?.();
             return null;
           }
           return tiff;


### PR DESCRIPTION
#### Motivation

some tiffs are getting closed via the garbage collector rather than safely using `.close()

#### Modification

Ensures that when tiffs are created the are closed cleanly.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
