### PR TITLE
feat(geo): Truncate bearing and pitch values in url.

### DIFF
--- a/packages/geo/src/__tests__/slug.test.ts
+++ b/packages/geo/src/__tests__/slug.test.ts
@@ -55,7 +55,7 @@ describe('LocationUrl', () => {
   it('should slug the bearing and pitch', () => {
     assert.equal(
       LocationSlug.toSlug({ lat: -41.277848, lon: 174.7763921, zoom: 8, bearing: 25.3, pitch: -35.722 }),
-      `@-41.2778480,174.7763921,z8,b25.3,p-35.722`,
+      `@-41.2778480,174.7763921,z8,b25.3,p-36`,
     );
     assert.deepEqual(LocationSlug.fromSlug(`@-41.2778480,174.7763921,z8,b25.3,p-35.722`), {
       lat: -41.277848,
@@ -82,7 +82,7 @@ describe('LocationUrl', () => {
   it('should slug the pitch only bearing pitch is 0', () => {
     assert.equal(
       LocationSlug.toSlug({ lat: -41.277848, lon: 174.7763921, zoom: 8, pitch: -0.01 }),
-      `@-41.2778480,174.7763921,z8,p-0.01`,
+      `@-41.2778480,174.7763921,z8`,
     );
     assert.deepEqual(LocationSlug.fromSlug(`@-41.2778480,174.7763921,z8,p-0.01`), {
       lat: -41.277848,
@@ -104,5 +104,24 @@ describe('LocationUrl', () => {
     assert.deepEqual(LocationSlug.fromSlug('@-41.2778480,174.7763921,z8,p35'), { ...lonLatZoom, pitch: 35 });
     assert.deepEqual(LocationSlug.fromSlug('@-41.2778480,174.7763921,z8,p-60.1'), lonLatZoom);
     assert.deepEqual(LocationSlug.fromSlug('@-41.2778480,174.7763921,z8,p70'), lonLatZoom);
+  });
+
+  it('toSlug should truncate bearing and pitch', () => {
+    assert.equal(
+      LocationSlug.toSlug({ lat: -41.277848, lon: 174.7763921, zoom: 8, pitch: -0.9 }),
+      `@-41.2778480,174.7763921,z8,p-1`,
+    );
+    assert.equal(
+      LocationSlug.toSlug({ lat: -41.277848, lon: 174.7763921, zoom: 8, pitch: 0.4 }),
+      `@-41.2778480,174.7763921,z8`,
+    );
+    assert.equal(
+      LocationSlug.toSlug({ lat: -41.277848, lon: 174.7763921, zoom: 8, pitch: 0.4, bearing: 0.09 }),
+      `@-41.2778480,174.7763921,z8,b0.1`,
+    );
+    assert.equal(
+      LocationSlug.toSlug({ lat: -41.277848, lon: 174.7763921, zoom: 8, pitch: 0.4, bearing: 0.04 }),
+      `@-41.2778480,174.7763921,z8`,
+    );
   });
 });

--- a/packages/geo/src/slug.ts
+++ b/packages/geo/src/slug.ts
@@ -50,6 +50,12 @@ export const LocationSlug = {
   /** Number of decimal places to fix a location zoom too */
   ZoomFixed: 2,
 
+  /** Number of decimal places to fix a bearing */
+  BearingFixed: 1,
+
+  /** Number of decimal places to fix a pitch */
+  PitchFixed: 0,
+
   /**
    * Truncate a lat lon based on the zoom level
    *
@@ -63,7 +69,20 @@ export const LocationSlug = {
     };
   },
 
-  cameraStr(loc: LonLatZoom): string {
+  /**
+   * Truncate a bearing and pitch
+   *
+   * @param loc location to truncate
+   */
+  truncateBearingPitch(loc: LonLatZoom): Partial<LonLatZoom> {
+    let bearing;
+    let pitch;
+    if (loc.bearing) bearing = Number(loc.bearing.toFixed(LocationSlug.BearingFixed));
+    if (loc.pitch) pitch = Number(loc.pitch.toFixed(LocationSlug.PitchFixed));
+    return { bearing, pitch };
+  },
+
+  cameraStr(loc: Partial<LonLatZoom>): string {
     let str = '';
     if (loc.bearing && loc.bearing !== 0) str += `,b${loc.bearing}`;
     if (loc.pitch && loc.pitch !== 0) str += `,p${loc.pitch}`;
@@ -83,7 +102,7 @@ export const LocationSlug = {
    */
   toSlug(loc: LonLatZoom): string {
     const fixed = LocationSlug.truncateLatLon(loc);
-    return `@${fixed.lat},${fixed.lon},z${fixed.zoom}${this.cameraStr(loc)}`;
+    return `@${fixed.lat},${fixed.lon},z${fixed.zoom}${this.cameraStr(this.truncateBearingPitch(loc))}`;
   },
 
   /**

--- a/packages/geo/src/slug.ts
+++ b/packages/geo/src/slug.ts
@@ -75,10 +75,10 @@ export const LocationSlug = {
    * @param loc location to truncate
    */
   truncateBearingPitch(loc: LonLatZoom): Partial<LonLatZoom> {
-return {
- bearing: loc.bearing ? Number(loc.bearing.toFixed(LocationSlug.BearingFixed)) : undefined,
- pitch: loc.pitch ? Number(loc.pitch.toFixed(LocationSlug.PitchFixed)) : undefined
- }
+    return {
+      bearing: loc.bearing ? Number(loc.bearing.toFixed(LocationSlug.BearingFixed)) : undefined,
+      pitch: loc.pitch ? Number(loc.pitch.toFixed(LocationSlug.PitchFixed)) : undefined,
+    };
   },
 
   cameraStr(loc: Partial<LonLatZoom>): string {

--- a/packages/geo/src/slug.ts
+++ b/packages/geo/src/slug.ts
@@ -75,11 +75,10 @@ export const LocationSlug = {
    * @param loc location to truncate
    */
   truncateBearingPitch(loc: LonLatZoom): Partial<LonLatZoom> {
-    let bearing;
-    let pitch;
-    if (loc.bearing) bearing = Number(loc.bearing.toFixed(LocationSlug.BearingFixed));
-    if (loc.pitch) pitch = Number(loc.pitch.toFixed(LocationSlug.PitchFixed));
-    return { bearing, pitch };
+return {
+ bearing: loc.bearing ? Number(loc.bearing.toFixed(LocationSlug.BearingFixed)) : undefined,
+ pitch: loc.pitch ? Number(loc.pitch.toFixed(LocationSlug.PitchFixed)) : undefined
+ }
   },
 
   cameraStr(loc: Partial<LonLatZoom>): string {


### PR DESCRIPTION
#### Motivation

We need to truncate the bearing and pitch in url which stay the same as maplibre. 1dp for bearing and 0dp for pitch

#### Modification

Update the `fromSlug` function to include the truncate bearing and pitch output in string.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
