### PR TITLE
fix(cli): Fix the missing format for vector config with Basemaps v7.

### DIFF
--- a/packages/config/src/config/tile.set.ts
+++ b/packages/config/src/config/tile.set.ts
@@ -141,10 +141,10 @@ export interface ConfigTileSetVector extends ConfigTileSetBase {
   type: TileSetType.Vector;
 
   /**
-   * Vector output format
-   * Should be default to pbf format
+   * TODO: This is for supporting vector format with the new config Structure on Basemaps V7.
+   * We can remove this after release New Basemaps version.
    */
-  format: VectorFormat;
+  format?: VectorFormat;
 }
 
 export type ConfigTileSet = ConfigTileSetVector | ConfigTileSetRaster;

--- a/packages/config/src/config/tile.set.ts
+++ b/packages/config/src/config/tile.set.ts
@@ -1,4 +1,4 @@
-import { EpsgCode, ImageFormat } from '@basemaps/geo';
+import { EpsgCode, ImageFormat, VectorFormat } from '@basemaps/geo';
 
 import { ConfigBase } from './base.js';
 
@@ -139,6 +139,12 @@ export interface ConfigRasterPipelineColorRamp {
 
 export interface ConfigTileSetVector extends ConfigTileSetBase {
   type: TileSetType.Vector;
+
+  /**
+   * Vector output format
+   * Should be default to pbf format
+   */
+  format: VectorFormat;
 }
 
 export type ConfigTileSet = ConfigTileSetVector | ConfigTileSetRaster;


### PR DESCRIPTION
#### Motivation
We have done some refactoring for the config structure to support elevation data in future, but this moved the `format` into `output.format`. This breaking change will broken the vector config in the current basemaps version. We should make sure the transaction of format stay consistent.

#### Modification

Add a optional `format` for the `ConfigTileSetVector`

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
