### PR TITLE
feat(smoke): add tests to validate tiles are served BM-975

### DIFF
--- a/packages/smoke/src/base.ts
+++ b/packages/smoke/src/base.ts
@@ -14,7 +14,6 @@ const Cors = { origin: 'https://example.com' };
 const host = new URL(process.env['BASEMAPS_HOST'] || 'https://dev.basemaps.linz.govt.nz');
 
 if (!host.protocol.startsWith('http')) throw new Error(`Invalid host: ${host}`);
-// if (host.endsWith('/')) host = host.slice(0, host.length - 1);
 
 /**
  * Request a url with options

--- a/packages/smoke/src/base.ts
+++ b/packages/smoke/src/base.ts
@@ -5,23 +5,25 @@ import ulid from 'ulid';
 
 const logger = LogConfig.get();
 /** Fresh API Key to use */
-const apiKey = 'c' + ulid.ulid().toLowerCase();
+const apiKey = 'c' + ulid.ulid().toLowerCase().slice(0, 22) + 'test';
 
 /** Http headers required to trigger CORS */
 const Cors = { origin: 'https://example.com' };
 
 /** Host that is being tested */
-let host = process.env['BASEMAPS_HOST'] || 'https://dev.basemaps.linz.govt.nz';
+const host = new URL(process.env['BASEMAPS_HOST'] || 'https://dev.basemaps.linz.govt.nz');
 
-if (!host.startsWith('http')) throw new Error(`Invalid host: ${host}`);
-if (host.endsWith('/')) host = host.slice(0, host.length - 1);
+if (!host.protocol.startsWith('http')) throw new Error(`Invalid host: ${host}`);
+// if (host.endsWith('/')) host = host.slice(0, host.length - 1);
 
-/** Request a url with options
+/**
+ * Request a url with options
  *
  * @example
  * ```typescript
  * await req('/v1/version')
  * await req('/v1/version', { method: 'OPTIONS' })
+ * await req(`/v1/version?api=${ctx.apiKey}`)
  * ````
  */
 async function req(path: string, opts?: RequestInit): Promise<Response> {
@@ -29,10 +31,7 @@ async function req(path: string, opts?: RequestInit): Promise<Response> {
   logger.trace({ path, url: target.href }, 'Fetch');
   const startTime = performance.now();
   const res = await fetch(target, opts);
-  logger.info(
-    { path, url: target.href, status: res.status, ...opts, duration: performance.now() - startTime },
-    'Fetch:Done',
-  );
+  logger.info({ url: target.href, status: res.status, ...opts, duration: performance.now() - startTime }, 'Fetch:Done');
   return res;
 }
 

--- a/packages/smoke/src/fonts.ts
+++ b/packages/smoke/src/fonts.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { ctx } from './base.js';
+
+describe('fonts', () => {
+  it('GET /v1/fonts.json', async () => {
+    const res = await ctx.req('/v1/fonts.json');
+    assert.equal(res.status, 200);
+    const data = await res.json();
+    assert.ok(data.length > 0);
+    assert.ok(data.includes('Noto Sans Regular'));
+  });
+
+  it('GET /v1/fonts/Noto Sans Bold/0-255.pbf', async () => {
+    const res = await ctx.req('/v1/fonts/Noto Sans Bold/0-255.pbf');
+    assert.equal(res.status, 200);
+  });
+});

--- a/packages/smoke/src/tile.test.ts
+++ b/packages/smoke/src/tile.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { ctx } from './base.js';
+
+describe('tile', () => {
+  it('should serve a NZTM2000Quad', async () => {
+    const res = await ctx.req(`/v1/tiles/aerial/NZTM2000Quad/16/33757/30417.webp?api=${ctx.apiKey}`);
+    assert.equal(res.status, 200, res.statusText);
+    const body = Buffer.from(await res.arrayBuffer());
+    assert.equal(body.subarray(0, 4).toString(), 'RIFF');
+  });
+
+  it('should serve a tile as WebMercatorQuad', async () => {
+    const res = await ctx.req(`/v1/tiles/aerial/WebMercatorQuad/17/129506/80410.webp?api=${ctx.apiKey}`);
+    assert.equal(res.status, 200, res.statusText);
+
+    const body = Buffer.from(await res.arrayBuffer());
+    assert.equal(body.subarray(0, 4).toString(), 'RIFF');
+  });
+
+  it('should serve a vector tile', async () => {
+    const res = await ctx.req(`/v1/tiles/topographic/WebMercatorQuad/15/32267/19905.pbf?api=${ctx.apiKey}`);
+    assert.equal(res.status, 200, res.statusText);
+  });
+
+  for (const ext of ['png', 'jpeg', 'avif']) {
+    it(`should serve a ${ext} tile`, async () => {
+      const res = await ctx.req(`/v1/tiles/aerial/WebMercatorQuad/6/62/40.${ext}?api=${ctx.apiKey}`);
+      assert.equal(res.status, 200);
+      assert.equal(res.headers.get('content-type'), `image/${ext}`);
+    });
+  }
+});


### PR DESCRIPTION
#### Motivation

To be more confident the deployed system is working as expected expand the smoke test coverage

#### Modification

add a few smoke tests to validate tiles are rendered and returned.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
