### PR TITLE
fix(cogify): improve DEM quality when reprojecting and scaling BM-987

### DIFF
--- a/packages/cogify/src/cogify/cli.ts
+++ b/packages/cogify/src/cogify/cli.ts
@@ -3,6 +3,7 @@ import { subcommands } from 'cmd-ts';
 import { BasemapsCogifyCreateCommand } from './cli/cli.cog.js';
 import { BasemapsCogifyConfigCommand } from './cli/cli.config.js';
 import { BasemapsCogifyCoverCommand } from './cli/cli.cover.js';
+import { BasemapsCogifyValidateCommand } from './cli/cli.validate.js';
 
 export const CogifyCli = subcommands({
   name: 'cogify',
@@ -10,5 +11,6 @@ export const CogifyCli = subcommands({
     cover: BasemapsCogifyCoverCommand,
     create: BasemapsCogifyCreateCommand,
     config: BasemapsCogifyConfigCommand,
+    validate: BasemapsCogifyValidateCommand,
   },
 });

--- a/packages/cogify/src/cogify/cli/cli.cog.ts
+++ b/packages/cogify/src/cogify/cli/cli.cog.ts
@@ -348,11 +348,11 @@ async function validateOutputTiff(url: URL, logger: LogType): Promise<void> {
     const tiffStats = tiff.images.map((t) => {
       return { id: t.id, ...t.size, tiles: t.tileCount };
     });
-    logger.info({ path }, 'Cog:Validate:Ok');
-    logger.info({ tiffStats }, 'Cog:Validate:Stats');
+    logger.info({ url }, 'Cog:Validate:Ok');
+    logger.info({ url, tiffStats }, 'Cog:Validate:Stats');
     await tiff.source.close?.();
   } catch (err) {
-    logger.error({ path, err }, 'Cog:ValidateFailed');
+    logger.error({ url, err }, 'Cog:ValidateFailed');
     throw err;
   }
 }

--- a/packages/cogify/src/cogify/cli/cli.cog.ts
+++ b/packages/cogify/src/cogify/cli/cli.cog.ts
@@ -366,7 +366,6 @@ export async function validateOutputTiff(
         resolution,
         zResolution: zoomScale,
         z: closestZoom,
-        // zResolution: zoomScale,
         isResolutionOk: zoomDiff < 1e-8,
       };
       logger.debug({ url, imageStats: obj }, 'Cog:Validate:Image');

--- a/packages/cogify/src/cogify/cli/cli.cog.ts
+++ b/packages/cogify/src/cogify/cli/cli.cog.ts
@@ -1,5 +1,5 @@
 import { isEmptyTiff } from '@basemaps/config-loader';
-import { ProjectionLoader, TileId, TileMatrixSets } from '@basemaps/geo';
+import { Projection, ProjectionLoader, TileId, TileMatrixSet, TileMatrixSets } from '@basemaps/geo';
 import { fsa, LogType, stringToUrlFolder, Tiff } from '@basemaps/shared';
 import { CliId, CliInfo } from '@basemaps/shared/build/cli/info.js';
 import { Metrics } from '@linzjs/metrics';
