### PR TITLE
feat(config): use the same config loader for server and cli

### DIFF
--- a/packages/cli/src/cli/config/action.bundle.ts
+++ b/packages/cli/src/cli/config/action.bundle.ts
@@ -1,6 +1,7 @@
 import { ConfigJson } from '@basemaps/config-loader';
 import { fsa, LogConfig } from '@basemaps/shared';
 import { CommandLineAction, CommandLineStringParameter } from '@rushstack/ts-command-line';
+import pLimit from 'p-limit';
 
 export const DefaultConfig = 'config/';
 export const DefaultOutput = 'config/config.json';
@@ -40,7 +41,8 @@ export class CommandBundle extends CommandLineAction {
     const logger = LogConfig.get();
     const configUrl = fsa.toUrl(this.config.value ?? DefaultConfig);
     const outputUrl = fsa.toUrl(this.output.value ?? DefaultOutput);
-    const mem = await ConfigJson.fromUrl(configUrl, logger);
+    const q = pLimit(25);
+    const mem = await ConfigJson.fromUrl(configUrl, q, logger);
     if (this.assets.value) mem.assets = this.assets.value;
     const configJson = mem.toJson();
     await fsa.write(outputUrl, JSON.stringify(configJson));

--- a/packages/cogify/src/cogify/cli/cli.config.ts
+++ b/packages/cogify/src/cogify/cli/cli.config.ts
@@ -43,7 +43,8 @@ export const BasemapsCogifyConfigCommand = command({
     const q = pLimit(args.concurrency);
 
     metrics.start('imagery:load');
-    const im = await initImageryFromTiffUrl(provider, args.path, q, logger);
+    const im = await initImageryFromTiffUrl(args.path, q, logger);
+    provider.put(im);
     metrics.end('imagery:load');
 
     logger.info({ files: im.files.length, titles: im.title }, 'ImageryConfig:Loaded');

--- a/packages/config-loader/src/json/__tests__/tiff.load.test.ts
+++ b/packages/config-loader/src/json/__tests__/tiff.load.test.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert';
+import { before, describe, it } from 'node:test';
+
+import { fsa, FsMemory, LogConfig } from '@basemaps/shared';
+import pLimit from 'p-limit';
+
+import { ConfigJson } from '../json.config.js';
+
+describe('tiff-loader', () => {
+  // Write some test tiffs
+  const mem = new FsMemory();
+  fsa.register('source://', mem);
+
+  const tmp = new FsMemory();
+  fsa.register('tmp://', tmp);
+
+  const stac = {
+    id: 'stac_id',
+    title: 'stac_title',
+  };
+
+  before(async () => {
+    const tiffA = new URL('../../../../__tests__/static/rgba8.google.tiff', import.meta.url);
+    await fsa.write(new URL('source://source/rgba8/google.tiff'), await fsa.read(tiffA));
+
+    await fsa.write(new URL('source://source/stac/01HQ99T8C965EXQM58WF6B6CJ0/collection.json'), JSON.stringify(stac));
+    await fsa.write(new URL('source://source/stac/01HQ99T8C965EXQM58WF6B6CJ0/google.tiff'), await fsa.read(tiffA));
+  });
+
+  it('should load a config with a example image', async () => {
+    const ts = {
+      id: 'ts_google',
+      type: 'raster',
+      title: 'GoogleExample',
+      layers: [{ 3857: 'source://source/rgba8/', title: 'google_title', name: 'google_name' }],
+    };
+
+    const cfgUrl = new URL('tmp://config/ts_google.json');
+    await fsa.write(cfgUrl, JSON.stringify(ts));
+
+    const cfg = await ConfigJson.fromUrl(cfgUrl, pLimit(10), LogConfig.get());
+    assert.equal(cfg.objects.size, 2); // Should be a im_ and ts_
+
+    const tsGoogle = await cfg.TileSet.get('ts_google')!;
+    assert.ok(tsGoogle);
+
+    assert.equal(tsGoogle.title, 'GoogleExample');
+    assert.equal(tsGoogle.format, 'webp');
+    assert.equal(tsGoogle.layers.length, 1);
+
+    const layerOne = tsGoogle?.layers[0];
+    assert.ok(layerOne);
+
+    const imgId = layerOne[3857];
+    assert.ok(imgId);
+
+    const img = await cfg.Imagery.get(imgId);
+
+    assert.ok(img);
+    assert.equal(img.files.length, 1);
+    assert.deepEqual(img.bands, ['uint8', 'uint8', 'uint8', 'uint8']);
+  });
+
+  it('should load a config with a stac collection', async () => {
+    const ts = {
+      id: 'ts_google',
+      type: 'raster',
+      title: 'GoogleExample',
+      layers: [
+        { 3857: 'source://source/stac/01HQ99T8C965EXQM58WF6B6CJ0/', title: 'google_title', name: 'google_name' },
+      ],
+    };
+
+    const cfgUrl = new URL('tmp://config/ts_google.json');
+    await fsa.write(cfgUrl, JSON.stringify(ts));
+
+    const cfg = await ConfigJson.fromUrl(cfgUrl, pLimit(10), LogConfig.get());
+
+    assert.equal(cfg.objects.size, 2); // Should be a im_ and ts_
+
+    const tsGoogle = await cfg.TileSet.get('ts_google')!;
+    assert.ok(tsGoogle);
+
+    assert.equal(tsGoogle.title, 'GoogleExample');
+    assert.equal(tsGoogle.format, 'webp');
+    assert.equal(tsGoogle.layers.length, 1);
+
+    const layerOne = tsGoogle?.layers[0];
+    assert.ok(layerOne);
+
+    const imgId = layerOne[3857];
+    assert.ok(imgId);
+    assert.equal(imgId, 'im_01HQ99T8C965EXQM58WF6B6CJ0');
+
+    const img = await cfg.Imagery.get(imgId);
+
+    assert.ok(img);
+    assert.equal(img.files.length, 1);
+    assert.deepEqual(img.bands, ['uint8', 'uint8', 'uint8', 'uint8']);
+  });
+});

--- a/packages/config-loader/src/json/__tests__/tiff.load.test.ts
+++ b/packages/config-loader/src/json/__tests__/tiff.load.test.ts
@@ -7,19 +7,18 @@ import pLimit from 'p-limit';
 import { ConfigJson } from '../json.config.js';
 
 describe('tiff-loader', () => {
-  // Write some test tiffs
-  const mem = new FsMemory();
-  fsa.register('source://', mem);
-
-  const tmp = new FsMemory();
-  fsa.register('tmp://', tmp);
-
   const stac = {
     id: 'stac_id',
     title: 'stac_title',
   };
 
   before(async () => {
+    // Write some test tiffs
+    const mem = new FsMemory();
+    const tmp = new FsMemory();
+    fsa.register('source://', mem);
+    fsa.register('tmp://', tmp);
+
     const tiffA = new URL('../../../../__tests__/static/rgba8.google.tiff', import.meta.url);
     await fsa.write(new URL('source://source/rgba8/google.tiff'), await fsa.read(tiffA));
 
@@ -39,7 +38,7 @@ describe('tiff-loader', () => {
     await fsa.write(cfgUrl, JSON.stringify(ts));
 
     const cfg = await ConfigJson.fromUrl(cfgUrl, pLimit(10), LogConfig.get());
-    assert.equal(cfg.objects.size, 2); // Should be a im_ and ts_
+    assert.equal(cfg.objects.size, 2, [...cfg.objects.values()].map((m) => m.id).join(', ')); // Should be a im_ and ts_
 
     const tsGoogle = await cfg.TileSet.get('ts_google')!;
     assert.ok(tsGoogle);
@@ -76,7 +75,7 @@ describe('tiff-loader', () => {
 
     const cfg = await ConfigJson.fromUrl(cfgUrl, pLimit(10), LogConfig.get());
 
-    assert.equal(cfg.objects.size, 2); // Should be a im_ and ts_
+    assert.equal(cfg.objects.size, 2, [...cfg.objects.values()].map((m) => m.id).join(', ')); // Should be a im_ and ts_
 
     const tsGoogle = await cfg.TileSet.get('ts_google')!;
     assert.ok(tsGoogle);

--- a/packages/config-loader/src/json/json.config.ts
+++ b/packages/config-loader/src/json/json.config.ts
@@ -267,9 +267,15 @@ export class ConfigJson {
     this.logger.trace({ url: url.href, imageId: id }, 'Imagery:Fetch');
 
     const img = await initImageryFromTiffUrl(url, this.Q, this.logger);
-    img.id = id;
+    img.id = id; // TODO could we use img.collection.id for this?
+
+    // TODO should we be overwriting the name and title when it is loaded from the STAC metadata?
     img.name = name;
     img.title = title;
+
+    // TODO should we store the STAC collection somewhere?
+    delete img.collection;
+    this.mem.put(img);
     return img;
   }
 

--- a/packages/config-loader/src/json/json.config.ts
+++ b/packages/config-loader/src/json/json.config.ts
@@ -15,33 +15,16 @@ import {
   StyleJson,
   TileSetType,
 } from '@basemaps/config';
-import {
-  Bounds,
-  GoogleTms,
-  ImageFormat,
-  NamedBounds,
-  Nztm2000QuadTms,
-  TileMatrixSet,
-  TileMatrixSets,
-  VectorFormat,
-} from '@basemaps/geo';
+import { ImageFormat, TileMatrixSet, TileMatrixSets, VectorFormat } from '@basemaps/geo';
 import { Cotar, fsa, stringToUrlFolder, Tiff, TiffTag } from '@basemaps/shared';
-import PLimit from 'p-limit';
-import { basename } from 'path';
+import { LimitFunction } from 'p-limit';
 import ulid from 'ulid';
 
 import { LogType } from './log.js';
 import { zProviderConfig } from './parse.provider.js';
 import { zStyleJson } from './parse.style.js';
 import { TileSetConfigSchemaLayer, zTileSetConfig } from './parse.tile.set.js';
-import { loadTiffsFromPaths } from './tiff.config.js';
-
-const Q = PLimit(10);
-
-function isTiff(u: URL): boolean {
-  const filePath = u.pathname.toLowerCase();
-  return filePath.endsWith('.tiff') || filePath.endsWith('.tif');
-}
+import { initImageryFromTiffUrl } from './tiff.config.js';
 
 export function matchUri(a: string, b: string): boolean {
   const UrlA = new URL(a.endsWith('/') ? a : a + '/');
@@ -107,15 +90,17 @@ export class ConfigJson {
   url: URL;
   cache: Map<string, Promise<ConfigImagery>> = new Map();
   logger: LogType;
+  Q: LimitFunction;
 
-  constructor(url: URL, log: LogType) {
+  constructor(url: URL, Q: LimitFunction, log: LogType) {
     this.url = url;
     this.mem = new ConfigProviderMemory();
     this.logger = log;
+    this.Q = Q;
   }
 
   /** Import configuration from a base path */
-  static async fromUrl(basePath: URL, log: LogType): Promise<ConfigProviderMemory> {
+  static async fromUrl(basePath: URL, Q: LimitFunction, log: LogType): Promise<ConfigProviderMemory> {
     if (basePath.pathname.endsWith('.json') || basePath.pathname.endsWith('.json.gz')) {
       const config = await fsa.readJson<BaseConfig>(basePath);
       if (config.id && config.id.startsWith('cb_')) {
@@ -124,7 +109,7 @@ export class ConfigJson {
       }
     }
 
-    const cfg = new ConfigJson(basePath, log);
+    const cfg = new ConfigJson(basePath, Q, log);
 
     const files = await fsa.toArray(fsa.list(basePath));
 
@@ -189,11 +174,11 @@ export class ConfigJson {
     if (ts.type === TileSetType.Raster) {
       for (const layer of ts.layers) {
         if (layer[2193] != null) {
-          imageryFetch.push(this.loadImagery(stringToUrlFolder(layer[2193]), Nztm2000QuadTms, layer.name, layer.title));
+          imageryFetch.push(this.loadImagery(stringToUrlFolder(layer[2193]), layer.name, layer.title));
         }
 
         if (layer[3857] != null) {
-          imageryFetch.push(this.loadImagery(stringToUrlFolder(layer[3857]), GoogleTms, layer.name, layer.title));
+          imageryFetch.push(this.loadImagery(stringToUrlFolder(layer[3857]), layer.name, layer.title));
         }
       }
     }
@@ -266,109 +251,26 @@ export class ConfigJson {
     return tileSet as ConfigTileSet;
   }
 
-  loadImagery(url: URL, tileMatrix: TileMatrixSet, name: string, title: string): Promise<ConfigImagery> {
+  loadImagery(url: URL, name: string, title: string): Promise<ConfigImagery> {
     let existing = this.cache.get(url.href);
     if (existing == null) {
-      existing = this._loadImagery(url, tileMatrix, name, title);
+      existing = this._loadImagery(url, name, title);
       this.cache.set(url.href, existing);
     }
     return existing;
   }
 
-  async _loadImagery(url: URL, tileMatrix: TileMatrixSet, name: string, title: string): Promise<ConfigImagery> {
+  async _loadImagery(url: URL, name: string, title: string): Promise<ConfigImagery> {
     // TODO is there a better way of guessing the imagery id & tile matrix?
     const imageId = guessIdFromUri(url.href) ?? sha256base58(url.href);
     const id = ConfigId.prefix(ConfigPrefix.Imagery, imageId);
     this.logger.trace({ url: url.href, imageId: id }, 'Imagery:Fetch');
 
-    const fileList = await fsa.toArray(fsa.details(url));
-    const tiffFiles = fileList.filter((f) => isTiff(f.url));
-
-    const tiffTiles = [];
-    // Files can be stored as `{z}-{x}-{y}.tiff`
-    // Check to see if all tiffs match the z-x-y format
-    for (const tiff of tiffFiles) {
-      const tileName = basename(tiff.url.pathname).replace('.tiff', '');
-      const [z, x, y] = tileName.split('-').map((f) => Number(f));
-      if (isNaN(x) || isNaN(y) || isNaN(z)) break;
-
-      tiffTiles.push({ tiff, tile: { z, x, y } });
-    }
-
-    let bounds: Bounds | null = null;
-
-    const imageList: NamedBounds[] = [];
-    if (tiffTiles.length !== tiffFiles.length) {
-      // some of the tiffs are not named `{z}-{x}-{y}.tiff` so extract bounds from the tiff
-      const tiffs = await loadTiffsFromPaths(
-        tiffFiles.map((m) => m.url),
-        Q,
-      );
-
-      for (const tiff of tiffs) {
-        const gsd = tiff.images[0].resolution[0];
-
-        const gsdRound = Math.floor(gsd * 100) / 10000;
-        const bbox = tiff.images[0].bbox.map((f) => Math.floor(f / gsdRound) * gsdRound);
-        const imgBounds = Bounds.fromBbox(bbox);
-
-        if (bounds == null) bounds = imgBounds;
-        else bounds = bounds.union(imgBounds);
-
-        const tileName = basename(tiff.source.url.pathname);
-        imageList.push({ ...imgBounds, name: tileName });
-      }
-    } else {
-      for (const t of tiffTiles) {
-        // TODO add the .tiff extension back in once the new basemaps-config workflow has been merged
-        const tileName = basename(t.tiff.url.pathname).replace('.tiff', '');
-
-        const tile = tileMatrix.tileToSourceBounds(t.tile);
-        // Expand the total bounds to cover this tile
-        if (bounds == null) bounds = Bounds.fromJson(tile);
-        else bounds = bounds.union(Bounds.fromJson(tile));
-        imageList.push({ ...tile, name: tileName });
-      }
-    }
-
-    // Sort the files by Z, X, Y
-    imageList.sort((a, b): number => {
-      const widthSize = a.width - b.width;
-      if (widthSize !== 0) return widthSize;
-
-      const aXyz = a.name.split('-').map((f) => Number(f));
-      const bXyz = b.name.split('-').map((f) => Number(f));
-
-      const zDiff = aXyz[0] - bXyz[0];
-      if (zDiff !== 0) return zDiff;
-
-      const xDiff = aXyz[1] - bXyz[1];
-      if (xDiff !== 0) return xDiff;
-
-      return bXyz[2] - aXyz[2];
-    });
-
-    this.logger.debug({ url, imageId, files: imageList.length }, 'Imagery:Fetch:Done');
-
-    if (bounds == null) throw new Error('Failed to get bounds from URL: ' + url.href);
-    const now = Date.now();
-    const output: ConfigImagery = {
-      id,
-      name,
-      title,
-      updatedAt: now,
-      projection: tileMatrix.projection.code,
-      tileMatrix: tileMatrix.identifier,
-      uri: url.href,
-      bounds,
-      files: imageList,
-    };
-
-    output.overviews = await ConfigJson.findImageryOverviews(output);
-    this.mem.put(output);
-    // Ensure there is also a tile set for each imagery set
-    // this.mem.put(ConfigJson.imageryToTileSet(output));
-    return output;
+    const img = await initImageryFromTiffUrl(url, this.Q, this.logger);
+    img.id = id;
+    img.name = name;
+    img.title = title;
+    return img;
   }
 
   static async findImageryOverviews(cfg: ConfigImagery): Promise<ConfigImageryOverview | undefined> {

--- a/packages/config-loader/src/json/tiff.config.ts
+++ b/packages/config-loader/src/json/tiff.config.ts
@@ -334,12 +334,7 @@ export async function loadTiffsFromPaths(sourceFiles: URL[], Q: LimitFunction): 
  *
  * @returns Imagery configuration generated from the path
  */
-export async function initImageryFromTiffUrl(
-  provider: ConfigProviderMemory,
-  target: URL,
-  Q: LimitFunction,
-  log?: LogType,
-): Promise<ConfigImageryTiff> {
+export async function initImageryFromTiffUrl(target: URL, Q: LimitFunction, log?: LogType): Promise<ConfigImageryTiff> {
   const sourceFiles = await fsa.toArray(fsa.list(target));
   const tiffs = await loadTiffsFromPaths(sourceFiles, Q);
 
@@ -354,7 +349,7 @@ export async function initImageryFromTiffUrl(
       params.projection === EpsgCode.Nztm2000 ? Nztm2000QuadTms : TileMatrixSets.tryGet(params.projection);
 
     const imagery: ConfigImageryTiff = {
-      id: provider.Imagery.id(sha256base58(target.href)),
+      id: `im_${sha256base58(target.href)}`,
       name: imageryName,
       title,
       updatedAt: Date.now(),
@@ -371,8 +366,6 @@ export async function initImageryFromTiffUrl(
     };
     imagery.overviews = await ConfigJson.findImageryOverviews(imagery);
     log?.info({ title, imageryName, files: imagery.files.length }, 'Tiff:Loaded');
-
-    provider.put(imagery);
 
     return imagery;
   } finally {
@@ -425,7 +418,7 @@ export async function initConfigFromUrls(
   const q = pLimit(concurrency);
 
   const imageryConfig: Promise<ConfigImageryTiff>[] = [];
-  for (const target of targets) imageryConfig.push(initImageryFromTiffUrl(provider, target, q, log));
+  for (const target of targets) imageryConfig.push(initImageryFromTiffUrl(target, q, log));
 
   const aerialTileSet: ConfigTileSetRaster = {
     id: 'ts_aerial',
@@ -450,6 +443,7 @@ export async function initConfigFromUrls(
   const configs = await Promise.all(imageryConfig);
   const tileSets = [aerialTileSet];
   for (const cfg of configs) {
+    provider.put(cfg);
     if (isRgbOrRgba(cfg)) {
       let existingLayer = aerialTileSet.layers.find((l) => l.title === cfg.title);
       if (existingLayer == null) {

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -1,7 +1,7 @@
 import { BasemapsConfigProvider, ConfigBundled, ConfigPrefix, ConfigProviderMemory } from '@basemaps/config';
 import { ConfigJson, initConfigFromUrls } from '@basemaps/config-loader';
 import { ConfigProviderDynamo, fsa, getDefaultConfig, LogType } from '@basemaps/shared';
-
+import pLimit from 'p-limit';
 export type ServerOptions = ServerOptionsTiffs | ServerOptionsConfig;
 
 /** Load configuration from folders */
@@ -72,7 +72,7 @@ export async function loadConfig(opts: ServerOptions, logger: LogType): Promise<
     return mem;
   }
 
-  const mem = await ConfigJson.fromUrl(fsa.toUrl(configPath), logger);
+  const mem = await ConfigJson.fromUrl(fsa.toUrl(configPath), pLimit(25), logger);
   logger.info({ path: configPath, mode: 'config:json' }, 'Starting Server');
   mem.createVirtualTileSets();
   return mem;


### PR DESCRIPTION
#### Motivation

Basemaps Server and Basemaps Config importer were using two seperate configuration loading paths when reading metadata from tiff source files.

This greatly increases the number of requests needed to load configuration from tiff files, a caching layer will need to be added later.

#### Modification

Use the same code path between server and config bundling when reading metadata about tiff files.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
