### PR TITLE
fix(cli): Fix the bundling asset that remove extra letter at path and decode font paths.

### DIFF
--- a/packages/cli/src/cli/config/action.bundle.assets.ts
+++ b/packages/cli/src/cli/config/action.bundle.assets.ts
@@ -75,8 +75,8 @@ export class CommandBundleAssets extends CommandLineAction {
     logger.info({ output: outputTar, files: files.length }, 'Tar:Create');
 
     for (const file of files) {
-      let filePath = file.href.replace(input.href, '');
-      if(filePath.startsWith('/')) filePath.slice(1); // Remove the leading '/'
+      const filePath = file.href.replace(input.href, '');
+      if (filePath.startsWith('/')) filePath.slice(1); // Remove the leading '/'
       await tarBuilder.write(decodeURI(filePath), await fsa.read(file));
     }
 

--- a/packages/cli/src/cli/config/action.bundle.assets.ts
+++ b/packages/cli/src/cli/config/action.bundle.assets.ts
@@ -75,8 +75,9 @@ export class CommandBundleAssets extends CommandLineAction {
     logger.info({ output: outputTar, files: files.length }, 'Tar:Create');
 
     for (const file of files) {
-      const filePath = file.href.replace(input.href, '').slice(1); // Remove the leading '/'
-      await tarBuilder.write(filePath, await fsa.read(file));
+      let filePath = file.href.replace(input.href, '');
+      if(filePath.startsWith('/')) filePath.slice(1); // Remove the leading '/'
+      await tarBuilder.write(decodeURI(filePath), await fsa.read(file));
     }
 
     await tarBuilder.close();


### PR DESCRIPTION
#### Motivation

The bundle asset got broken after update to URL type of paths. The removing leading "/" shouldn't remove it if no leading "/", and the output font paths should be decoded from URL to remain the same as existing version.
I have uploaded some example screenshot of comparing prod and broken asset files.
![image](https://github.com/linz/basemaps/assets/12163920/2b9b2c24-d15b-4d0a-8c90-07e5c0f7b6e8)

#### Modification
- Check leading slash before removing, leading slash can be introduced if the input asset location doesn't have slash at end.
- decode the file path from url

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
