### PR TITLE
feat(shared): Allow basemaps file systemt to access http files.

### DIFF
--- a/packages/shared/src/file.system.ts
+++ b/packages/shared/src/file.system.ts
@@ -2,7 +2,7 @@ import { fileURLToPath } from 'node:url';
 
 import { S3Client } from '@aws-sdk/client-s3';
 import { sha256base58 } from '@basemaps/config';
-import { FileSystem, FsHttp, fsa } from '@chunkd/fs';
+import { FileSystem, fsa, FsHttp } from '@chunkd/fs';
 import { AwsCredentialConfig, AwsS3CredentialProvider, FsAwsS3 } from '@chunkd/fs-aws';
 import { SourceCache, SourceChunk } from '@chunkd/middleware';
 import type { SourceCallback, SourceRequest } from '@chunkd/source';

--- a/packages/shared/src/file.system.ts
+++ b/packages/shared/src/file.system.ts
@@ -2,7 +2,7 @@ import { fileURLToPath } from 'node:url';
 
 import { S3Client } from '@aws-sdk/client-s3';
 import { sha256base58 } from '@basemaps/config';
-import { FileSystem, fsa } from '@chunkd/fs';
+import { FileSystem, FsHttp, fsa } from '@chunkd/fs';
 import { AwsCredentialConfig, AwsS3CredentialProvider, FsAwsS3 } from '@chunkd/fs-aws';
 import { SourceCache, SourceChunk } from '@chunkd/middleware';
 import type { SourceCallback, SourceRequest } from '@chunkd/source';
@@ -34,6 +34,7 @@ if (credentialPath) credentials.registerConfig(fsa.toUrl(credentialPath), s3Fs);
 
 s3Fs.credentials = credentials;
 
+fsa.register('https://', new FsHttp());
 fsa.register('s3://', s3Fs);
 fsa.register('s3://nz-imagery', s3FsPublic);
 


### PR DESCRIPTION
#### Motivation

We want to read some file from basemaps-config repo in order to make smoke test. Http access are required first.

#### Modification


#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
