### PR TITLE
feat(tiler): add bilinear resampler for DEM/DSM

### DIFF
--- a/packages/tiler-sharp/src/__tests__/tile.creation.test.ts
+++ b/packages/tiler-sharp/src/__tests__/tile.creation.test.ts
@@ -48,7 +48,7 @@ describe('TileCreation', () => {
     const topLeft = layer0.find((f) => f.source.x === 0 && f.source.y === 0);
     assert.deepEqual(topLeft?.source, { x: 0, y: 0, imageId: 0, width: 16, height: 16 });
     assert.equal(topLeft?.asset.source.url, tiff.source.url);
-    assert.deepEqual(topLeft?.resize, { width: 32, height: 32, scaleX: 2, scaleY: 2 });
+    assert.deepEqual(topLeft?.resize, { width: 32, height: 32, scaleX: 2, scaleY: 2, scale: 1.9999999999999982 });
     assert.equal(topLeft?.x, 64);
     assert.equal(topLeft?.y, 64);
     await tiff?.source.close?.();

--- a/packages/tiler-sharp/src/index.ts
+++ b/packages/tiler-sharp/src/index.ts
@@ -11,7 +11,7 @@ import { Metrics } from '@linzjs/metrics';
 import Sharp from 'sharp';
 
 import { Decompressors } from './pipeline/decompressor.lerc.js';
-import { cropResizeNearest } from './pipeline/pipeline.resize.js';
+import { cropResize } from './pipeline/pipeline.resize.js';
 import { Pipelines } from './pipeline/pipelines.js';
 
 function notEmpty<T>(value: T | null | undefined): value is T {
@@ -168,7 +168,7 @@ export class TileMakerSharp implements TileMaker {
     let result = bytes;
     if (ctx.pipeline) {
       const resizePerf = performance.now();
-      result = cropResizeNearest(comp.asset, result, comp);
+      result = cropResize(comp.asset, result, comp, 'bilinear');
       ctx.log?.trace(
         {
           pipeline: 'resize',

--- a/packages/tiler-sharp/src/pipeline/pipeline.resize.ts
+++ b/packages/tiler-sharp/src/pipeline/pipeline.resize.ts
@@ -1,4 +1,5 @@
-import { CompositionTiff } from '@basemaps/tiler';
+import { BoundingBox, Size } from '@basemaps/geo';
+import { CompositionTiff, ResizeKernelType } from '@basemaps/tiler';
 import { Tiff } from '@cogeotiff/core';
 
 import { DecompressedInterleaved } from './decompressor.js';
@@ -6,10 +7,11 @@ import { DecompressedInterleaved } from './decompressor.js';
 /**
  * Pipeline to apply the crop/resizing to datasets
  */
-export function cropResizeNearest(
-  _source: Tiff,
+export function cropResize(
+  tiff: Tiff,
   data: DecompressedInterleaved,
   comp: CompositionTiff,
+  mode: ResizeKernelType | 'bilinear',
 ): DecompressedInterleaved {
   // Nothing to do
   if (comp.extract == null && comp.resize == null && comp.crop == null) return data;
@@ -21,7 +23,7 @@ export function cropResizeNearest(
   // Area of the source data that needs to be resampled
   const source = { x: 0, y: 0, width: data.width, height: data.height };
   // Area of the output data
-  const target = { width: 0, height: 0, scaleX: 1, scaleY: 1 };
+  const target = { width: 0, height: 0, scale: 1 };
 
   if (comp.extract) {
     source.width = comp.extract.width;
@@ -34,33 +36,101 @@ export function cropResizeNearest(
   if (comp.resize) {
     target.width = comp.resize.width;
     target.height = comp.resize.height;
-    target.scaleX = comp.resize.scaleX;
-    target.scaleY = comp.resize.scaleY;
+    target.scale = comp.resize.scale;
   }
 
-  const invScaleX = 1 / target.scaleX;
-  const invScaleY = 1 / target.scaleY;
+  const invScale = 1 / target.scale;
+
   if (comp.crop) {
-    source.x = Math.round(comp.crop.x * invScaleX);
-    source.y = Math.round(comp.crop.y * invScaleY);
-    source.width = Math.round(comp.crop.width * invScaleX);
-    source.height = Math.round(comp.crop.height * invScaleY);
+    source.x = Math.round(comp.crop.x * invScale);
+    source.y = Math.round(comp.crop.y * invScale);
+    source.width = Math.round(comp.crop.width * invScale);
+    source.height = Math.round(comp.crop.height * invScale);
 
     target.width = comp.crop.width;
     target.height = comp.crop.height;
   }
 
+  const noData = tiff.images[0].noData;
+
+  switch (mode) {
+    case 'nearest':
+      return resizeNearest(data, comp, source, target);
+    case 'bilinear':
+      return resizeBilinear(data, comp, source, target, noData);
+    default:
+      throw new Error('Unable to use resize kernel: ' + mode);
+  }
+}
+
+function resizeNearest(
+  data: DecompressedInterleaved,
+  comp: CompositionTiff,
+  source: BoundingBox,
+  target: Size & { scale: number },
+): DecompressedInterleaved {
+  const maxWidth = Math.min(comp.source.width, data.width) - 1;
+  const maxHeight = Math.min(comp.source.height, data.height) - 1;
+  const invScale = 1 / target.scale;
+
   // Resample the input tile into the output tile using a nearest neighbor approach
   const outputBuffer = new Float32Array(target.width * target.height);
   for (let y = 0; y < target.height; y++) {
-    let sourceY = Math.round(y * invScaleY + source.y);
-    if (sourceY > data.height - 1) sourceY = data.height - 1;
+    let sourceY = Math.round((y + 0.5) * invScale + source.y);
+    if (sourceY > maxHeight) sourceY = maxHeight;
 
     for (let x = 0; x < target.width; x++) {
-      let sourceX = Math.round(x * invScaleX + source.x);
-      if (sourceX > data.width - 1) sourceX = data.width - 1;
+      let sourceX = Math.round((x + 0.5) * invScale + source.x);
+      if (sourceX > maxWidth) sourceX = maxWidth;
 
       outputBuffer[y * target.width + x] = data.pixels[sourceY * data.width + sourceX];
+    }
+  }
+
+  return { pixels: outputBuffer, width: target.width, height: target.height, depth: 'float32', channels: 1 };
+}
+
+function resizeBilinear(
+  data: DecompressedInterleaved,
+  comp: CompositionTiff,
+  source: BoundingBox,
+  target: Size & { scale: number },
+  noData?: number | null,
+): DecompressedInterleaved {
+  const invScale = 1 / target.scale;
+
+  const maxWidth = Math.min(comp.source.width, data.width) - 2;
+  const maxHeight = Math.min(comp.source.height, data.height) - 2;
+  const outputBuffer = new Float32Array(target.width * target.height);
+  for (let y = 0; y < target.height; y++) {
+    const sourceY = Math.min((y + 0.5) * invScale + source.y, maxHeight);
+    const minY = Math.floor(sourceY);
+    const maxY = minY + 1;
+
+    for (let x = 0; x < target.width; x++) {
+      const sourceX = Math.min((x + 0.5) * invScale + source.x, maxWidth);
+      const minX = Math.floor(sourceX);
+      const maxX = minX + 1;
+
+      const minXMinY = data.pixels[minY * data.width + minX];
+      if (minXMinY === noData) continue;
+      const maxXMinY = data.pixels[minY * data.width + maxX];
+      if (maxXMinY === noData) continue;
+      const minXMaxY = data.pixels[maxY * data.width + minX];
+      if (minXMaxY === noData) continue;
+      const maxXMaxY = data.pixels[maxY * data.width + maxX];
+      if (maxXMaxY === noData) continue;
+
+      const xDiff = sourceX - minX;
+      const yDiff = sourceY - minY;
+      const weightA = (1 - xDiff) * (1 - yDiff);
+      const weightB = xDiff * (1 - yDiff);
+      const weightC = (1 - xDiff) * yDiff;
+      const weightD = xDiff * yDiff;
+
+      const py = minXMinY * weightA + maxXMinY * weightB + minXMaxY * weightC + maxXMaxY * weightD;
+
+      outputBuffer[y * target.width + x] = py;
     }
   }
 

--- a/packages/tiler/src/__tests__/tiler.test.ts
+++ b/packages/tiler/src/__tests__/tiler.test.ts
@@ -78,7 +78,7 @@ describe('tiler.test', () => {
       y: 0,
       x: 64,
       extract: { width: 512, height: 388 },
-      resize: { width: 256, height: 194, scaleX: 0.5, scaleY: 0.5 },
+      resize: { width: 256, height: 194, scaleX: 0.5, scaleY: 0.5, scale: 0.5 },
       crop,
     });
 

--- a/packages/tiler/src/raster.ts
+++ b/packages/tiler/src/raster.ts
@@ -55,6 +55,8 @@ export interface CompositionTiff {
     scaleX: number;
     /** Scale height  < 1 to zoom in, > 1 to zoom out */
     scaleY: number;
+    /** desired scale */
+    scale: number;
   };
   /** Crop after the resize */
   crop?: Size & Point;

--- a/packages/tiler/src/tiler.ts
+++ b/packages/tiler/src/tiler.ts
@@ -130,7 +130,7 @@ export class Tiler {
     if (source.width !== target.width || source.height !== target.height) {
       const scaleX = target.width / source.width;
       const scaleY = target.height / source.height;
-      composition.resize = { width: target.width, height: target.height, scaleX, scaleY };
+      composition.resize = { width: target.width, height: target.height, scaleX, scaleY, scale: scaleFactor };
     }
 
     // If the output XYZ tile needs a piece of a COG tile, extract the speicific


### PR DESCRIPTION
#### Motivation

Nearest neighbor while really fast doesn't give the best visual output for most of our usecases

#### Modification

switch to bilinear resampling by default.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
