### PR TITLE
feat(tiler-sharp): allow outputs to customise how output is compressed

### DIFF
--- a/packages/config/src/config/tile.set.ts
+++ b/packages/config/src/config/tile.set.ts
@@ -107,6 +107,13 @@ export interface ConfigTileSetRasterOutput {
      * {@link ConfigTileSetRaster.background} if not defined
      */
     background?: { r: number; g: number; b: number; alpha: number };
+
+    /**
+     * When scaling tiles in the rendering process what kernel to use
+     *
+     * will fall back to  {@link ConfigTileSetRaster.background} if not defined
+     */
+    resizeKernel?: { in: TileResizeKernel; out: TileResizeKernel };
   };
 }
 

--- a/packages/lambda-tiler/src/routes/preview.ts
+++ b/packages/lambda-tiler/src/routes/preview.ts
@@ -147,12 +147,14 @@ export async function renderPreview(req: LambdaHttpRequest, ctx: PreviewRenderCo
     compositions.push(...result);
   }
 
+  const tileOutput = ctx.output;
   const tileContext = {
     layers: compositions,
-    format: ctx.output.output.type,
-    lossless: ctx.output.output.lossless,
-    background: ctx.output.output.background ?? ctx.tileSet.background ?? DefaultBackground,
-    resizeKernel: DefaultResizeKernel,
+    pipeline: tileOutput.pipeline,
+    format: tileOutput.output.type,
+    lossless: tileOutput.output.lossless,
+    background: tileOutput.output.background ?? ctx.tileSet.background ?? DefaultBackground,
+    resizeKernel: tileOutput.output.resizeKernel ?? ctx.tileSet.resizeKernel ?? DefaultResizeKernel,
   };
 
   // Load all the tiff tiles and resize/them into the correct locations

--- a/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
+++ b/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
@@ -139,7 +139,7 @@ export const TileXyzRaster = {
       format: tileOutput.output.type,
       lossless: tileOutput.output.lossless,
       background: tileOutput.output.background ?? tileSet.background ?? DefaultBackground,
-      resizeKernel: { in: 'nearest', out: 'nearest' },
+      resizeKernel: tileOutput.output.resizeKernel ?? tileSet.resizeKernel ?? DefaultResizeKernel,
       metrics: req.timer,
     });
 

--- a/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
+++ b/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
@@ -139,7 +139,7 @@ export const TileXyzRaster = {
       format: tileOutput.output.type,
       lossless: tileOutput.output.lossless,
       background: tileOutput.output.background ?? tileSet.background ?? DefaultBackground,
-      resizeKernel: tileSet.resizeKernel ?? DefaultResizeKernel,
+      resizeKernel: { in: 'nearest', out: 'nearest' },
       metrics: req.timer,
     });
 

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -28,7 +28,13 @@ export async function loadConfig(opts: ServerOptions, logger: LogType): Promise<
   if ('paths' in opts) {
     const mem = new ConfigProviderMemory();
     const ret = await initConfigFromUrls(mem, opts.paths);
-    logger.info({ tileSet: ret.tileSet.name, layers: ret.tileSet.layers.length }, 'TileSet:Loaded');
+    for (const ts of ret.tileSets) {
+      logger.info(
+        { tileSet: ts.name, layers: ts.layers.length, outputs: ts.outputs?.map((f) => f.name) },
+        'TileSet:Loaded',
+      );
+    }
+
     for (const im of ret.imagery) {
       logger.info(
         { imagery: im.uri, title: im.title, tileMatrix: im.tileMatrix, files: im.files.length },

--- a/packages/tiler-sharp/src/index.ts
+++ b/packages/tiler-sharp/src/index.ts
@@ -66,12 +66,12 @@ export class TileMakerSharp implements TileMaker {
   toImage(format: ImageFormat, pipeline: Sharp.Sharp, lossless?: boolean): Promise<Buffer> {
     switch (format) {
       case 'jpeg':
-        if (lossless) throw new Error('Jpeg is not lossless');
+        if (lossless) throw new Error('lossless jpeg is not defined');
         return pipeline.jpeg().toBuffer();
       case 'png':
         return pipeline.png().toBuffer();
       case 'webp':
-        // if (lossless) return pipeline.webp({ lossless: true, quality: 100, alphaQuality: 100 }).toBuffer();
+        if (lossless) return pipeline.webp({ lossless: true, quality: 100, alphaQuality: 100 }).toBuffer();
         return pipeline.webp().toBuffer();
       case 'avif':
         if (lossless) throw new Error('lossless avif is not defined');

--- a/packages/tiler-sharp/src/index.ts
+++ b/packages/tiler-sharp/src/index.ts
@@ -71,8 +71,8 @@ export class TileMakerSharp implements TileMaker {
       case 'png':
         return pipeline.png().toBuffer();
       case 'webp':
-        if (lossless) return pipeline.webp({ lossless: true, quality: 100, alphaQuality: 100 }).toBuffer();
-        return pipeline.webp({}).toBuffer();
+        // if (lossless) return pipeline.webp({ lossless: true, quality: 100, alphaQuality: 100 }).toBuffer();
+        return pipeline.webp().toBuffer();
       case 'avif':
         if (lossless) throw new Error('lossless avif is not defined');
         return pipeline.avif().toBuffer();


### PR DESCRIPTION
#### Motivation

TerrainRGB needs to be lossless compressed, this adds the abilities for pipelines to customise how they create the output eg resizeKernels and lossless parameters

#### Modification

allows outputs to define resize kernels

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
