### PR TITLE
feat(tiler)!: support custom raster processing pipelines'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12608,6 +12608,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/lerc": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-4.0.4.tgz",
+      "integrity": "sha512-nHZH+ffiGPkgKUQtiZrljGUGV2GddvPcVTV5E345ZFncbKz+/rBIjDPrSxkiqW0EAtg1Jw7qAgRdaCwV+95Fow=="
+    },
     "node_modules/lerna": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/lerna/-/lerna-8.0.0.tgz",
@@ -20098,7 +20103,8 @@
       "dependencies": {
         "@basemaps/geo": "^7.0.0",
         "@basemaps/tiler": "^7.0.0",
-        "@linzjs/metrics": "^7.0.0"
+        "@linzjs/metrics": "^7.0.0",
+        "lerc": "^4.0.4"
       },
       "devDependencies": {
         "@types/pixelmatch": "^5.2.3",

--- a/packages/config-loader/src/json/__tests__/tiff.config.test.ts
+++ b/packages/config-loader/src/json/__tests__/tiff.config.test.ts
@@ -1,10 +1,10 @@
 import assert from 'node:assert';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 
+import { ConfigImagery } from '@basemaps/config';
 import { fsa, FsMemory } from '@basemaps/shared';
 
-import { loadStacFromURL, isRgbOrRgba } from '../tiff.config.js';
-import { ConfigImagery } from '@basemaps/config';
+import { isRgbOrRgba, loadStacFromURL } from '../tiff.config.js';
 
 describe('loadStacFromURL', () => {
   const mem = new FsMemory();
@@ -39,30 +39,29 @@ describe('loadStacFromURL', () => {
   });
 });
 
-
 describe('isRgbOrRgba', () => {
   const uint8 = { type: 'uint', bits: 8 };
   it('should allow imagery with no band information', () => {
     assert.equal(isRgbOrRgba({} as ConfigImagery), true);
-  })
+  });
 
   it('should allow 3 or 4 band imagery', () => {
     assert.equal(isRgbOrRgba({ bands: [uint8, uint8, uint8] } as ConfigImagery), true);
     assert.equal(isRgbOrRgba({ bands: [uint8, uint8, uint8, uint8] } as ConfigImagery), true);
-  })
+  });
 
   it('should not allow 1,2,5,6 band imagery', () => {
     assert.equal(isRgbOrRgba({ bands: [uint8] } as ConfigImagery), false);
     assert.equal(isRgbOrRgba({ bands: [uint8, uint8] } as ConfigImagery), false);
     assert.equal(isRgbOrRgba({ bands: [uint8, uint8, uint8, uint8, uint8] } as ConfigImagery), false);
     assert.equal(isRgbOrRgba({ bands: [uint8, uint8, uint8, uint8, uint8, uint8] } as ConfigImagery), false);
-  })
+  });
 
   it('should not allow float32 imagery', () => {
     assert.equal(isRgbOrRgba({ bands: [uint8, uint8, uint8, { type: 'float', bits: 32 }] } as ConfigImagery), false);
-  })
+  });
 
   it('should not allow uint16', () => {
     assert.equal(isRgbOrRgba({ bands: [uint8, uint8, uint8, { type: 'uint', bits: 16 }] } as ConfigImagery), false);
-  })
-})
+  });
+});

--- a/packages/config-loader/src/json/__tests__/tiff.config.test.ts
+++ b/packages/config-loader/src/json/__tests__/tiff.config.test.ts
@@ -3,7 +3,8 @@ import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import { fsa, FsMemory } from '@basemaps/shared';
 
-import { loadStacFromURL } from '../tiff.config.js';
+import { loadStacFromURL, isRgbOrRgba } from '../tiff.config.js';
+import { ConfigImagery } from '@basemaps/config';
 
 describe('loadStacFromURL', () => {
   const mem = new FsMemory();
@@ -37,3 +38,31 @@ describe('loadStacFromURL', () => {
     assert.deepEqual(result as unknown, { hello: 'world' });
   });
 });
+
+
+describe('isRgbOrRgba', () => {
+  const uint8 = { type: 'uint', bits: 8 };
+  it('should allow imagery with no band information', () => {
+    assert.equal(isRgbOrRgba({} as ConfigImagery), true);
+  })
+
+  it('should allow 3 or 4 band imagery', () => {
+    assert.equal(isRgbOrRgba({ bands: [uint8, uint8, uint8] } as ConfigImagery), true);
+    assert.equal(isRgbOrRgba({ bands: [uint8, uint8, uint8, uint8] } as ConfigImagery), true);
+  })
+
+  it('should not allow 1,2,5,6 band imagery', () => {
+    assert.equal(isRgbOrRgba({ bands: [uint8] } as ConfigImagery), false);
+    assert.equal(isRgbOrRgba({ bands: [uint8, uint8] } as ConfigImagery), false);
+    assert.equal(isRgbOrRgba({ bands: [uint8, uint8, uint8, uint8, uint8] } as ConfigImagery), false);
+    assert.equal(isRgbOrRgba({ bands: [uint8, uint8, uint8, uint8, uint8, uint8] } as ConfigImagery), false);
+  })
+
+  it('should not allow float32 imagery', () => {
+    assert.equal(isRgbOrRgba({ bands: [uint8, uint8, uint8, { type: 'float', bits: 32 }] } as ConfigImagery), false);
+  })
+
+  it('should not allow uint16', () => {
+    assert.equal(isRgbOrRgba({ bands: [uint8, uint8, uint8, { type: 'uint', bits: 16 }] } as ConfigImagery), false);
+  })
+})

