### PR TITLE
feat(tiler-sharp): directly resize/resample DEM inputs rather than RGBA outputs

### DIFF
--- a/packages/lambda-tiler/src/routes/preview.ts
+++ b/packages/lambda-tiler/src/routes/preview.ts
@@ -147,6 +147,7 @@ export async function renderPreview(req: LambdaHttpRequest, ctx: PreviewRenderCo
     format: tileOutput.format?.[0] ?? 'webp', // default to the first output format if defined or webp
     background: tileOutput.background ?? ctx.tileSet.background ?? DefaultBackground,
     resizeKernel: tileOutput.resizeKernel ?? ctx.tileSet.resizeKernel ?? DefaultResizeKernel,
+    log: req.log,
   };
 
   // Load all the tiff tiles and resize/them into the correct locations

--- a/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
+++ b/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
@@ -139,6 +139,7 @@ export const TileXyzRaster = {
       background: tileOutput.background ?? tileSet.background ?? DefaultBackground,
       resizeKernel: tileOutput.resizeKernel ?? tileSet.resizeKernel ?? DefaultResizeKernel,
       metrics: req.timer,
+      log: req.log,
     });
 
     req.set('layersUsed', res.layers);

--- a/packages/landing/src/components/map.tsx
+++ b/packages/landing/src/components/map.tsx
@@ -105,15 +105,12 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
   ensureTerrainControl(): void {
     if (Config.map.debug['debug.screenshot']) return;
     if (Config.map.debug) {
-      const sources = Object.entries(this.map.getStyle().sources);
-      const rasterDem = sources.find((e) => e[1].type === 'raster-dem');
-      // const terrainSource = this.map.getSource('elevation-terrain');
-      // console.log(this.map.getStyle().sources);
+      const terrainSource = this.map.getSource('elevation-terrain');
       if (this.controlTerrain != null) return;
-      if (rasterDem != null) {
+      if (terrainSource != null) {
         this.controlTerrain = new maplibre.TerrainControl({
-          source: rasterDem[0],
-          exaggeration: 2.2,
+          source: terrainSource.id,
+          exaggeration: 1,
         });
         this.map.addControl(this.controlTerrain, 'top-left');
       }

--- a/packages/landing/src/components/map.tsx
+++ b/packages/landing/src/components/map.tsx
@@ -105,12 +105,15 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
   ensureTerrainControl(): void {
     if (Config.map.debug['debug.screenshot']) return;
     if (Config.map.debug) {
-      const terrainSource = this.map.getSource('elevation-terrain');
+      const sources = Object.entries(this.map.getStyle().sources);
+      const rasterDem = sources.find((e) => e[1].type === 'raster-dem');
+      // const terrainSource = this.map.getSource('elevation-terrain');
+      // console.log(this.map.getStyle().sources);
       if (this.controlTerrain != null) return;
-      if (terrainSource != null) {
+      if (rasterDem != null) {
         this.controlTerrain = new maplibre.TerrainControl({
-          source: terrainSource.id,
-          exaggeration: 1,
+          source: rasterDem[0],
+          exaggeration: 2.2,
         });
         this.map.addControl(this.controlTerrain, 'top-left');
       }

--- a/packages/shared/src/file.system.ts
+++ b/packages/shared/src/file.system.ts
@@ -60,7 +60,7 @@ export const FsaLog = {
     this.requests.push(requestId);
     const startTime = performance.now();
     const res = await next(req);
-    LogConfig.get().debug(
+    LogConfig.get().trace(
       {
         source: req.source.url.href,
         offset: req.offset,

--- a/packages/tiler-sharp/src/index.ts
+++ b/packages/tiler-sharp/src/index.ts
@@ -11,6 +11,7 @@ import { Metrics } from '@linzjs/metrics';
 import Sharp from 'sharp';
 
 import { Decompressors } from './pipeline/decompressor.lerc.js';
+import { cropResizeNearest } from './pipeline/pipeline.resize.js';
 import { Pipelines } from './pipeline/pipelines.js';
 
 function notEmpty<T>(value: T | null | undefined): value is T {
@@ -160,45 +161,51 @@ export class TileMakerSharp implements TileMaker {
   async composeTilePipeline(comp: CompositionTiff, ctx: TileMakerContext): Promise<SharpOverlay | null> {
     const tile = await comp.asset.images[comp.source.imageId].getTile(comp.source.x, comp.source.y);
     if (tile == null) return null;
-
+    const tiffTile = { imageId: comp.source.imageId, x: comp.source.x, y: comp.source.y };
     const bytes = await Decompressors[tile.compression]?.bytes(comp.asset, tile.bytes);
     if (bytes == null) throw new Error('Failed to decompress: ' + comp.asset.source.url);
 
     let result = bytes;
     if (ctx.pipeline) {
+      const resizePerf = performance.now();
+      result = cropResizeNearest(comp.asset, result, comp);
+      ctx.log?.trace(
+        {
+          pipeline: 'resize',
+          source: comp.asset.source.url,
+          isCrop: comp.crop != null,
+          isResize: comp.resize != null,
+          isExtract: comp.extract != null,
+          tiffTile,
+          duration: performance.now() - resizePerf,
+        },
+        'pipeline:resize',
+      );
+
       for (const pipe of ctx.pipeline) {
+        const pipelineStart = performance.now();
         result = await Pipelines[pipe.type]?.process(comp.asset, result);
+        ctx.log?.trace(
+          {
+            pipeline: pipe.type,
+            source: comp.asset.source.url,
+            tiffTile,
+            duration: performance.now() - pipelineStart,
+          },
+          'pipeline:' + pipe.type,
+        );
+
         if (result == null) throw new Error(`Failed to process pipeline:${pipe.type} on ${comp.asset.source.url}`);
       }
     }
 
     if (result.depth !== 'uint8') throw new Error('Expected RGBA image output');
-    const sharp = Sharp(result.pixels, {
-      raw: { width: result.width, height: result.height, channels: result.channels as 4 },
-    });
 
-    // Extract the vars to make it easier to reference later
-    const { extract, resize, crop } = comp;
-
-    // FIXME: extract should be run before the pipelines
-    if (extract) sharp.extract({ top: 0, left: 0, width: extract.width, height: extract.height });
-
-    if (resize) {
-      const resizeOptions = {
-        fit: Sharp.fit.cover,
-        kernel: resize.scaleX > 1 ? ctx.resizeKernel.in : ctx.resizeKernel.out,
-      };
-      sharp.resize(resize.width, resize.height, resizeOptions);
-    }
-
-    if (crop) sharp.extract({ top: crop.y, left: crop.x, width: crop.width, height: crop.height });
-
-    const ret = await sharp.raw().toBuffer({ resolveWithObject: true });
     return {
-      input: ret.data,
+      input: Buffer.from(result.pixels),
       top: comp.y,
       left: comp.x,
-      raw: { width: ret.info.width, height: ret.info.height, channels: ret.info.channels },
+      raw: { width: result.width, height: result.height, channels: result.channels as 1 },
     };
   }
 

--- a/packages/tiler-sharp/src/pipeline/pipeline.resize.ts
+++ b/packages/tiler-sharp/src/pipeline/pipeline.resize.ts
@@ -1,0 +1,68 @@
+import { Tiff } from '@basemaps/shared';
+import { CompositionTiff } from '@basemaps/tiler';
+
+import { DecompressedInterleaved } from './decompressor.js';
+
+/**
+ * Pipeline to apply the crop/resizing to datasets
+ */
+export function cropResizeNearest(
+  _source: Tiff,
+  data: DecompressedInterleaved,
+  comp: CompositionTiff,
+): DecompressedInterleaved {
+  // Nothing to do
+  if (comp.extract == null && comp.resize == null && comp.crop == null) return data;
+
+  // Currently very limited supported input parameters
+  if (data.channels !== 1) throw new Error('Unable to crop-resize more than one channel got:' + data.channels);
+  if (data.depth !== 'float32') throw new Error('Unable to crop-resize other than float32 got:' + data.depth);
+
+  // Area of the source data that needs to be resampled
+  const source = { x: 0, y: 0, width: data.width, height: data.height };
+  // Area of the output data
+  const target = { width: 0, height: 0, scaleX: 1, scaleY: 1 };
+
+  if (comp.extract) {
+    source.width = comp.extract.width;
+    source.height = comp.extract.height;
+
+    target.width = comp.extract.width;
+    target.height = comp.extract.height;
+  }
+
+  if (comp.resize) {
+    target.width = comp.resize.width;
+    target.height = comp.resize.height;
+    target.scaleX = comp.resize.scaleX;
+    target.scaleY = comp.resize.scaleY;
+  }
+
+  const invScaleX = 1 / target.scaleX;
+  const invScaleY = 1 / target.scaleY;
+  if (comp.crop) {
+    source.x = Math.round(comp.crop.x * invScaleX);
+    source.y = Math.round(comp.crop.y * invScaleY);
+    source.width = Math.round(comp.crop.width * invScaleX);
+    source.height = Math.round(comp.crop.height * invScaleY);
+
+    target.width = comp.crop.width;
+    target.height = comp.crop.height;
+  }
+
+  // Resample the input tile into the output tile using a nearest neighbor approach
+  const outputBuffer = new Float32Array(target.width * target.height);
+  for (let y = 0; y < target.height; y++) {
+    let sourceY = Math.round(y * invScaleY + source.y);
+    if (sourceY > data.height - 1) sourceY = data.height - 1;
+
+    for (let x = 0; x < target.width; x++) {
+      let sourceX = Math.round(x * invScaleX + source.x);
+      if (sourceX > data.width - 1) sourceX = data.width - 1;
+
+      outputBuffer[y * target.width + x] = data.pixels[sourceY * data.width + sourceX];
+    }
+  }
+
+  return { pixels: outputBuffer, width: target.width, height: target.height, depth: 'float32', channels: 1 };
+}

--- a/packages/tiler-sharp/src/pipeline/pipeline.resize.ts
+++ b/packages/tiler-sharp/src/pipeline/pipeline.resize.ts
@@ -1,5 +1,5 @@
-import { Tiff } from '@basemaps/shared';
 import { CompositionTiff } from '@basemaps/tiler';
+import { Tiff } from '@cogeotiff/core';
 
 import { DecompressedInterleaved } from './decompressor.js';
 

--- a/packages/tiler/src/raster.ts
+++ b/packages/tiler/src/raster.ts
@@ -22,7 +22,14 @@ export interface TileMakerContext {
   background: { r: number; g: number; b: number; alpha: number };
   /** Default resize parameters */
   resizeKernel: TileMakerResizeKernel;
+  /** Optional metrics to track */
   metrics?: Metrics;
+
+  /** optional logger for trace level metrics */
+  log?: {
+    level: string;
+    trace: (rec: Record<string, unknown>, msg: string) => void;
+  };
 }
 export type Composition = CompositionTiff | CompositionCotar;
 

--- a/packages/tiler/src/tiler.ts
+++ b/packages/tiler/src/tiler.ts
@@ -110,6 +110,7 @@ export class Tiler {
     }
 
     const drawAtRegion = target.subtract(raster.tile);
+
     const composition: Composition = {
       type: 'tiff',
       asset: img.tiff,


### PR DESCRIPTION
#### Motivation

Resizing/resmapling after the pipelines are applied is very wasteful as we apply a pipeline then only use a very low percentage of data.

#### Modification

Adds a direct resize/resample on the input data rather than resampling the output.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
