### PR TITLE
feat: move to query parameters for pipeline selection

### DIFF
--- a/packages/_infra/src/edge/index.ts
+++ b/packages/_infra/src/edge/index.ts
@@ -103,7 +103,7 @@ export class EdgeStack extends cdk.Stack {
           forwardedValues: {
             /** Forward all query strings but do not use them for caching */
             queryString: true,
-            queryStringCacheKeys: ['config', 'exclude'].map(encodeURIComponent),
+            queryStringCacheKeys: ['config', 'exclude', 'pipeline'].map(encodeURIComponent),
           },
           lambdaFunctionAssociations: [],
         },
@@ -118,6 +118,7 @@ export class EdgeStack extends cdk.Stack {
               'exclude',
               'tileMatrix',
               'style',
+              'pipeline',
               // Deprecated single character query params for style and projection
               's',
               'p',

--- a/packages/config-loader/src/json/tiff.config.ts
+++ b/packages/config-loader/src/json/tiff.config.ts
@@ -16,6 +16,7 @@ import { fileURLToPath } from 'url';
 
 import { ConfigJson, isEmptyTiff } from './json.config.js';
 import { LogType } from './log.js';
+import { DefaultColorRamp, DefaultTerrainRgb } from './tileset.output.js';
 
 /** Does a file look like a tiff, ending in .tif or .tiff */
 function isTiff(f: URL): boolean {
@@ -446,29 +447,11 @@ export async function initConfigFromUrls(
   const elevationTileSet: ConfigTileSetRaster = {
     id: 'ts_elevation',
     name: 'elevation',
-    title: 'Basemaps',
+    title: 'Elevation Basemap',
     category: 'Basemaps',
     type: TileSetType.Raster,
     layers: [],
-    outputs: [
-      {
-        title: 'TerrainRGB',
-        name: 'terrain-rgb',
-        pipeline: [{ type: 'terrain-rgb' }],
-        output: {
-          type: 'webp',
-          lossless: true,
-          background: { r: 1, g: 134, b: 160, alpha: 1 },
-          resizeKernel: { in: 'nearest', out: 'nearest' },
-        },
-      },
-      {
-        title: 'Color ramp',
-        name: 'color-ramp',
-        pipeline: [{ type: 'color-ramp' }],
-        output: { type: 'webp' },
-      },
-    ],
+    outputs: [DefaultTerrainRgb, DefaultColorRamp],
   };
 
   provider.put(aerialTileSet);
@@ -489,11 +472,13 @@ export async function initConfigFromUrls(
         elevationTileSet.layers.push(existingLayer);
       }
       existingLayer[cfg.projection] = cfg.id;
-      provider.put(elevationTileSet);
-      tileSets.push(elevationTileSet);
+      if (!provider.objects.has(elevationTileSet.id)) {
+        provider.put(elevationTileSet);
+        tileSets.push(elevationTileSet);
+      }
     }
   }
-  // FIXME: this should return all the tile sets that were created
+  // FIXME: tileSet should be removed now that we are returning all tilesets
   return { tileSet: aerialTileSet, tileSets, imagery: configs };
 }
 

