### PR TITLE
fix(tiler-sharp): resampling should set no-data

### DIFF
--- a/packages/config/src/config/tile.set.output.ts
+++ b/packages/config/src/config/tile.set.output.ts
@@ -18,7 +18,7 @@ export const DefaultColorRampOutput: ConfigTileSetRasterOutput = {
   name: 'color-ramp',
   pipeline: [{ type: 'color-ramp' }],
   // Taken from 0 of DefaultColorRamp
-  background: { r: 167, g: 205, b: 228, alpha: 1 },
+  background: { r: 172, g: 204, b: 226, alpha: 1 },
 } as const;
 
 export const DefaultColorRamp = `-8764 0 0 0 255

--- a/packages/tiler-sharp/src/pipeline/pipeline.resize.ts
+++ b/packages/tiler-sharp/src/pipeline/pipeline.resize.ts
@@ -112,14 +112,28 @@ function resizeBilinear(
       const minX = Math.floor(sourceX);
       const maxX = minX + 1;
 
+      const outPx = y * target.width + x;
+
       const minXMinY = data.pixels[minY * data.width + minX];
-      if (minXMinY === noData) continue;
+      if (minXMinY === noData) {
+        outputBuffer[outPx] = noData;
+        continue;
+      }
       const maxXMinY = data.pixels[minY * data.width + maxX];
-      if (maxXMinY === noData) continue;
+      if (maxXMinY === noData) {
+        outputBuffer[outPx] = noData;
+        continue;
+      }
       const minXMaxY = data.pixels[maxY * data.width + minX];
-      if (minXMaxY === noData) continue;
+      if (minXMaxY === noData) {
+        outputBuffer[outPx] = noData;
+        continue;
+      }
       const maxXMaxY = data.pixels[maxY * data.width + maxX];
-      if (maxXMaxY === noData) continue;
+      if (maxXMaxY === noData) {
+        outputBuffer[outPx] = noData;
+        continue;
+      }
 
       const xDiff = sourceX - minX;
       const yDiff = sourceY - minY;
@@ -128,9 +142,9 @@ function resizeBilinear(
       const weightC = (1 - xDiff) * yDiff;
       const weightD = xDiff * yDiff;
 
-      const py = minXMinY * weightA + maxXMinY * weightB + minXMaxY * weightC + maxXMaxY * weightD;
+      const pixel = minXMinY * weightA + maxXMinY * weightB + minXMaxY * weightC + maxXMaxY * weightD;
 
-      outputBuffer[y * target.width + x] = py;
+      outputBuffer[outPx] = pixel;
     }
   }
 


### PR DESCRIPTION
#### Motivation

NO_DATA value needs to be set in the output of resizing otherwise a value of 0 is assumed.

#### Modification

Set NO_DATA if it is encountered while resizing.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