--- a/packages/config-loader/src/json/tiff.config.ts
+++ b/packages/config-loader/src/json/tiff.config.ts
@@ -453,13 +453,13 @@ export async function initConfigFromUrls(
     outputs: [
       {
         title: 'Color ramp',
-        extension: 'color-ramp.webp',
+        name: 'color-ramp',
         pipeline: [{ type: 'color-ramp' }],
         output: { type: 'webp' },
       },
       {
         title: 'TerrainRGB',
-        extension: 'terrain-rgb.webp',
+        name: 'terrain-rgb',
         pipeline: [{ type: 'terrain-rgb' }],
         output: { type: 'webp', lossless: true },
       },

--- a/packages/config/src/config/tile.set.ts
+++ b/packages/config/src/config/tile.set.ts
@@ -79,12 +79,13 @@ export interface ConfigTileSetRaster extends ConfigTileSetBase {
 export interface ConfigTileSetRasterOutput {
   /** Human friendly description of the output */
   title: string;
+
   /**
-   * URL extensions to separate this output from others, Must be unique per tile set.
+   * Common name for the configuration
    *
-   * @example "terrain-rgb.webp"
+   * @example "terrain-rgb", "color-ramp"
    */
-  extension: string;
+  name: string;
 
   /**
    * Raster processing pipeline, for configuration on how to convert the source into a RGBA output

--- a/packages/config/src/config/tile.set.ts
+++ b/packages/config/src/config/tile.set.ts
@@ -86,18 +86,37 @@ export interface ConfigTileSetRasterOutput {
    */
   extension: string;
 
+  /**
+   * Raster processing pipeline, for configuration on how to convert the source into a RGBA output
+   */
+  pipeline?: ConfigRasterPipeline[];
+
   /** Raster output format */
   output: {
     /** Output file format to use */
     type: ImageFormat;
-    /** should the output be lossless */
-    lossless: boolean;
     /**
-     *  Background to render for areas where there is no data, falls back to
-     *  {@link ConfigTileSetRaster.background} if not defined
+     * should the output be lossless
+     *
+     * @default false
+     */
+    lossless?: boolean;
+    /**
+     * Background to render for areas where there is no data, falls back to
+     * {@link ConfigTileSetRaster.background} if not defined
      */
     background?: { r: number; g: number; b: number; alpha: number };
   };
+}
+
+export type ConfigRasterPipeline = ConfigRasterPipelineTerrainRgb | ConfigRasterPipelineColorRamp;
+
+export interface ConfigRasterPipelineTerrainRgb {
+  type: 'terrain-rgb';
+}
+
+export interface ConfigRasterPipelineColorRamp {
+  type: 'color-ramp';
 }
 
 export interface ConfigTileSetVector extends ConfigTileSetBase {

--- a/packages/config/src/memory/memory.config.ts
+++ b/packages/config/src/memory/memory.config.ts
@@ -8,7 +8,7 @@ import { ConfigBundle } from '../config/config.bundle.js';
 import { ConfigImagery } from '../config/imagery.js';
 import { ConfigPrefix } from '../config/prefix.js';
 import { ConfigProvider } from '../config/provider.js';
-import { ConfigLayer, ConfigTileSet, TileSetType } from '../config/tile.set.js';
+import { ConfigLayer, ConfigTileSet, ConfigTileSetRaster, TileSetType } from '../config/tile.set.js';
 import { ConfigVectorStyle } from '../config/vector.style.js';
 import { standardizeLayerName } from '../name.convertor.js';
 
@@ -163,7 +163,7 @@ export class ConfigProviderMemory extends BasemapsConfigProvider {
   imageryToTileSetByName(i: ConfigImagery): ConfigTileSet {
     const targetName = standardizeLayerName(i.name);
     const targetId = ConfigId.prefix(ConfigPrefix.TileSet, targetName);
-    let existing = this.objects.get(targetId) as ConfigTileSet;
+    let existing = this.objects.get(targetId) as ConfigTileSetRaster;
     if (existing == null) {
       existing = {
         type: TileSetType.Raster,
@@ -174,9 +174,21 @@ export class ConfigProviderMemory extends BasemapsConfigProvider {
         layers: [{ name: targetName, title: i.title, minZoom: 0, maxZoom: 32 }],
         background: { r: 0, g: 0, b: 0, alpha: 0 },
         updatedAt: Date.now(),
-      } as ConfigTileSet;
+      } as ConfigTileSetRaster;
       removeUndefined(existing);
       this.put(existing);
+
+      // FIXME: should we store output types here
+      if (i.bands?.length === 1) {
+        existing.outputs = [
+          {
+            title: 'Color ramp',
+            extension: 'color-ramp.webp',
+            pipeline: [{ type: 'color-ramp' }],
+            output: { type: 'webp' },
+          },
+        ];
+      }
     }
     // The latest imagery overwrite the earlier ones.
     const existingImageryId = existing.layers[0][i.projection];
@@ -195,7 +207,7 @@ export class ConfigProviderMemory extends BasemapsConfigProvider {
 
   /** Create a tile set of direct to imagery name `ts_imageId */
   static imageryToTileSet(i: ConfigImagery): ConfigTileSet {
-    return {
+    const ts: ConfigTileSetRaster = {
       type: TileSetType.Raster,
       id: ConfigId.prefix(ConfigPrefix.TileSet, ConfigId.unprefix(ConfigPrefix.Imagery, i.id)),
       name: i.name,
@@ -204,6 +216,19 @@ export class ConfigProviderMemory extends BasemapsConfigProvider {
       background: { r: 0, g: 0, b: 0, alpha: 0 },
       updatedAt: Date.now(),
     };
+
+    // FIXME: should we store output types here
+    if (i.bands?.length === 1) {
+      ts.outputs = [
+        {
+          title: 'Color ramp',
+          extension: 'color-ramp.webp',
+          pipeline: [{ type: 'color-ramp' }],
+          output: { type: 'webp' },
+        },
+      ];
+    }
+    return ts;
   }
 
   /** Load a bundled configuration creating virtual tilesets for all imagery */

--- a/packages/config/src/memory/memory.config.ts
+++ b/packages/config/src/memory/memory.config.ts
@@ -183,7 +183,7 @@ export class ConfigProviderMemory extends BasemapsConfigProvider {
         existing.outputs = [
           {
             title: 'Color ramp',
-            extension: 'color-ramp.webp',
+            name: 'color-ramp',
             pipeline: [{ type: 'color-ramp' }],
             output: { type: 'webp' },
           },
@@ -222,7 +222,7 @@ export class ConfigProviderMemory extends BasemapsConfigProvider {
       ts.outputs = [
         {
           title: 'Color ramp',
-          extension: 'color-ramp.webp',
+          name: 'color-ramp',
           pipeline: [{ type: 'color-ramp' }],
           output: { type: 'webp' },
         },

--- a/packages/lambda-tiler/scripts/create.deployment.package.mjs
+++ b/packages/lambda-tiler/scripts/create.deployment.package.mjs
@@ -17,7 +17,7 @@ export function getPackageVersion(packageName) {
 // the bundle is a commonjs module
 parentPackage.type = 'commonjs';
 parentPackage.main = 'index.js';
-parentPackage.dependencies = { sharp: getPackageVersion('sharp') };
+parentPackage.dependencies = { sharp: getPackageVersion('sharp'), lerc: getPackageVersion('lerc') };
 
 // Clean up
 delete parentPackage.types;

--- a/packages/lambda-tiler/src/cli/render.preview.ts
+++ b/packages/lambda-tiler/src/cli/render.preview.ts
@@ -39,7 +39,7 @@ async function main(): Promise<void> {
     tileSet,
     location,
     z,
-    output: { title: outputFormat, output: { type: outputFormat }, extension: outputFormat },
+    output: { title: outputFormat, output: { type: outputFormat }, name: 'rgba' },
   });
   const previewFile = fsa.toUrl(`./z${z}_${location.lon}_${location.lat}.${outputFormat}`);
   await fsa.write(previewFile, Buffer.from(res.body, 'base64'));

--- a/packages/lambda-tiler/src/cli/render.preview.ts
+++ b/packages/lambda-tiler/src/cli/render.preview.ts
@@ -34,7 +34,13 @@ async function main(): Promise<void> {
   if (tileMatrix == null) throw new Error('No tileMatrix found');
 
   const req = new LambdaUrlRequest({ headers: {} } as UrlEvent, {} as Context, LogConfig.get()) as LambdaHttpRequest;
-  const res = await renderPreview(req, { tileMatrix, tileSet, location, z, outputFormat });
+  const res = await renderPreview(req, {
+    tileMatrix,
+    tileSet,
+    location,
+    z,
+    output: { title: outputFormat, output: { type: outputFormat }, extension: outputFormat },
+  });
   const previewFile = fsa.toUrl(`./z${z}_${location.lon}_${location.lat}.${outputFormat}`);
   await fsa.write(previewFile, Buffer.from(res.body, 'base64'));
   log.info({ path: previewFile }, 'Tile:Write');

--- a/packages/lambda-tiler/src/index.ts
+++ b/packages/lambda-tiler/src/index.ts
@@ -77,6 +77,8 @@ handler.router.get('/v1/tiles/:tileSet/:tileMatrix/:z(^\\d+)/:x(^\\d+)/:y(^\\d+)
 
 // Preview
 handler.router.get('/v1/preview/:tileSet/:tileMatrix/:z/:lon/:lat', tilePreviewGet);
+handler.router.get('/v1/preview/:tileSet/:tileMatrix/:z/:lon/:lat/:outputType', tilePreviewGet);
+
 handler.router.get('/v1/@:location', previewIndexGet);
 handler.router.get('/@:location', previewIndexGet);
 

--- a/packages/lambda-tiler/src/routes/__tests__/xyz.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/xyz.test.ts
@@ -134,9 +134,7 @@ describe('/v1/tiles', () => {
 
     const elevation = FakeData.tileSetRaster('elevation');
 
-    elevation.outputs = [
-      { title: 'Terrain RGB', extension: 'terrain-rgb.webp', output: { type: 'webp', lossless: true } },
-    ];
+    elevation.outputs = [{ title: 'Terrain RGB', name: 'terrain-rgb', output: { type: 'webp', lossless: true } }];
     config.put(elevation);
 
     const request = mockRequest('/v1/tiles/elevation/3857/11/2022/1283-terrain-rgb.webp', 'get', Api.header);

--- a/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
+++ b/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
@@ -133,7 +133,7 @@ export const TileXyzRaster = {
 
     const res = await TileComposer.compose({
       layers,
-      format: tileOutput.output.type,
+      output: tileOutput,
       background: tileOutput.output.background ?? tileSet.background ?? DefaultBackground,
       resizeKernel: tileSet.resizeKernel ?? DefaultResizeKernel,
       metrics: req.timer,
@@ -155,15 +155,21 @@ export const TileXyzRaster = {
  *
  * Defaults to standard image format output if no outputs are defined on the tileset
  */
-function getTileSetOutput(tileSet: ConfigTileSetRaster, tileType: string): ConfigTileSetRasterOutput | null {
+export function getTileSetOutput(tileSet: ConfigTileSetRaster, tileType?: string): ConfigTileSetRasterOutput | null {
   if (tileSet.outputs != null) {
+    // Default to the first output if no extension given
+    if (tileType == null) return tileSet.outputs[0];
     for (const out of tileSet.outputs) {
       if (out.extension === tileType) return out;
+    }
+
+    for (const out of tileSet.outputs) {
+      if (out.extension.endsWith(tileType)) return out;
     }
     return null;
   }
 
-  const img = getImageFormat(tileType);
+  const img = getImageFormat(tileType ?? 'webp');
   if (img == null) return null;
   return {
     title: `Default ${tileType}`,

--- a/packages/lambda-tiler/src/util/validate.ts
+++ b/packages/lambda-tiler/src/util/validate.ts
@@ -95,6 +95,7 @@ export const Validate = {
     if (req.params.tileType.startsWith('.') || req.params.tileType.startsWith('-')) {
       req.params.tileType = req.params.tileType.slice(1);
     }
+
     req.set('extension', req.params.tileType);
 
     if (isNaN(z) || z > tileMatrix.maxZoom || z < 0) throw new LambdaHttpResponse(404, `Zoom not found: ${z}`);

--- a/packages/tiler-sharp/package.json
+++ b/packages/tiler-sharp/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "@basemaps/geo": "^7.0.0",
     "@basemaps/tiler": "^7.0.0",
-    "@linzjs/metrics": "^7.0.0"
+    "@linzjs/metrics": "^7.0.0",
+    "lerc": "^4.0.4"
   },
   "devDependencies": {
     "@types/pixelmatch": "^5.2.3",

--- a/packages/tiler-sharp/src/__tests__/tile.benchmark.ts
+++ b/packages/tiler-sharp/src/__tests__/tile.benchmark.ts
@@ -1,4 +1,3 @@
-import { ConfigTileSetRasterOutput } from '@basemaps/config';
 import { GoogleTms } from '@basemaps/geo';
 import { fsa, Tiff } from '@basemaps/shared';
 import { TestTiff } from '@basemaps/test';
@@ -14,7 +13,6 @@ const Center = 2 ** Zoom;
 const CenterTile = Center / 2;
 
 const background = { r: 0, g: 0, b: 0, alpha: 1 };
-const output: ConfigTileSetRasterOutput = { title: 'Png', output: { type: 'png', lossless: true }, extension: '.png' };
 
 async function main(): Promise<void> {
   const tileSize = Number(process.argv[process.argv.length - 1]);
@@ -33,7 +31,7 @@ async function main(): Promise<void> {
     if (layers == null) throw new Error('Tile is null');
     await tileMaker.compose({
       layers,
-      output,
+      format: 'png',
       background,
       resizeKernel,
     });

--- a/packages/tiler-sharp/src/__tests__/tile.benchmark.ts
+++ b/packages/tiler-sharp/src/__tests__/tile.benchmark.ts
@@ -1,3 +1,4 @@
+import { ConfigTileSetRasterOutput } from '@basemaps/config';
 import { GoogleTms } from '@basemaps/geo';
 import { fsa, Tiff } from '@basemaps/shared';
 import { TestTiff } from '@basemaps/test';
@@ -13,6 +14,7 @@ const Center = 2 ** Zoom;
 const CenterTile = Center / 2;
 
 const background = { r: 0, g: 0, b: 0, alpha: 1 };
+const output: ConfigTileSetRasterOutput = { title: 'Png', output: { type: 'png', lossless: true }, extension: '.png' };
 
 async function main(): Promise<void> {
   const tileSize = Number(process.argv[process.argv.length - 1]);
@@ -29,7 +31,12 @@ async function main(): Promise<void> {
     const layers = await tiler.tile([tiff], CenterTile, CenterTile, Zoom);
 
     if (layers == null) throw new Error('Tile is null');
-    await tileMaker.compose({ layers, format: 'png', background, resizeKernel });
+    await tileMaker.compose({
+      layers,
+      output,
+      background,
+      resizeKernel,
+    });
     await tiff.source.close?.();
   }
 }

--- a/packages/tiler-sharp/src/__tests__/tile.creation.test.ts
+++ b/packages/tiler-sharp/src/__tests__/tile.creation.test.ts
@@ -85,7 +85,7 @@ describe('TileCreation', () => {
   it('should error when provided invalid image formats', async () => {
     const tileMaker = new TileMakerSharp(256);
     try {
-      await tileMaker.compose({ layers: [], background } as any);
+      await tileMaker.compose({ layers: [], output: { output: {} }, background } as any);
       assert.equal(true, false, 'invalid format');
     } catch (e: any) {
       assert.equal(e.message.includes('Invalid image'), true);

--- a/packages/tiler-sharp/src/__tests__/tile.creation.test.ts
+++ b/packages/tiler-sharp/src/__tests__/tile.creation.test.ts
@@ -1,7 +1,6 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { ConfigTileSetRasterOutput } from '@basemaps/config';
 import { Epsg, GoogleTms, Nztm2000Tms, QuadKey, Tile } from '@basemaps/geo';
 import { fsa, Tiff } from '@basemaps/shared';
 import { TestTiff } from '@basemaps/test';
@@ -59,7 +58,7 @@ describe('TileCreation', () => {
     const tileMaker = new TileMakerSharp(256);
     const res = await tileMaker.compose({
       layers: [],
-      output: { title: '', extension: '.webp', output: { type: 'webp' } },
+      format: 'webp',
       background,
       resizeKernel,
     });
@@ -74,7 +73,7 @@ describe('TileCreation', () => {
     const tileMaker = new TileMakerSharp(256);
     const res = await tileMaker.compose({
       layers: [],
-      output: { title: '', extension: '.jpeg', output: { type: 'jpeg' } },
+      format: 'jpeg',
       background,
       resizeKernel,
     });
@@ -85,7 +84,7 @@ describe('TileCreation', () => {
   it('should error when provided invalid image formats', async () => {
     const tileMaker = new TileMakerSharp(256);
     try {
-      await tileMaker.compose({ layers: [], output: { output: {} }, background } as any);
+      await tileMaker.compose({ layers: [], background } as any);
       assert.equal(true, false, 'invalid format');
     } catch (e: any) {
       assert.equal(e.message.includes('Invalid image'), true);
@@ -121,12 +120,6 @@ describe('TileCreation', () => {
     { tileSize: 256, tms: Nztm2000Tms, tile: { x: 6, y: 8, z: 2 } }, // Empty tile
   ];
 
-  const output: ConfigTileSetRasterOutput = {
-    title: 'Png',
-    output: { type: 'png', lossless: true },
-    extension: '.png',
-  };
-
   RenderTests.forEach(({ tileSize, tms, tile }) => {
     const projection = tms.projection;
     const tileText = `${tile.x}, ${tile.y} z${tile.z}`;
@@ -146,7 +139,7 @@ describe('TileCreation', () => {
 
       const png = await tileMaker.compose({
         layers,
-        output,
+        format: 'png',
         background,
         resizeKernel,
       });

--- a/packages/tiler-sharp/src/__tests__/tile.creation.test.ts
+++ b/packages/tiler-sharp/src/__tests__/tile.creation.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
+import { ConfigTileSetRasterOutput } from '@basemaps/config';
 import { Epsg, GoogleTms, Nztm2000Tms, QuadKey, Tile } from '@basemaps/geo';
 import { fsa, Tiff } from '@basemaps/shared';
 import { TestTiff } from '@basemaps/test';
@@ -56,7 +57,12 @@ describe('TileCreation', () => {
 
   it('should generate webp', async () => {
     const tileMaker = new TileMakerSharp(256);
-    const res = await tileMaker.compose({ layers: [], format: 'webp', background, resizeKernel });
+    const res = await tileMaker.compose({
+      layers: [],
+      output: { title: '', extension: '.webp', output: { type: 'webp' } },
+      background,
+      resizeKernel,
+    });
     // Image format `R I F F <fileSize (int32)> W E B P`
     const magicBytes = res.buffer.slice(0, 4);
     const magicWebP = res.buffer.slice(8, 12);
@@ -66,7 +72,12 @@ describe('TileCreation', () => {
 
   it('should generate jpeg', async () => {
     const tileMaker = new TileMakerSharp(256);
-    const res = await tileMaker.compose({ layers: [], format: 'jpeg', background, resizeKernel });
+    const res = await tileMaker.compose({
+      layers: [],
+      output: { title: '', extension: '.jpeg', output: { type: 'jpeg' } },
+      background,
+      resizeKernel,
+    });
     const magicBytes = res.buffer.slice(0, 4);
     assert.deepEqual(magicBytes.toJSON().data, [0xff, 0xd8, 0xff, 0xdb]);
   });
@@ -110,6 +121,12 @@ describe('TileCreation', () => {
     { tileSize: 256, tms: Nztm2000Tms, tile: { x: 6, y: 8, z: 2 } }, // Empty tile
   ];
 
+  const output: ConfigTileSetRasterOutput = {
+    title: 'Png',
+    output: { type: 'png', lossless: true },
+    extension: '.png',
+  };
+
   RenderTests.forEach(({ tileSize, tms, tile }) => {
     const projection = tms.projection;
     const tileText = `${tile.x}, ${tile.y} z${tile.z}`;
@@ -129,7 +146,7 @@ describe('TileCreation', () => {
 
       const png = await tileMaker.compose({
         layers,
-        format: 'png',
+        output,
         background,
         resizeKernel,
       });

--- a/packages/tiler-sharp/src/index.ts
+++ b/packages/tiler-sharp/src/index.ts
@@ -1,3 +1,4 @@
+import { ConfigTileSetRasterOutput } from '@basemaps/config';
 import { ImageFormat } from '@basemaps/geo';
 import {
   Composition,
@@ -9,6 +10,9 @@ import {
 } from '@basemaps/tiler';
 import { Metrics } from '@linzjs/metrics';
 import Sharp from 'sharp';
+
+import { Decompressors } from './pipeline/decompressor.lerc.js';
+import { Pipelines } from './pipeline/pipelines.js';
 
 function notEmpty<T>(value: T | null | undefined): value is T {
   return value != null;
@@ -60,14 +64,14 @@ export class TileMakerSharp implements TileMaker {
    * @throws if unsupported image format is used
    * @returns image as the supplied image format
    */
-  toImage(format: ImageFormat, pipeline: Sharp.Sharp): Promise<Buffer> {
+  toImage(format: ImageFormat, pipeline: Sharp.Sharp, lossless?: boolean): Promise<Buffer> {
     switch (format) {
       case 'jpeg':
         return pipeline.jpeg().toBuffer();
       case 'png':
         return pipeline.png().toBuffer();
       case 'webp':
-        return pipeline.webp().toBuffer();
+        return pipeline.webp({ lossless }).toBuffer();
       case 'avif':
         return pipeline.avif().toBuffer();
       default:
@@ -80,39 +84,6 @@ export class TileMakerSharp implements TileMaker {
     return this.toImage(format, this.createImage(background).composite(layers));
   }
 
-  /** Can we just serve the image directly from the cotar */
-  private isDirectCotar(ctx: TileMakerContext): boolean {
-    if (ctx.layers.length !== 1) return false;
-    const firstLayer = ctx.layers[0];
-    if (firstLayer.type !== 'cotar') return false;
-    if (this.width !== 256 || this.height !== 256) return false; // TODO this should not be hard coded
-    if (ctx.format !== 'webp') return false; // TODO this should not be hard coded
-    if (ctx.background.alpha !== 0) return false;
-    return true;
-  }
-
-  /** Are we just serving the source tile directly back to the user without any modifications */
-  private isDirectImage(ctx: TileMakerContext): boolean {
-    if (ctx.layers.length !== 1) return false;
-    const firstLayer = ctx.layers[0];
-    if (firstLayer.type !== 'tiff') return false;
-    // Has to be rendered at the top left with no modification
-    if (firstLayer.x !== 0 || firstLayer.y !== 0) return false;
-    if (firstLayer.crop != null || firstLayer.extract != null || firstLayer.resize != null) return false;
-
-    // Validate tile size is expected
-    const img = firstLayer.asset.images[firstLayer.source.imageId];
-    const tileSize = img?.tileSize;
-    if (tileSize.height !== this.height || tileSize.width !== this.width) return false;
-
-    // Image format has to match
-    if (!img.compression?.includes(ctx.format)) return false;
-    // Only transparent backgrounds can be served
-    if (ctx.background.alpha !== 0) return false;
-
-    return true;
-  }
-
   public async compose(ctx: TileMakerContext): Promise<{ buffer: Buffer; metrics: Metrics; layers: number }> {
     const metrics = ctx.metrics ?? new Metrics();
     // TODO to prevent too many of these running, it should ideally be inside of a two step promise queue
@@ -120,41 +91,21 @@ export class TileMakerSharp implements TileMaker {
     // 2. Create image overlays
     metrics.start('compose:overlay');
 
-    if (this.isDirectCotar(ctx)) {
-      const firstLayer = ctx.layers[0] as CompositionCotar;
-      const buf = await firstLayer.asset.get(firstLayer.path);
-      if (buf == null) return { buffer: await this.getEmptyImage(ctx.format, ctx.background), metrics, layers: 0 };
-      metrics.start('compose:direct');
-      metrics.end('compose:direct');
-      return { buffer: Buffer.from(buf), metrics, layers: 1 };
-    }
-
-    // If we are serving a single tile back to the user, sometimes we can serve the raw image buffer from the tiff
-    if (this.isDirectImage(ctx)) {
-      const firstLayer = ctx.layers[0] as CompositionTiff;
-      const buf = await firstLayer.asset.images[firstLayer.source.imageId].getTile(
-        firstLayer.source.x,
-        firstLayer.source.y,
-      );
-      metrics.end('compose:overlay');
-
-      if (buf == null) return { buffer: await this.getEmptyImage(ctx.format, ctx.background), metrics, layers: 0 };
-      // Track that a direct tiff was served to a user
-      metrics.start('compose:direct');
-      metrics.end('compose:direct');
-      return { buffer: Buffer.from(buf.bytes), metrics, layers: 1 };
-    }
-
     const todo: Promise<SharpOverlay | null>[] = [];
     for (const comp of ctx.layers) {
       if (this.isTooLarge(comp)) continue;
-      todo.push(this.composeTile(comp, ctx.resizeKernel));
+      if (ctx.output.pipeline) {
+        if (comp.type === 'cotar') throw new Error('Cannot compose from cotar');
+        todo.push(this.composeTilePipeline(comp, ctx.output, ctx.resizeKernel));
+      } else {
+        todo.push(this.composeTile(comp, ctx.resizeKernel));
+      }
     }
     const overlays = await Promise.all(todo).then((items) => items.filter(notEmpty));
     metrics.end('compose:overlay');
 
     metrics.start('compose:compress');
-    const buffer = await this.getImageBuffer(overlays, ctx.format, ctx.background);
+    const buffer = await this.getImageBuffer(overlays, ctx.output.output.type, ctx.background);
     metrics.end('compose:compress');
 
     return { buffer, metrics, layers: overlays.length };
@@ -181,6 +132,52 @@ export class TileMakerSharp implements TileMaker {
     // Extract the vars to make it easier to reference later
     const { extract, resize, crop } = comp;
 
+    if (extract) sharp.extract({ top: 0, left: 0, width: extract.width, height: extract.height });
+
+    if (resize) {
+      const resizeOptions = { fit: Sharp.fit.cover, kernel: resize.scaleX > 1 ? resizeKernel.in : resizeKernel.out };
+      sharp.resize(resize.width, resize.height, resizeOptions);
+    }
+
+    if (crop) sharp.extract({ top: crop.y, left: crop.x, width: crop.width, height: crop.height });
+
+    const ret = await sharp.raw().toBuffer({ resolveWithObject: true });
+    return {
+      input: ret.data,
+      top: comp.y,
+      left: comp.x,
+      raw: { width: ret.info.width, height: ret.info.height, channels: ret.info.channels },
+    };
+  }
+
+  async composeTilePipeline(
+    comp: CompositionTiff,
+    output: ConfigTileSetRasterOutput,
+    resizeKernel: TileMakerResizeKernel,
+  ): Promise<SharpOverlay | null> {
+    const tile = await comp.asset.images[comp.source.imageId].getTile(comp.source.x, comp.source.y);
+    if (tile == null) return null;
+
+    const bytes = await Decompressors[tile.compression]?.bytes(comp.asset, tile.bytes);
+    if (bytes == null) throw new Error('Failed to decompress: ' + comp.asset.source.url);
+
+    let result = bytes;
+    if (output.pipeline) {
+      for (const pipe of output.pipeline) {
+        result = await Pipelines[pipe.type]?.process(comp.asset, result, pipe);
+        if (result == null) throw new Error(`Failed to process pipeline:${pipe.type} on ${comp.asset.source.url}`);
+      }
+    }
+
+    if (result.depth !== 'uint8') throw new Error('Expected RGBA image output');
+    const sharp = Sharp(result.pixels, {
+      raw: { width: result.width, height: result.height, channels: result.channels as 4 },
+    });
+
+    // Extract the vars to make it easier to reference later
+    const { extract, resize, crop } = comp;
+
+    // FIXME: extract should be run before the pipelines
     if (extract) sharp.extract({ top: 0, left: 0, width: extract.width, height: extract.height });
 
     if (resize) {

--- a/packages/tiler-sharp/src/pipeline/decompressor.lerc.ts
+++ b/packages/tiler-sharp/src/pipeline/decompressor.lerc.ts
@@ -1,5 +1,4 @@
-import { Tiff } from '@basemaps/shared';
-import { Compression } from '@cogeotiff/core';
+import { Compression, Tiff } from '@cogeotiff/core';
 import Lerc from 'lerc';
 
 import { DecompressedInterleaved, Decompressor } from './decompressor.js';

--- a/packages/tiler-sharp/src/pipeline/decompressor.lerc.ts
+++ b/packages/tiler-sharp/src/pipeline/decompressor.lerc.ts
@@ -1,0 +1,45 @@
+import { Tiff } from '@basemaps/shared';
+import { Compression } from '@cogeotiff/core';
+import Lerc from 'lerc';
+
+import { DecompressedInterleaved, Decompressor } from './decompressor.js';
+
+function lercDepth(s: string): string {
+  switch (s) {
+    case 'F32':
+      return 'float';
+    default:
+      throw new Error('Unknown LERC Byte depth: ' + s);
+  }
+}
+
+export const LercDecompressor: Decompressor = {
+  type: 'application/lerc',
+  async bytes(source: Tiff, tile: ArrayBuffer): Promise<DecompressedInterleaved> {
+    await Lerc.load();
+    const bytes = Lerc.decode(tile);
+
+    if (lercDepth(bytes.pixelType) !== 'float') {
+      throw new Error(`Lerc: Invalid output pixelType:${bytes.pixelType} from:${source.source.url}`);
+    }
+    if (bytes.depthCount !== 1) {
+      throw new Error(`Lerc: Invalid output depthCount:${bytes.depthCount} from:${source.source.url}`);
+    }
+    if (bytes.pixels.length !== 1) {
+      throw new Error(`Lerc: Invalid output bandCount:${bytes.pixels.length} from:${source.source.url}`);
+    }
+
+    return {
+      pixels: bytes.pixels[0] as Float32Array,
+      width: bytes.width,
+      height: bytes.height,
+      channels: 1,
+      depth: 'float32',
+    };
+  },
+};
+
+export const Decompressors: Record<string, Decompressor> = {
+  [LercDecompressor.type]: LercDecompressor,
+  [Compression.Lerc]: LercDecompressor,
+};

--- a/packages/tiler-sharp/src/pipeline/decompressor.ts
+++ b/packages/tiler-sharp/src/pipeline/decompressor.ts
@@ -1,5 +1,4 @@
-import { ConfigRasterPipeline } from '@basemaps/config/build/config/tile.set.js';
-import { Tiff } from '@basemaps/shared';
+import { Tiff } from '@cogeotiff/core';
 
 export interface DecompressedInterleavedFloat {
   pixels: Float32Array;
@@ -27,9 +26,5 @@ export interface Decompressor {
 
 export interface Pipeline {
   type: string;
-  process(
-    source: Tiff,
-    bytes: DecompressedInterleaved,
-    pipeline: ConfigRasterPipeline,
-  ): Promise<DecompressedInterleaved> | DecompressedInterleaved;
+  process(source: Tiff, bytes: DecompressedInterleaved): Promise<DecompressedInterleaved> | DecompressedInterleaved;
 }

--- a/packages/tiler-sharp/src/pipeline/decompressor.ts
+++ b/packages/tiler-sharp/src/pipeline/decompressor.ts
@@ -1,0 +1,35 @@
+import { ConfigRasterPipeline } from '@basemaps/config/build/config/tile.set.js';
+import { Tiff } from '@basemaps/shared';
+
+export interface DecompressedInterleavedFloat {
+  pixels: Float32Array;
+  depth: 'float32';
+  channels: number;
+  width: number;
+  height: number;
+}
+
+export interface DecompressedInterleavedUint8 {
+  pixels: Uint8Array | Uint8ClampedArray;
+  depth: 'uint8';
+  channels: number;
+  width: number;
+  height: number;
+}
+
+// One buffer containing all bands
+export type DecompressedInterleaved = DecompressedInterleavedFloat | DecompressedInterleavedUint8;
+
+export interface Decompressor {
+  type: 'image/webp' | 'application/lerc';
+  bytes(source: Tiff, tile: ArrayBuffer): Promise<DecompressedInterleaved>;
+}
+
+export interface Pipeline {
+  type: string;
+  process(
+    source: Tiff,
+    bytes: DecompressedInterleaved,
+    pipeline: ConfigRasterPipeline,
+  ): Promise<DecompressedInterleaved> | DecompressedInterleaved;
+}

--- a/packages/tiler-sharp/src/pipeline/pipeline.color.ramp.ts
+++ b/packages/tiler-sharp/src/pipeline/pipeline.color.ramp.ts
@@ -1,0 +1,102 @@
+import { Tiff } from '@basemaps/shared';
+
+import { DecompressedInterleaved, Pipeline } from './decompressor.js';
+
+export class ColorRamp {
+  noData: { v: number; color: [number, number, number, number] } = { v: NaN, color: [0, 0, 0, 0] };
+  ramps: { v: number; color: [number, number, number, number] }[] = [];
+  constructor(ramp: string, noDataValue: number) {
+    const ramps = ramp.split('\n');
+
+    for (const ramp of ramps) {
+      const parts = ramp.trim().split(' ');
+      if (parts[0] === 'nv') {
+        this.noData = { v: noDataValue, color: parts.slice(1).map(Number) as [number, number, number, number] };
+        continue;
+      }
+      const numbers = parts.map(Number);
+      this.ramps.push({ v: numbers[0], color: numbers.slice(1) as [number, number, number, number] });
+    }
+  }
+
+  get(num: number): [number, number, number, number] {
+    if (num === this.noData.v) return this.noData.color;
+
+    const first = this.ramps[0];
+    if (num < first.v) return first.color;
+
+    for (let i = 0; i < this.ramps.length - 1; i++) {
+      const ramp = this.ramps[i];
+      const rampNext = this.ramps[i + 1];
+      if (num >= rampNext.v) continue;
+      if (num < ramp.v) continue;
+      if (ramp.v === num) return ramp.color;
+
+      const range = rampNext.v - ramp.v;
+      const offset = num - ramp.v;
+      const scale = offset / range;
+
+      const r = Math.round((rampNext.color[0] - ramp.color[0]) * scale + ramp.color[0]);
+      const g = Math.round((rampNext.color[1] - ramp.color[1]) * scale + ramp.color[1]);
+      const b = Math.round((rampNext.color[2] - ramp.color[2]) * scale + ramp.color[2]);
+      const a = Math.round((rampNext.color[3] - ramp.color[3]) * scale + ramp.color[3]);
+
+      return [r, g, b, a];
+    }
+    return this.ramps[this.ramps.length - 1].color;
+  }
+}
+
+// Stolen from https://github.com/andrewharvey/srtm-stylesheets/blob/master/stylesheets/color-ramps/srtm-Australia-color-ramp.gdaldem.txt
+export const ramp = new ColorRamp(
+  `nv 0 0 0 0
+-8764 0 0 0 255
+-4000 3 45 85 255
+-100 0 101 199 255
+0 192 224 255 255
+1 108 220 108 255
+55 50 180 50 255
+390 240 250 150 255
+835 190 185 135 255
+1114 180 128 107 255
+1392 235 220 220 255
+4000 215 244 244 255
+7000 255 255 255 255`,
+  -9999,
+);
+
+export const PipelineColorRamp: Pipeline = {
+  type: 'color-ramp',
+  process(source: Tiff, data: DecompressedInterleaved): DecompressedInterleaved {
+    const raw = new Uint8ClampedArray(data.width * data.height * 4);
+    const output: DecompressedInterleaved = {
+      pixels: raw,
+      depth: 'uint8',
+      channels: 4,
+      width: data.width,
+      height: data.height,
+    };
+
+    const size = data.width * data.height;
+    const noData = source.images[0].noData;
+
+    for (let i = 0; i < size; i++) {
+      const source = i * data.channels;
+
+      const px = data.pixels[source];
+
+      if (noData && px === noData) continue;
+
+      const target = i * 4;
+
+      const color = ramp.get(px);
+
+      raw[target + 0] = color[0];
+      raw[target + 1] = color[1];
+      raw[target + 2] = color[2];
+      raw[target + 3] = color[3];
+    }
+
+    return output;
+  },
+};

--- a/packages/tiler-sharp/src/pipeline/pipeline.color.ramp.ts
+++ b/packages/tiler-sharp/src/pipeline/pipeline.color.ramp.ts
@@ -1,4 +1,4 @@
-import { Tiff } from '@basemaps/shared';
+import { Tiff } from '@cogeotiff/core';
 
 import { DecompressedInterleaved, Pipeline } from './decompressor.js';
 

--- a/packages/tiler-sharp/src/pipeline/pipelines.ts
+++ b/packages/tiler-sharp/src/pipeline/pipelines.ts
@@ -1,0 +1,6 @@
+import { Pipeline } from './decompressor.js';
+import { PipelineColorRamp } from './pipeline.color.ramp.js';
+
+export const Pipelines: Record<string, Pipeline> = {
+  [PipelineColorRamp.type]: PipelineColorRamp,
+};

--- a/packages/tiler/src/raster.ts
+++ b/packages/tiler/src/raster.ts
@@ -1,3 +1,4 @@
+import { ConfigTileSetRasterOutput } from '@basemaps/config';
 import { ImageFormat, Point, Size } from '@basemaps/geo';
 import { Tiff } from '@cogeotiff/core';
 import { Cotar } from '@cotar/core';
@@ -12,7 +13,7 @@ export type TileMakerResizeKernel = { in: ResizeKernelType; out: ResizeKernelTyp
 
 export interface TileMakerContext {
   layers: Composition[];
-  format: ImageFormat;
+  output: ConfigTileSetRasterOutput;
   background: { r: number; g: number; b: number; alpha: number };
   resizeKernel: TileMakerResizeKernel;
   metrics?: Metrics;

--- a/packages/tiler/src/raster.ts
+++ b/packages/tiler/src/raster.ts
@@ -1,4 +1,3 @@
-import { ConfigTileSetRasterOutput } from '@basemaps/config';
 import { ImageFormat, Point, Size } from '@basemaps/geo';
 import { Tiff } from '@cogeotiff/core';
 import { Cotar } from '@cotar/core';
@@ -13,8 +12,15 @@ export type TileMakerResizeKernel = { in: ResizeKernelType; out: ResizeKernelTyp
 
 export interface TileMakerContext {
   layers: Composition[];
-  output: ConfigTileSetRasterOutput;
+  /** Apply a processing pipeline to each layer */
+  pipeline?: { type: string }[];
+  /** Image output format type */
+  format: ImageFormat;
+  /** Should the output image be lossless */
+  lossless?: boolean;
+  /** Default background to use */
   background: { r: number; g: number; b: number; alpha: number };
+  /** Default resize parameters */
   resizeKernel: TileMakerResizeKernel;
   metrics?: Metrics;
 }


### PR DESCRIPTION
#### Motivation

To allow more complex dynamic rendering options, We need a way to specifiy a pipeline full of processing steps to be run on the raw imagery to create a 4 band RGBA output.


#### Modification

Adds a pipeline to imagery rendering 

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
