### PR TITLE
fix(lambda-tiler): lerc needs to be external to allow wasm import

### DIFF
--- a/packages/lambda-tiler/package.json
+++ b/packages/lambda-tiler/package.json
@@ -40,7 +40,8 @@
     "outdir": "dist/",
     "external": [
       "pino-pretty",
-      "sharp"
+      "sharp",
+      "lerc"
     ]
   },
   "scripts": {


### PR DESCRIPTION
#### Motivation

Fixes:
> (Error: ENOENT: no such file or directory, open '/var/task/lerc-wasm.wasm')


#### Modification

LERC needs to be next to where the lerc-wasm.wasm file is located by bundling the lerc file it breaks the path for lerc.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
