### PR TITLE
fix(cogify): log key collisions

### DIFF
--- a/packages/cogify/src/cogify/cli/cli.config.ts
+++ b/packages/cogify/src/cogify/cli/cli.config.ts
@@ -73,7 +73,7 @@ export const BasemapsCogifyConfigCommand = command({
     logger.info(
       {
         imageryId: im.id,
-        path: outputPath,
+        configUrl: outputPath,
         url,
         urlPreview,
         config: configPath,

--- a/packages/cogify/src/cogify/gdal.runner.ts
+++ b/packages/cogify/src/cogify/gdal.runner.ts
@@ -45,7 +45,7 @@ export class GdalRunner {
    */
   async run(logger?: LogType): Promise<{ stdout: string; stderr: string; duration: number }> {
     const commandHash = sha256base58(JSON.stringify(this.cmd)); // Hash the arguments as the arguments can be way too big to log
-    logger?.debug({ command: this.cmd.command, args: this.cmd.args, hash: commandHash }, 'Gdal:Command');
+    logger?.debug({ command: this.cmd.command, gdalArgs: this.cmd.args, hash: commandHash }, 'Gdal:Command');
     logger?.info({ command: this.cmd.command, commandHash }, 'Gdal:Start');
 
     const cmd = this.cmd.command;


### PR DESCRIPTION
#### Motivation

some log keys are duplicated causing indexing exceptions in elasticsearch


#### Modification

renamed a couple of conflicting log keys.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