--- a/packages/config-loader/src/json/tiff.config.ts
+++ b/packages/config-loader/src/json/tiff.config.ts
@@ -2,6 +2,8 @@ import {
   ConfigImagery,
   ConfigProviderMemory,
   ConfigTileSetRaster,
+  DefaultColorRampOutput,
+  DefaultTerrainRgbOutput,
   ImageryDataType,
   sha256base58,
   TileSetType,
@@ -16,7 +18,6 @@ import { fileURLToPath } from 'url';
 
 import { ConfigJson, isEmptyTiff } from './json.config.js';
 import { LogType } from './log.js';
-import { DefaultColorRamp, DefaultTerrainRgb } from './tileset.output.js';
 
 /** Does a file look like a tiff, ending in .tif or .tiff */
 function isTiff(f: URL): boolean {
@@ -451,7 +452,7 @@ export async function initConfigFromUrls(
     category: 'Basemaps',
     type: TileSetType.Raster,
     layers: [],
-    outputs: [DefaultTerrainRgb, DefaultColorRamp],
+    outputs: [DefaultTerrainRgbOutput, DefaultColorRampOutput],
   };
 
   provider.put(aerialTileSet);

--- a/packages/config/src/config/tile.set.output.ts
+++ b/packages/config/src/config/tile.set.output.ts
@@ -1,0 +1,23 @@
+import { ConfigTileSetRasterOutput } from './tile.set.js';
+
+export const DefaultTerrainRgbOutput: ConfigTileSetRasterOutput = {
+  title: 'TerrainRGB',
+  name: 'terrain-rgb',
+  pipeline: [{ type: 'terrain-rgb' }],
+  output: {
+    // terrain rgb cannot be resampled after it has been made
+    lossless: true,
+    // Zero encoded as a TerrainRGB
+    background: { r: 1, g: 134, b: 160, alpha: 1 },
+    resizeKernel: { in: 'nearest', out: 'nearest' },
+  },
+} as const;
+
+export const DefaultColorRampOutput: ConfigTileSetRasterOutput = {
+  title: 'Color ramp',
+  name: 'color-ramp',
+  pipeline: [{ type: 'color-ramp' }],
+  output: {
+    background: { r: 1, g: 134, b: 160, alpha: 1 },
+  },
+} as const;

--- a/packages/config/src/config/tile.set.ts
+++ b/packages/config/src/config/tile.set.ts
@@ -92,10 +92,20 @@ export interface ConfigTileSetRasterOutput {
    */
   pipeline?: ConfigRasterPipeline[];
 
-  /** Raster output format */
-  output: {
-    /** Output file format to use */
-    type: ImageFormat;
+  /**
+   * Raster output format
+   * if none is provided it is assumed to be a RGBA output allowing all image formats
+   */
+  output?: {
+    /**
+     * Allowed output file format to use
+     *
+     * Will default to all image formats
+     * if "lossless" is set then lossless image formats
+     *
+     * @default ImageFormat[] - All Image formats
+     */
+    type?: ImageFormat[];
     /**
      * should the output be lossless
      *
@@ -111,7 +121,7 @@ export interface ConfigTileSetRasterOutput {
     /**
      * When scaling tiles in the rendering process what kernel to use
      *
-     * will fall back to  {@link ConfigTileSetRaster.background} if not defined
+     * will fall back to {@link ConfigTileSetRaster.background} if not defined
      */
     resizeKernel?: { in: TileResizeKernel; out: TileResizeKernel };
   };

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -22,6 +22,7 @@ export {
   TileResizeKernel,
   TileSetType,
 } from './config/tile.set.js';
+export { DefaultColorRampOutput, DefaultTerrainRgbOutput } from './config/tile.set.output.js';
 export { ConfigVectorStyle, Layer, Sources, StyleJson } from './config/vector.style.js';
 export { ConfigBundled, ConfigProviderMemory } from './memory/memory.config.js';
 export { standardizeLayerName } from './name.convertor.js';

--- a/packages/lambda-tiler/src/cli/render.preview.ts
+++ b/packages/lambda-tiler/src/cli/render.preview.ts
@@ -39,7 +39,7 @@ async function main(): Promise<void> {
     tileSet,
     location,
     z,
-    output: { title: outputFormat, output: { type: outputFormat }, name: 'rgba' },
+    output: { title: outputFormat, output: { type: [outputFormat] }, name: 'rgba' },
   });
   const previewFile = fsa.toUrl(`./z${z}_${location.lon}_${location.lat}.${outputFormat}`);
   await fsa.write(previewFile, Buffer.from(res.body, 'base64'));

--- a/packages/lambda-tiler/src/index.ts
+++ b/packages/lambda-tiler/src/index.ts
@@ -73,7 +73,7 @@ handler.router.get('/v1/tiles/:tileSet/:tileMatrix/style/:styleName.json', style
 handler.router.get('/v1/tiles/:tileSet/:tileMatrix/tile.json', tileJsonGet);
 
 // Tiles
-handler.router.get('/v1/tiles/:tileSet/:tileMatrix/:z(^\\d+)/:x(^\\d+)/:y(^\\d+):tileType', tileXyzGet);
+handler.router.get('/v1/tiles/:tileSet/:tileMatrix/:z/:x/:y.:tileType', tileXyzGet);
 
 // Preview
 handler.router.get('/v1/preview/:tileSet/:tileMatrix/:z/:lon/:lat', tilePreviewGet);

--- a/packages/lambda-tiler/src/routes/tile.style.json.ts
+++ b/packages/lambda-tiler/src/routes/tile.style.json.ts
@@ -74,9 +74,10 @@ export async function tileSetToStyle(
   if (tileFormat == null) return new LambdaHttpResponse(400, 'Invalid image format');
 
   const pipeline = Validate.pipeline(tileSet, tileFormat, req.query.get('pipeline'));
+  const pipelineName = pipeline?.name === 'rgba' ? undefined : pipeline?.name;
 
   const configLocation = ConfigLoader.extract(req);
-  const query = toQueryString({ config: configLocation, api: apiKey, ...getFilters(req), pipeline: pipeline?.name });
+  const query = toQueryString({ config: configLocation, api: apiKey, ...getFilters(req), pipeline: pipelineName });
 
   const tileUrl =
     (Env.get(Env.PublicUrlBase) ?? '') +

--- a/packages/lambda-tiler/src/routes/tile.style.json.ts
+++ b/packages/lambda-tiler/src/routes/tile.style.json.ts
@@ -73,8 +73,10 @@ export async function tileSetToStyle(
   const [tileFormat] = Validate.getRequestedFormats(req) ?? ['webp'];
   if (tileFormat == null) return new LambdaHttpResponse(400, 'Invalid image format');
 
+  const pipeline = Validate.pipeline(tileSet, tileFormat, req.query.get('pipeline'));
+
   const configLocation = ConfigLoader.extract(req);
-  const query = toQueryString({ config: configLocation, api: apiKey, ...getFilters(req) });
+  const query = toQueryString({ config: configLocation, api: apiKey, ...getFilters(req), pipeline: pipeline?.name });
 
   const tileUrl =
     (Env.get(Env.PublicUrlBase) ?? '') +

--- a/packages/landing/src/url.ts
+++ b/packages/landing/src/url.ts
@@ -29,6 +29,7 @@ export interface TileUrlParams {
   layerId: string;
   style?: string | null;
   config?: string | null;
+  pipeline?: string | null;
   date?: FilterDate;
 }
 
@@ -66,6 +67,7 @@ export const WindowUrl = {
     const queryParams = new URLSearchParams();
     if (Config.ApiKey != null && Config.ApiKey !== '') queryParams.set('api', Config.ApiKey);
     if (params.config != null) queryParams.set('config', ensureBase58(params.config));
+    if (params.pipeline != null) queryParams.set('pipeline', params.pipeline);
     if (params.date?.before != null) queryParams.set('date[before]', params.date.before);
 
     if (params.urlType === MapOptionType.Style) {

--- a/packages/server/src/route.layers.ts
+++ b/packages/server/src/route.layers.ts
@@ -18,6 +18,7 @@ export async function createLayersHtml(mem: BasemapsConfigProvider): Promise<str
   for (const img of layers) {
     let tileMatrix = TileMatrixSets.find(img.tileMatrix);
     if (tileMatrix == null) tileMatrix = GoogleTms;
+
     const ret = getPreviewUrl(img, previewSize);
 
     const els = [
@@ -32,7 +33,10 @@ export async function createLayersHtml(mem: BasemapsConfigProvider): Promise<str
     cards.push(
       V(
         'a',
-        { class: `layer layer-${img.id}`, href: `/?p=${tileMatrix.projection.code}&i=${ret.name}#${ret.locationHash}` },
+        {
+          class: `layer layer-${img.id}`,
+          href: `/?tileMatrix=${tileMatrix.identifier}&style=${ret.name}#${ret.locationHash}`,
+        },
         els,
       ),
     );

--- a/packages/shared/src/imagery.url.ts
+++ b/packages/shared/src/imagery.url.ts
@@ -22,6 +22,7 @@ export function getImageryCenterZoom(im: ConfigImagery, previewSize: Size): { la
 export function getPreviewUrl(
   im: ConfigImagery,
   previewSize: Size = PreviewSize,
+  pipeline?: string,
 ): {
   url: string;
   name: string;
@@ -34,11 +35,13 @@ export function getPreviewUrl(
   const lon = location.lon.toFixed(7);
   const locationHash = `@${lat},${lon},z${location.zoom}`;
 
+  const query = pipeline ? `?pipeline=${pipeline}` : '';
+
   const name = standardizeLayerName(im.name);
   return {
     name,
     location,
     locationHash,
-    url: `/v1/preview/${name}/${im.tileMatrix}/${targetZoom}/${lon}/${lat}`,
+    url: `/v1/preview/${name}/${im.tileMatrix}/${targetZoom}/${lon}/${lat}${query}`,
   };
 }


### PR DESCRIPTION
#### Motivation

inline parameters in the  URL were hard to parse and did not allow for future expansion of pipeline configuration, by moving to a query parameter the pipline can be configured easier and has opportunities for expansion later.

#### Modification

switches from a inline url to a query parameter for pipline selection

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
