### PR TITLE
fix(shared): allow reading of buckets from other regions

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1,5 +1,5 @@
 import { handler } from '@basemaps/lambda-tiler';
-import { fsa, getDefaultConfig, LogType, setDefaultConfig } from '@basemaps/shared';
+import { Env, fsa, getDefaultConfig, LogType, setDefaultConfig } from '@basemaps/shared';
 import formBodyPlugin from '@fastify/formbody';
 import fastifyStatic from '@fastify/static';
 import { LambdaUrlRequest, UrlEvent } from '@linzjs/lambda';
@@ -46,7 +46,8 @@ export async function createServer(opts: ServerOptions, logger: LogType): Promis
   if (landingLocation == null) {
     logger.warn('Server:Landing:Failed');
   } else {
-    const root = path.join(path.dirname(landingLocation), '..', 'dist');
+    const root = path.join(path.dirname(landingLocation), '..', 'dist/');
+    if (process.env[Env.StaticAssetLocation] == null) process.env[Env.StaticAssetLocation] = root;
     logger.info({ path: root }, 'Server:Landing');
     BasemapsServer.register(fastifyStatic, { root });
   }

--- a/packages/shared/src/file.system.ts
+++ b/packages/shared/src/file.system.ts
@@ -11,11 +11,21 @@ import type { RequestSigner } from '@smithy/types';
 import { Env } from './const.js';
 import { LogConfig } from './log.js';
 
-export const s3Fs = new FsAwsS3(new S3Client());
+export const s3Fs = new FsAwsS3(
+  new S3Client({
+    /**
+     * We buckets in multiple regions we do not know ahead of time which bucket is in what region
+     *
+     * So the S3 Client will have to follow the endpoints, this adds a bit of extra latency as requests have to be retried
+     */
+    followRegionRedirects: true,
+  }),
+);
 
 // For public URLS use --no-sign-request
 export const s3FsPublic = new FsAwsS3(
   new S3Client({
+    followRegionRedirects: true,
     signer: {
       sign: async (req) => req,
     } as RequestSigner,


### PR DESCRIPTION
#### Motivation

We have buckets in multiple regions, when requesting data using the default client it will throw a 301 moved error rather than fetching the data from the bucket.

If we know the region ahead of time we should create new s3 clients for those regions to save the request -> failure -> retry flow.

#### Modification

Retry bucket reads when reading across region

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
