### PR TITLE
fix(tiler-sharp): do not resample if its not needed

### DIFF
--- a/packages/tiler-sharp/src/pipeline/pipeline.resize.ts
+++ b/packages/tiler-sharp/src/pipeline/pipeline.resize.ts
@@ -1,4 +1,4 @@
-import { BoundingBox, Size } from '@basemaps/geo';
+import { BoundingBox, Point, Size } from '@basemaps/geo';
 import { CompositionTiff, ResizeKernelType } from '@basemaps/tiler';
 import { Tiff } from '@cogeotiff/core';
 
@@ -13,8 +13,14 @@ export function cropResize(
   comp: CompositionTiff,
   mode: ResizeKernelType | 'bilinear',
 ): DecompressedInterleaved {
-  // Nothing to do
-  if (comp.extract == null && comp.resize == null && comp.crop == null) return data;
+  if (comp.extract == null && comp.resize == null) {
+    const cropVal = comp.crop;
+    // Nothing to do
+    if (cropVal == null) return data;
+
+    // since there is no resize we can just copy input buffers into output buffers
+    return applyCrop(tiff, data, cropVal);
+  }
 
   // Currently very limited supported input parameters
   if (data.channels !== 1) throw new Error('Unable to crop-resize more than one channel got:' + data.channels);
@@ -61,6 +67,19 @@ export function cropResize(
     default:
       throw new Error('Unable to use resize kernel: ' + mode);
   }
+}
+
+export function applyCrop(_tiff: Tiff, data: DecompressedInterleaved, crop: Size & Point): DecompressedInterleaved {
+  // Cropping a image is just copying sub parts of a source image into a output image
+  // loop line by line slicing the new image
+  const output = new Float32Array(crop.width * crop.height * data.channels);
+  for (let y = 0; y < crop.height; y++) {
+    const source = ((y + crop.y) * data.width + crop.x) * data.channels;
+    const length = crop.width * data.channels;
+    output.set(data.pixels.subarray(source, source + length), y * crop.width);
+  }
+
+  return { pixels: output, width: crop.width, height: crop.height, channels: data.channels, depth: 'float32' };
 }
 
 function resizeNearest(


### PR DESCRIPTION
#### Motivation

When cropping images bilinear resampling is currently applied, this does not need to happen as it should just be a one to one copy of the data

#### Modification

Directly crops a image using sub array slices.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
