### PR TITLE
fix: only allow f32 lerc

### DIFF
--- a/packages/tiler-sharp/src/pipeline/decompressor.lerc.ts
+++ b/packages/tiler-sharp/src/pipeline/decompressor.lerc.ts
@@ -3,22 +3,13 @@ import Lerc from 'lerc';
 
 import { DecompressedInterleaved, Decompressor } from './decompressor.js';
 
-function lercDepth(s: string): string {
-  switch (s) {
-    case 'F32':
-      return 'float';
-    default:
-      throw new Error('Unknown LERC Byte depth: ' + s);
-  }
-}
-
 export const LercDecompressor: Decompressor = {
   type: 'application/lerc',
   async bytes(source: Tiff, tile: ArrayBuffer): Promise<DecompressedInterleaved> {
     await Lerc.load();
     const bytes = Lerc.decode(tile);
 
-    if (lercDepth(bytes.pixelType) !== 'float') {
+    if (bytes.pixelType !== 'F32') {
       throw new Error(`Lerc: Invalid output pixelType:${bytes.pixelType} from:${source.source.url}`);
     }
     if (bytes.depthCount !== 1) {

--- a/packages/tiler-sharp/src/pipeline/pipeline.color.ramp.ts
+++ b/packages/tiler-sharp/src/pipeline/pipeline.color.ramp.ts
@@ -85,7 +85,7 @@ export const PipelineColorRamp: Pipeline = {
 
       const px = data.pixels[source];
 
-      if (noData && px === noData) continue;
+      if (noData != null && px === noData) continue;
 
       const target = i * 4;
 


### PR DESCRIPTION
#### Motivation

We currently only have and expect float32 Lerc files, so lets error if we get something different.

#### Modification

Dissallows anything other than float32 for lerc


#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
