### PR TITLE
feat(config): use shorter band names for band information

### DIFF
--- a/packages/config-loader/src/json/__tests__/config.loader.test.ts
+++ b/packages/config-loader/src/json/__tests__/config.loader.test.ts
@@ -28,12 +28,7 @@ describe('config import', () => {
     assert.equal(imagery.name, 'tile-tiff-name');
     assert.deepEqual(imagery.files, [{ name: 'tiff-a.tiff', x: 0, y: -64, width: 64, height: 64 }]);
 
-    assert.deepEqual(imagery.bands, [
-      { type: 'uint', bits: 8 },
-      { type: 'uint', bits: 8 },
-      { type: 'uint', bits: 8 },
-      { type: 'uint', bits: 8 },
-    ]);
+    assert.deepEqual(imagery.bands, ['uint8', 'uint8', 'uint8', 'uint8']);
 
     assert.equal(imagery.noData, undefined);
   });

--- a/packages/config-loader/src/json/__tests__/tiff.config.test.ts
+++ b/packages/config-loader/src/json/__tests__/tiff.config.test.ts
@@ -40,7 +40,7 @@ describe('loadStacFromURL', () => {
 });
 
 describe('isRgbOrRgba', () => {
-  const uint8 = { type: 'uint', bits: 8 };
+  const uint8 = 'uint8';
   it('should allow imagery with no band information', () => {
     assert.equal(isRgbOrRgba({} as ConfigImagery), true);
   });
@@ -58,10 +58,10 @@ describe('isRgbOrRgba', () => {
   });
 
   it('should not allow float32 imagery', () => {
-    assert.equal(isRgbOrRgba({ bands: [uint8, uint8, uint8, { type: 'float', bits: 32 }] } as ConfigImagery), false);
+    assert.equal(isRgbOrRgba({ bands: [uint8, uint8, uint8, 'float32'] } as ConfigImagery), false);
   });
 
   it('should not allow uint16', () => {
-    assert.equal(isRgbOrRgba({ bands: [uint8, uint8, uint8, { type: 'uint', bits: 16 }] } as ConfigImagery), false);
+    assert.equal(isRgbOrRgba({ bands: [uint8, uint8, uint8, 'uint16'] } as ConfigImagery), false);
   });
 });

--- a/packages/config/src/config/imagery.ts
+++ b/packages/config/src/config/imagery.ts
@@ -10,6 +10,15 @@ import { ConfigBase } from './base.js';
  */
 export type ImageryDataType = 'uint' | 'int' | 'float' | 'void' | 'unknown' | 'cint' | 'cfloat';
 
+// TODO add more band types
+export const ImageryBandParser = z.union([
+  z.literal('float16'),
+  z.literal('float32'),
+  z.literal('uint8'),
+  z.literal('uint16'),
+]);
+export type ImageryBandType = z.infer<typeof ImageryBandParser>;
+
 export const ConfigImageryOverviewParser = z
   .object({
     /**
@@ -36,21 +45,6 @@ export const ConfigImageryOverviewParser = z
     maxZoom: z.number().refine((r) => r >= 0 && r <= 32),
   })
   .refine((obj) => obj.minZoom < obj.maxZoom);
-
-export const ImageryBandsParser = z.object({
-  /**
-   * Data type of the band
-   *
-   * @example "uint"
-   */
-  type: z.string(),
-  /**
-   * Number of bits used for the data type
-   *
-   * @example 32
-   */
-  bits: z.number(),
-});
 
 export const BoundingBoxParser = z.object({ x: z.number(), y: z.number(), width: z.number(), height: z.number() });
 export const NamedBoundsParser = z.object({
@@ -128,7 +122,7 @@ export const ConfigImageryParser = ConfigBase.extend({
   /**
    * Information about the common bands for the datasets
    */
-  bands: z.array(ImageryBandsParser).optional(),
+  bands: z.array(ImageryBandParser).optional(),
 
   /**
    * Optional noData value for the source

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -10,7 +10,7 @@ export { ensureBase58, sha256base58 } from './base58.node.js';
 export { parseHex, parseRgba } from './color.js';
 export { ConfigBase as BaseConfig } from './config/base.js';
 export { ConfigBundle } from './config/config.bundle.js';
-export { ConfigImagery, ConfigImageryOverview, ImageryDataType } from './config/imagery.js';
+export { ConfigImagery, ConfigImageryOverview, ImageryBandType, ImageryDataType } from './config/imagery.js';
 export { ConfigPrefix } from './config/prefix.js';
 export { ConfigProvider } from './config/provider.js';
 export {


### PR DESCRIPTION
#### Motivation

We only care about names of bands, using common names as `float32` or `uint8` is more common in this codebase

#### Modification

Moves from a complex object for band type to just the datatype.
```
const band = { type: 'uint', bits: 8 } 
// to
const band = 'uint8'
```

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
