### PR TITLE
feat(shared): Allow access to s3 nz-elevation public bucket.

### DIFF
--- a/packages/shared/src/file.system.ts
+++ b/packages/shared/src/file.system.ts
@@ -36,6 +36,7 @@ s3Fs.credentials = credentials;
 
 fsa.register('s3://', s3Fs);
 fsa.register('s3://nz-imagery', s3FsPublic);
+fsa.register('s3://nz-elevation', s3FsPublic);
 
 export const Fsa = fsa;
 


### PR DESCRIPTION
#### Motivation

Allow basemaps to access data from nz-elevation bucket.

#### Modification


#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