@@ -231,7 +231,7 @@ export const BasemapsCogifyCreateCommand = command({
           // Upload the output COG into the target location
           const readStream = fsa.readStream(outputTiffPath).pipe(new HashTransform('sha256'));
           await fsa.write(tiffPath, readStream);
-          await validateOutputTiff(tiffPath, logger);
+          await validateOutputTiff(tiffPath, tileMatrix, logger);
 
           asset['file:checksum'] = readStream.multihash;
           asset['file:size'] = readStream.size;
@@ -341,12 +341,36 @@ async function createCog(ctx: CogCreationContext): Promise<URL> {
  * Very basic checking for the output tiff to ensure it was uploaded ok
  * Just open it as a COG and ensure the metadata looks about  right
  */
-async function validateOutputTiff(url: URL, logger: LogType): Promise<void> {
+export async function validateOutputTiff(
+  url: URL,
+  tileMatrix: TileMatrixSet | undefined,
+  logger: LogType,
+): Promise<void> {
   logger.info({ url }, 'Cog:Validate');
   try {
     const tiff = await Tiff.create(fsa.source(url));
+    const tms = tileMatrix ?? TileMatrixSets.tryGet(tiff.images[0].epsg);
+    if (tms == null) throw new Error('Unknown EPSG');
+
     const tiffStats = tiff.images.map((t) => {
-      return { id: t.id, ...t.size, tiles: t.tileCount };
+      // all internal images should be approximately aligned to a tile matrix
+      const resolution = t.resolution[0];
+      const closestZoom = Projection.getTiffResZoom(tms, resolution);
+      const zoomScale = tms.pixelScale(closestZoom);
+      const zoomDiff = Math.abs(zoomScale - resolution);
+
+      const obj = {
+        id: t.id,
+        ...t.size,
+        tiles: t.tileCount,
+        resolution,
+        zResolution: zoomScale,
+        z: closestZoom,
+        // zResolution: zoomScale,
+        isResolutionOk: zoomDiff < 1e-8,
+      };
+      logger.debug({ url, imageStats: obj }, 'Cog:Validate:Image');
+      return obj;
     });
     logger.info({ url }, 'Cog:Validate:Ok');
     logger.info({ url, tiffStats }, 'Cog:Validate:Stats');

--- a/packages/cogify/src/cogify/cli/cli.validate.ts
+++ b/packages/cogify/src/cogify/cli/cli.validate.ts
@@ -1,0 +1,36 @@
+import { GoogleTms } from '@basemaps/geo';
+import { CliInfo } from '@basemaps/shared/build/cli/info.js';
+import { command, number, option, restPositionals } from 'cmd-ts';
+import pLimit from 'p-limit';
+
+import { getLogger, logArguments } from '../../log.js';
+import { Url } from '../parsers.js';
+import { validateOutputTiff } from './cli.cog.js';
+
+export const BasemapsCogifyValidateCommand = command({
+  name: 'cogify-validate',
+  version: CliInfo.version,
+  description: 'Validate a COG is created in a way basemaps likes',
+  args: {
+    ...logArguments,
+    concurrency: option({
+      type: number,
+      long: 'concurrency',
+      description: 'How many COGs to initialise at once',
+      defaultValue: () => 25,
+      defaultValueIsSerializable: true,
+    }),
+    path: restPositionals({ type: Url, displayName: 'path', description: 'COG to validate' }),
+  },
+
+  async handler(args) {
+    const logger = getLogger(this, args);
+    const q = pLimit(args.concurrency);
+
+    const promises = args.path.map((path) => {
+      return q(() => validateOutputTiff(path, undefined, logger));
+    });
+
+    await Promise.allSettled(promises);
+  },
+});

--- a/packages/cogify/src/cogify/cli/cli.validate.ts
+++ b/packages/cogify/src/cogify/cli/cli.validate.ts
@@ -1,4 +1,3 @@
-import { GoogleTms } from '@basemaps/geo';
 import { CliInfo } from '@basemaps/shared/build/cli/info.js';
 import { command, number, option, restPositionals } from 'cmd-ts';
 import pLimit from 'p-limit';
@@ -20,15 +19,15 @@ export const BasemapsCogifyValidateCommand = command({
       defaultValue: () => 25,
       defaultValueIsSerializable: true,
     }),
-    path: restPositionals({ type: Url, displayName: 'path', description: 'COG to validate' }),
+    tiffs: restPositionals({ type: Url, displayName: 'paths', description: 'COG to validate' }),
   },
 
   async handler(args) {
     const logger = getLogger(this, args);
     const q = pLimit(args.concurrency);
 
-    const promises = args.path.map((path) => {
-      return q(() => validateOutputTiff(path, undefined, logger));
+    const promises = args.tiffs.map((tiff) => {
+      return q(() => validateOutputTiff(tiff, undefined, logger));
     });
 
     await Promise.allSettled(promises);

--- a/packages/cogify/src/cogify/gdal.runner.ts
+++ b/packages/cogify/src/cogify/gdal.runner.ts
@@ -45,7 +45,7 @@ export class GdalRunner {
    */
   async run(logger?: LogType): Promise<{ stdout: string; stderr: string; duration: number }> {
     const commandHash = sha256base58(JSON.stringify(this.cmd)); // Hash the arguments as the arguments can be way too big to log
-    logger?.trace({ command: this.cmd.command, args: this.cmd.args, hash: commandHash }, 'Gdal:Command');
+    logger?.debug({ command: this.cmd.command, args: this.cmd.args, hash: commandHash }, 'Gdal:Command');
     logger?.info({ command: this.cmd.command, commandHash }, 'Gdal:Start');
 
     const cmd = this.cmd.command;

--- a/packages/cogify/src/cogify/stac.ts
+++ b/packages/cogify/src/cogify/stac.ts
@@ -20,7 +20,7 @@ export interface CogifyCreationOptions {
    *
    * @default 'webp'
    */
-  compression?: 'webp' | 'jpeg' | 'lerc';
+  compression?: 'webp' | 'jpeg' | 'lerc' | 'zstd' | 'lzw';
 
   /**
    * Output tile size

--- a/packages/cogify/src/preset.ts
+++ b/packages/cogify/src/preset.ts
@@ -59,4 +59,20 @@ const lerc1m: Preset = {
   },
 };
 
-export const Presets = { [webP.name]: webP, [lerc10mm.name]: lerc10mm, [lerc1mm.name]: lerc1mm, [lerc1m.name]: lerc1m };
+const lzw: Preset = {
+  name: 'lzw',
+  options: {
+    blockSize: 512,
+    compression: 'lzw',
+    warpResampling: 'bilinear',
+    overviewResampling: 'bilinear',
+  },
+};
+
+export const Presets = {
+  [webP.name]: webP,
+  [lerc10mm.name]: lerc10mm,
+  [lerc1mm.name]: lerc1mm,
+  [lerc1m.name]: lerc1m,
+  [lzw.name]: lzw,
+};


### PR DESCRIPTION
#### Motivation

Baseamps generally uses three GDAL commands to convert imagery/DEM/DSMs into COGS

build a VRT
`gdalbuildvrt tiffs.vrt *.tiff`

Apply cutline and warp
`gdalwarp -of vrt warped.vrt tiffs.vrt -wo ... `

Convert the warped to a COG

`gdal_translate -of COG warped.vrt`

When reprojecting we often change the resolution of a TIFF to better align with the desired output tile matrix this is done with a `-tr` inside the `gdal_translate` step.

We have found that with just a single `-tr` in the `gdal_translate` it leads to suboptimal COG creation with artifacts.

![old](https://github.com/linz/basemaps/assets/1082761/ab66aeff-7047-4968-b9ad-dec2041ae022)


adding another `-tr` to the warp resolves the issue.

![new](https://github.com/linz/basemaps/assets/1082761/2627537e-7db8-4992-8795-702229fa3da1)


#### Modification

- Adds `-tr` to the gdalwarp to fix some rendering issues
- Adds a `cogify validate` to validate tiffs are what basemaps is expecting.
- 
#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
