### PR TITLE
feat(config-loader): cache imagery configs to speed up loading times

### DIFF
--- a/packages/cli/src/cli/config/action.bundle.ts
+++ b/packages/cli/src/cli/config/action.bundle.ts
@@ -39,7 +39,7 @@ export class CommandBundle extends CommandLineAction {
     this.configCache = this.defineStringParameter({
       argumentName: 'CACHE',
       parameterLongName: '--cache',
-      description: 'Cache the imagery config to speed uploading',
+      description: 'Location of the config cache to reduce number of requests needed to source file',
     });
   }
 

--- a/packages/cli/src/cli/config/action.bundle.ts
+++ b/packages/cli/src/cli/config/action.bundle.ts
@@ -37,9 +37,9 @@ export class CommandBundle extends CommandLineAction {
       description: 'Add assets location into the config bundle file',
     });
     this.configCache = this.defineStringParameter({
-      argumentName: 'ASSETS',
+      argumentName: 'CACHE',
       parameterLongName: '--cache',
-      description: 'Add assets location into the config bundle file',
+      description: 'Cache the imagery config to speed uploading',
     });
   }
 

--- a/packages/cli/src/cli/config/action.bundle.ts
+++ b/packages/cli/src/cli/config/action.bundle.ts
@@ -10,6 +10,7 @@ export class CommandBundle extends CommandLineAction {
   private config!: CommandLineStringParameter;
   private output!: CommandLineStringParameter;
   private assets!: CommandLineStringParameter;
+  private configCache!: CommandLineStringParameter;
 
   public constructor() {
     super({
@@ -35,14 +36,20 @@ export class CommandBundle extends CommandLineAction {
       parameterLongName: '--assets',
       description: 'Add assets location into the config bundle file',
     });
+    this.configCache = this.defineStringParameter({
+      argumentName: 'ASSETS',
+      parameterLongName: '--cache',
+      description: 'Add assets location into the config bundle file',
+    });
   }
 
   async onExecute(): Promise<void> {
     const logger = LogConfig.get();
     const configUrl = fsa.toUrl(this.config.value ?? DefaultConfig);
     const outputUrl = fsa.toUrl(this.output.value ?? DefaultOutput);
+    const cacheLocation = this.configCache.value ? fsa.toUrl(this.configCache.value) : undefined;
     const q = pLimit(25);
-    const mem = await ConfigJson.fromUrl(configUrl, q, logger);
+    const mem = await ConfigJson.fromUrl(configUrl, q, logger, cacheLocation);
     if (this.assets.value) mem.assets = this.assets.value;
     const configJson = mem.toJson();
     await fsa.write(outputUrl, JSON.stringify(configJson));

--- a/packages/cogify/src/cogify/cli/cli.config.ts
+++ b/packages/cogify/src/cogify/cli/cli.config.ts
@@ -43,7 +43,7 @@ export const BasemapsCogifyConfigCommand = command({
     const q = pLimit(args.concurrency);
 
     metrics.start('imagery:load');
-    const im = await initImageryFromTiffUrl(args.path, q, logger);
+    const im = await initImageryFromTiffUrl(args.path, q, undefined, logger);
     provider.put(im);
     metrics.end('imagery:load');
 

--- a/packages/config-loader/src/json/__tests__/tiff.load.test.ts
+++ b/packages/config-loader/src/json/__tests__/tiff.load.test.ts
@@ -1,6 +1,5 @@
 import assert from 'node:assert';
 import { before, describe, it } from 'node:test';
-import { gunzipSync } from 'node:zlib';
 
 import { DefaultTerrainRgbOutput } from '@basemaps/config';
 import { fsa, FsMemory, LogConfig } from '@basemaps/shared';

--- a/packages/config-loader/src/json/imagery.config.cache.ts
+++ b/packages/config-loader/src/json/imagery.config.cache.ts
@@ -1,0 +1,64 @@
+import { promisify } from 'node:util';
+import { gzip } from 'node:zlib';
+
+import { sha256base58 } from '@basemaps/config';
+import { fsa, LogType } from '@basemaps/shared';
+import { FileInfo } from '@chunkd/fs';
+
+import { ConfigImageryTiff } from './tiff.config.js';
+
+export const ConfigCacheVersion = `V1`; // TODO this could just be the config packageJson ?
+
+const gzipPromise = promisify(gzip);
+
+/**
+ * Create a config cache key based off the source files, location, size and last modified times
+ *
+ * @example
+ * ```
+ * YYYY-MM/proto_hostname/hashKey.json.gz
+ * 2034-04/s3_linz-imagery/Ci4chK59behxsGZq6TaUde5DoVb7jTxhyaZ44j4wBnCb.json.gz
+ * ```
+ *
+ * @param sourceFiles
+ * @param cacheLocation
+ *
+ * @returns a unique config location
+ */
+function getCacheKey(sourceFiles: FileInfo[], cacheLocation: URL): URL {
+  const configKey =
+    ConfigCacheVersion + sourceFiles.map((m) => `${m.url.href}::${m.size}::${m.lastModified}`).join('\n');
+  // create a config hash based on the YYYY-MM/proto_hostname/hashKey.json.gz
+
+  const datePart = new Date().toISOString().slice(0, 7);
+  const protoPart = cacheLocation.protocol.replace(':', ''); // convert file: into file
+  const configKeyHash = [datePart, `${protoPart}_${sha256base58(configKey)}_.json.gz`].join('/');
+  return new URL(configKeyHash, cacheLocation);
+}
+
+export async function getCachedImageryConfig(
+  sourceFiles: FileInfo[],
+  cacheLocation?: URL,
+  log?: LogType,
+): Promise<ConfigImageryTiff | null> {
+  if (cacheLocation == null) return null;
+  const cacheKey = getCacheKey(sourceFiles, cacheLocation);
+  const previousVersion = await fsa.readJson<ConfigImageryTiff>(cacheKey).catch(() => null);
+
+  if (previousVersion == null) return null;
+  log?.info(
+    { title: previousVersion.title, imageryName: previousVersion.name, files: previousVersion.files.length, cacheKey },
+    'Tiff:Loaded:Cache',
+  );
+  return previousVersion;
+}
+
+export async function writeCachedImageryConfig(
+  sourceFiles: FileInfo[],
+  config: ConfigImageryTiff,
+  cacheLocation?: URL,
+): Promise<void> {
+  if (cacheLocation == null) return;
+  const cacheKey = getCacheKey(sourceFiles, cacheLocation);
+  await fsa.write(cacheKey, await gzipPromise(JSON.stringify(config))).catch(() => null);
+}

--- a/packages/config-loader/src/json/tiff.config.ts
+++ b/packages/config-loader/src/json/tiff.config.ts
@@ -139,10 +139,11 @@ async function computeTiffSummary(target: URL, tiffs: Tiff[]): Promise<TiffSumma
     }
 
     // Validate the bands and data types of the tiff are somewhat consistent
-    const [dataType, bitsPerSample] = await Promise.all([
+    const [dataType, bitsPerSample, noData] = await Promise.all([
       /** firstImage.fetch(TiffTag.Photometric), **/ // TODO enable RGB detection
       firstImage.fetch(TiffTag.SampleFormat),
       firstImage.fetch(TiffTag.BitsPerSample),
+      firstImage.fetch(TiffTag.GdalNoData),
     ]);
 
     if (dataType == null || bitsPerSample == null) {
@@ -163,7 +164,7 @@ async function computeTiffSummary(target: URL, tiffs: Tiff[]): Promise<TiffSumma
     res.bands = ensureBandsSimilar(tiff, res.bands, imageBands);
 
     // Validate NoData value is consistent across entire
-    const imageNoData = firstImage.noData;
+    const imageNoData = noData ? Number(noData) : null;
     if (res.noData != null && imageNoData !== res.noData) {
       throw new Error(`NoData mismatch on ${imageNoData} vs ${res.noData} from: ${tiff.source.url.href}`);
     }

--- a/packages/config-loader/src/json/tiff.config.ts
+++ b/packages/config-loader/src/json/tiff.config.ts
@@ -17,6 +17,7 @@ import { basename } from 'path';
 import { StacCollection } from 'stac-ts';
 import { fileURLToPath } from 'url';
 
+import { getCachedImageryConfig, writeCachedImageryConfig } from './imagery.config.cache.js';
 import { ConfigJson, isEmptyTiff } from './json.config.js';
 import { LogType } from './log.js';
 
@@ -331,12 +332,26 @@ export async function loadTiffsFromPaths(sourceFiles: URL[], Q: LimitFunction): 
  * Attempt to load all imagery inside of a path and create a configuration from it
  *
  * @param target path that contains the imagery
+ * @param Q limit the number of requests per second to the imagery
+ * @param configCache optional location to cache the configuration objects
  *
  * @returns Imagery configuration generated from the path
  */
-export async function initImageryFromTiffUrl(target: URL, Q: LimitFunction, log?: LogType): Promise<ConfigImageryTiff> {
-  const sourceFiles = await fsa.toArray(fsa.list(target));
-  const tiffs = await loadTiffsFromPaths(sourceFiles, Q);
+export async function initImageryFromTiffUrl(
+  target: URL,
+  Q: LimitFunction,
+  configCache?: URL,
+  log?: LogType,
+): Promise<ConfigImageryTiff> {
+  const sourceFiles = await fsa.toArray(fsa.details(target));
+
+  const prev = await getCachedImageryConfig(sourceFiles, configCache, log);
+  if (prev) return prev;
+
+  const tiffs = await loadTiffsFromPaths(
+    sourceFiles.map((m) => m.url),
+    Q,
+  );
 
   try {
     const stac = await loadStacFromURL(target);
@@ -366,6 +381,8 @@ export async function initImageryFromTiffUrl(target: URL, Q: LimitFunction, log?
     };
     imagery.overviews = await ConfigJson.findImageryOverviews(imagery);
     log?.info({ title, imageryName, files: imagery.files.length }, 'Tiff:Loaded');
+
+    await writeCachedImageryConfig(sourceFiles, imagery, configCache);
 
     return imagery;
   } finally {
@@ -413,12 +430,13 @@ export async function initConfigFromUrls(
   provider: ConfigProviderMemory,
   targets: URL[],
   concurrency = 25,
+  configCache?: URL,
   log?: LogType,
 ): Promise<{ tileSet: ConfigTileSetRaster; tileSets: ConfigTileSetRaster[]; imagery: ConfigImageryTiff[] }> {
   const q = pLimit(concurrency);
 
   const imageryConfig: Promise<ConfigImageryTiff>[] = [];
-  for (const target of targets) imageryConfig.push(initImageryFromTiffUrl(target, q, log));
+  for (const target of targets) imageryConfig.push(initImageryFromTiffUrl(target, q, configCache, log));
 
   const aerialTileSet: ConfigTileSetRaster = {
     id: 'ts_aerial',

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -42,6 +42,11 @@ export const BasemapsServerCommand = command({
       long: 'assets',
       description: 'Where the assets (sprites, fonts) are located',
     }),
+    cache: option({
+      type: optional(Url),
+      long: 'cache',
+      description: 'Cache the metadata from loading of tiff files',
+    }),
     paths: restPositionals({ type: Url, displayName: 'path', description: 'Path to imagery' }),
   },
   handler: async (args) => {
@@ -56,8 +61,8 @@ export const BasemapsServerCommand = command({
     // Force a default url base so WMTS requests know their relative url
     process.env[Env.PublicUrlBase] = ServerUrl;
     const serverOptions = args.config
-      ? { assets: args.assets, config: args.config }
-      : { assets: args.assets, paths: args.paths };
+      ? { assets: args.assets, config: args.config, configCache: args.cache }
+      : { assets: args.assets, paths: args.paths, configCache: args.cache };
 
     const server = await createServer(serverOptions, logger);
 


### PR DESCRIPTION
#### Motivation

When loading config from tiff files we open every tiff to validate that is in a format that basemaps can read, this can take a long time for large datasets

Adding a `--cache s3://config-cache/` to commands will cache the config for reuse in these locations which greatly reduces the number of files needed to be read to load a config

#### Modification

Adds a configuration cache that can be specified by the user to cache imagery config loading.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
