### PR TITLE
feat(lambda-tiler): show the first pipeline as the preview instead of a broken image

### DIFF
--- a/packages/geo/src/slug.ts
+++ b/packages/geo/src/slug.ts
@@ -31,6 +31,15 @@ export interface LocationQueryConfig {
    * "NZTM2000Quad"
    */
   tileMatrix: string;
+
+  /**
+   * Optional configuration of how to render the imagery
+   *
+   * @example
+   * "terrain-rgb"
+   * "color-ramp"
+   */
+  pipeline?: string;
 }
 
 export const LocationSlug = {
@@ -159,6 +168,7 @@ export const LocationSlug = {
     return {
       /** Style ordering, falling back onto the deprecated `?i=:imageryId  if it exists otherwise a default of `aerial` */
       style: str.get('style') ?? str.get('s') ?? str.get('i') ?? 'aerial',
+      pipeline: str.get('pipeline') ?? undefined,
       tileMatrix: tms?.identifier ?? 'WebMercatorQuad',
     };
   },

--- a/packages/lambda-tiler/src/routes/preview.index.ts
+++ b/packages/lambda-tiler/src/routes/preview.index.ts
@@ -2,7 +2,7 @@ import { promisify } from 'node:util';
 import { gunzip } from 'node:zlib';
 
 import { GoogleTms, LocationUrl, LonLatZoom, TileMatrixSets } from '@basemaps/geo';
-import { Env, fsa } from '@basemaps/shared';
+import { Env, fsa, getPreviewQuery } from '@basemaps/shared';
 import { HttpHeader, LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambda';
 
 import { ConfigLoader } from '../util/config.loader.js';
@@ -104,7 +104,7 @@ export async function previewIndexGet(req: LambdaHttpRequest<PreviewIndexGet>): 
   const shortLocation = [short.zoom, short.lon, short.lat].join('/');
 
   const cfg = ConfigLoader.extract(req);
-  const queryParams = cfg == null ? '' : `?config=${cfg}`;
+  const queryParams = getPreviewQuery({ config: cfg, pipeline: query.pipeline ?? tileSet.outputs?.[0]?.name });
 
   // Include tile matrix name eg "[NZTM2000Quad]" in the title if its not WebMercatorQuad
   const tileMatrixId = tileMatrix.identifier === GoogleTms.identifier ? '' : ` [${tileMatrix.identifier}]`;
@@ -118,7 +118,7 @@ export async function previewIndexGet(req: LambdaHttpRequest<PreviewIndexGet>): 
     ],
     [
       'og:image',
-      `<meta name="twitter:image" property="og:image" content="/v1/preview/${tileSet.name}/${tileMatrix.identifier}/${shortLocation}${queryParams}" />`,
+      `<meta name="twitter:image" property="og:image" content="/v1/preview/${tileSet.name}/${tileMatrix.identifier}/${shortLocation}/png${queryParams}" />`,
     ],
   ]);
 

--- a/packages/lambda-tiler/src/routes/preview.index.ts
+++ b/packages/lambda-tiler/src/routes/preview.index.ts
@@ -118,7 +118,7 @@ export async function previewIndexGet(req: LambdaHttpRequest<PreviewIndexGet>): 
     ],
     [
       'og:image',
-      `<meta name="twitter:image" property="og:image" content="/v1/preview/${tileSet.name}/${tileMatrix.identifier}/${shortLocation}/png${queryParams}" />`,
+      `<meta name="twitter:image" property="og:image" content="/v1/preview/${tileSet.name}/${tileMatrix.identifier}/${shortLocation}${queryParams}" />`,
     ],
   ]);
 

--- a/packages/lambda-tiler/src/routes/preview.ts
+++ b/packages/lambda-tiler/src/routes/preview.ts
@@ -64,7 +64,16 @@ export async function tilePreviewGet(req: LambdaHttpRequest<PreviewGet>): Promis
   // Only raster previews are supported
   if (tileSet.type !== 'raster') return new LambdaHttpResponse(404, 'Preview invalid tile set type');
 
-  const outputFormat = req.params.outputType ?? 'webp';
+  const pipeline = req.query.get('pipeline');
+
+  // Use the prefered output format from the pipeline if its defined
+  let defaultFormat = 'webp';
+  if (pipeline) {
+    const output = tileSet.outputs?.find((f) => f.name === pipeline);
+    defaultFormat = output?.format?.[0] ?? defaultFormat;
+  }
+
+  const outputFormat = req.params.outputType ?? defaultFormat;
 
   const tileOutput = Validate.pipeline(tileSet, outputFormat, req.query.get('pipeline'));
   if (tileOutput == null) return new LambdaHttpResponse(404, `Output format: ${outputFormat} not found`);

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,7 +6,7 @@ export { Const, Env } from './const.js';
 export { ConfigDynamoBase } from './dynamo/dynamo.config.base.js';
 export { ConfigProviderDynamo } from './dynamo/dynamo.config.js';
 export { Fsa as fsa, FsaCache, FsaChunk, FsaLog, stringToUrlFolder, urlToString } from './file.system.js';
-export { getImageryCenterZoom, getPreviewUrl, PreviewSize } from './imagery.url.js';
+export { getImageryCenterZoom, getPreviewQuery, getPreviewUrl, PreviewSize } from './imagery.url.js';
 export { LogConfig, LogType } from './log.js';
 export { LoggerFatalError } from './logger.fatal.error.js';
 export { toQueryString } from './url.js';


### PR DESCRIPTION
#### Motivation

We need preview URLS so that we can display a list of DEM layers in the layer viewer

![image](https://github.com/linz/basemaps/assets/1082761/198dd124-9576-411d-b27a-29e5cf0e08bf)


#### Modification

Adds support for pipelines for preview url generation when viewing the landing page.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
