### PR TITLE
feat(landing): add example of maplibre elevation with terrain-rgb

### DIFF
--- a/packages/landing/static/examples/index.maplibre.elevation.html
+++ b/packages/landing/static/examples/index.maplibre.elevation.html
@@ -31,10 +31,11 @@
       const apiKey = localStorage.getItem('api-key');
       if (apiKey == null) throw new Error('Missing api-key in localStorage');
 
-      const startPos = [173, -40.5];
-      const startZoom = 6;
 
       var map = new maplibregl.Map({
+        hash: true,
+        center: [173, -40.5], 
+        zoom: 6, 
         container: 'map', // container id
         style: {
           version: 8,
@@ -75,10 +76,8 @@
             source: 'terrainSource',
             exaggeration: 1,
           },
-        }, // style URL
-        hash: true,
-        center: startPos, // starting position [lng, lat]
-        zoom: startZoom, // starting zoom
+        },
+
       });
       map.addControl(
         new maplibregl.NavigationControl({

--- a/packages/landing/static/examples/index.maplibre.elevation.html
+++ b/packages/landing/static/examples/index.maplibre.elevation.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>Maplibre WGS84 Topographic Vector Basemaps Demo</title>
+    <title>Maplibre Elevation With Terrain-rgb Demo</title>
     <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
     <script
       src="https://unpkg.com/maplibre-gl@4.0.1/dist/maplibre-gl.js"

--- a/packages/landing/static/examples/index.maplibre.elevation.html
+++ b/packages/landing/static/examples/index.maplibre.elevation.html
@@ -1,99 +1,99 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
-
-<head>
+  <head>
     <meta charset="utf-8" />
     <title>Maplibre WGS84 Topographic Vector Basemaps Demo</title>
     <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
-    <script src="https://unpkg.com/maplibre-gl@4.0.1/dist/maplibre-gl.js"
-        integrity="sha384-QjD9FqfhisGHV+cOv+EZTmWGaKkTJgx6gRP7pgmyQns3aWACZb18pTpxTmRRAaDF"
-        crossorigin="anonymous"></script>
+    <script
+      src="https://unpkg.com/maplibre-gl@4.0.1/dist/maplibre-gl.js"
+      integrity="sha384-QjD9FqfhisGHV+cOv+EZTmWGaKkTJgx6gRP7pgmyQns3aWACZb18pTpxTmRRAaDF"
+      crossorigin="anonymous"
+    ></script>
     <link href="https://unpkg.com/maplibre-gl@4.0.1/dist/maplibre-gl.css" rel="stylesheet" />
     <style>
-        body {
-            margin: 0;
-            padding: 0;
-        }
+      body {
+        margin: 0;
+        padding: 0;
+      }
 
-        #map {
-            position: absolute;
-            top: 0;
-            bottom: 0;
-            width: 100%;
-        }
+      #map {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        width: 100%;
+      }
     </style>
-</head>
+  </head>
 
-<body>
+  <body>
     <div id="map"></div>
     <script>
-        const apiKey = localStorage.getItem('api-key');
-        if (apiKey == null) throw new Error('Missing api-key in localStorage');
+      const apiKey = localStorage.getItem('api-key');
+      if (apiKey == null) throw new Error('Missing api-key in localStorage');
 
-        const startPos = [173, -40.5];
-        const startZoom = 6;
+      const startPos = [173, -40.5];
+      const startZoom = 6;
 
-        var map = new maplibregl.Map({
-            container: 'map', // container id
-            style: {
-                version: 8,
-                sources: {
-                    osm: {
-                        type: 'raster',
-                        tiles: ['/v1/tiles/aerial/WebMercatorQuad/{z}/{x}/{y}.webp?api=' + apiKey],
-                        tileSize: 256,
-                        maxzoom: 22
-                    },
-                    // Use a different source for terrain and hillshade layers, to improve render quality
-                    terrainSource: {
-                        type: 'raster-dem',
-                        tiles: ['/v1/tiles/elevation/WebMercatorQuad/{z}/{x}/{y}.png?pipeline=terrain-rgb&api=' + apiKey],
-                        tileSize: 256
-                    },
-                    hillshadeSource: {
-                        type: 'raster-dem',
-                        tiles: ['/v1/tiles/elevation/WebMercatorQuad/{z}/{x}/{y}.png?pipeline=terrain-rgb&api=' + apiKey],
-                        tileSize: 256
-                    }
-                },
-                layers: [
-                    {
-                        id: 'osm',
-                        type: 'raster',
-                        source: 'osm'
-                    },
-                    {
-                        id: 'hills',
-                        type: 'hillshade',
-                        source: 'hillshadeSource',
-                        layout: { visibility: 'visible' },
-                        paint: { 'hillshade-shadow-color': '#473B24' }
-                    }
-                ],
-                terrain: {
-                    source: 'terrainSource',
-                    exaggeration: 1
-                }
-            }, // style URL
-            hash: true,
-            center: startPos, // starting position [lng, lat]
-            zoom: startZoom, // starting zoom
-        });
-        map.addControl(
-            new maplibregl.NavigationControl({
-                visualizePitch: true,
-                showZoom: true,
-                showCompass: true
-            })
-        );
+      var map = new maplibregl.Map({
+        container: 'map', // container id
+        style: {
+          version: 8,
+          sources: {
+            osm: {
+              type: 'raster',
+              tiles: ['/v1/tiles/aerial/WebMercatorQuad/{z}/{x}/{y}.webp?api=' + apiKey],
+              tileSize: 256,
+              maxzoom: 22,
+            },
+            // Use a different source for terrain and hillshade layers, to improve render quality
+            terrainSource: {
+              type: 'raster-dem',
+              tiles: ['/v1/tiles/elevation/WebMercatorQuad/{z}/{x}/{y}.png?pipeline=terrain-rgb&api=' + apiKey],
+              tileSize: 256,
+            },
+            hillshadeSource: {
+              type: 'raster-dem',
+              tiles: ['/v1/tiles/elevation/WebMercatorQuad/{z}/{x}/{y}.png?pipeline=terrain-rgb&api=' + apiKey],
+              tileSize: 256,
+            },
+          },
+          layers: [
+            {
+              id: 'osm',
+              type: 'raster',
+              source: 'osm',
+            },
+            {
+              id: 'hills',
+              type: 'hillshade',
+              source: 'hillshadeSource',
+              layout: { visibility: 'visible' },
+              paint: { 'hillshade-shadow-color': '#473B24' },
+            },
+          ],
+          terrain: {
+            source: 'terrainSource',
+            exaggeration: 1,
+          },
+        }, // style URL
+        hash: true,
+        center: startPos, // starting position [lng, lat]
+        zoom: startZoom, // starting zoom
+      });
+      map.addControl(
+        new maplibregl.NavigationControl({
+          visualizePitch: true,
+          showZoom: true,
+          showCompass: true,
+        }),
+      );
 
-        map.addControl(
-            new maplibregl.TerrainControl({
-                source: 'terrainSource',
-                exaggeration: 1
-            })
-        );
+      map.addControl(
+        new maplibregl.TerrainControl({
+          source: 'terrainSource',
+          exaggeration: 1,
+        }),
+      );
     </script>
-</body>
-
+  </body>
 </html>

--- a/packages/landing/static/examples/index.maplibre.elevation.html
+++ b/packages/landing/static/examples/index.maplibre.elevation.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="utf-8" />
+    <title>Maplibre WGS84 Topographic Vector Basemaps Demo</title>
+    <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
+    <script src="https://unpkg.com/maplibre-gl@4.0.1/dist/maplibre-gl.js"
+        integrity="sha384-QjD9FqfhisGHV+cOv+EZTmWGaKkTJgx6gRP7pgmyQns3aWACZb18pTpxTmRRAaDF"
+        crossorigin="anonymous"></script>
+    <link href="https://unpkg.com/maplibre-gl@4.0.1/dist/maplibre-gl.css" rel="stylesheet" />
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+        }
+
+        #map {
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            width: 100%;
+        }
+    </style>
+</head>
+
+<body>
+    <div id="map"></div>
+    <script>
+        const apiKey = localStorage.getItem('api-key');
+        if (apiKey == null) throw new Error('Missing api-key in localStorage');
+
+        const startPos = [173, -40.5];
+        const startZoom = 6;
+
+        var map = new maplibregl.Map({
+            container: 'map', // container id
+            style: {
+                version: 8,
+                sources: {
+                    osm: {
+                        type: 'raster',
+                        tiles: ['/v1/tiles/aerial/WebMercatorQuad/{z}/{x}/{y}.webp?api=' + apiKey],
+                        tileSize: 256,
+                        maxzoom: 22
+                    },
+                    // Use a different source for terrain and hillshade layers, to improve render quality
+                    terrainSource: {
+                        type: 'raster-dem',
+                        tiles: ['/v1/tiles/elevation/WebMercatorQuad/{z}/{x}/{y}.png?pipeline=terrain-rgb&api=' + apiKey],
+                        tileSize: 256
+                    },
+                    hillshadeSource: {
+                        type: 'raster-dem',
+                        tiles: ['/v1/tiles/elevation/WebMercatorQuad/{z}/{x}/{y}.png?pipeline=terrain-rgb&api=' + apiKey],
+                        tileSize: 256
+                    }
+                },
+                layers: [
+                    {
+                        id: 'osm',
+                        type: 'raster',
+                        source: 'osm'
+                    },
+                    {
+                        id: 'hills',
+                        type: 'hillshade',
+                        source: 'hillshadeSource',
+                        layout: { visibility: 'visible' },
+                        paint: { 'hillshade-shadow-color': '#473B24' }
+                    }
+                ],
+                terrain: {
+                    source: 'terrainSource',
+                    exaggeration: 1
+                }
+            }, // style URL
+            hash: true,
+            center: startPos, // starting position [lng, lat]
+            zoom: startZoom, // starting zoom
+        });
+        map.addControl(
+            new maplibregl.NavigationControl({
+                visualizePitch: true,
+                showZoom: true,
+                showCompass: true
+            })
+        );
+
+        map.addControl(
+            new maplibregl.TerrainControl({
+                source: 'terrainSource',
+                exaggeration: 1
+            })
+        );
+    </script>
+</body>
+
+</html>

--- a/packages/landing/static/examples/index.maplibre.elevation.html
+++ b/packages/landing/static/examples/index.maplibre.elevation.html
@@ -31,11 +31,10 @@
       const apiKey = localStorage.getItem('api-key');
       if (apiKey == null) throw new Error('Missing api-key in localStorage');
 
-
       var map = new maplibregl.Map({
         hash: true,
-        center: [173, -40.5], 
-        zoom: 6, 
+        center: [173, -40.5],
+        zoom: 6,
         container: 'map', // container id
         style: {
           version: 8,
@@ -77,7 +76,6 @@
             exaggeration: 1,
           },
         },
-
       });
       map.addControl(
         new maplibregl.NavigationControl({


### PR DESCRIPTION
#### Motivation

To give users a idea of how to interact with elevation services, add a example of using terrain-rgb to create a hillshade and 3d map view in maplibre

![image](https://github.com/linz/basemaps/assets/1082761/d20b1b56-b81c-4684-be80-3a945ad9ad29)


#### Modification

adds a maplibre 3d/hillshade example.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
