### PR TITLE
feat(landing): exaggerate the terrain when viewing in NZTM BM-983

### DIFF
--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -284,7 +284,7 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
 
     const target = getTerrainForSource(sourceId, Config.map.tileMatrix.projection);
     // no changes
-    if ((currentTerrain?.source === sourceId, currentTerrain?.exaggeration === target.exaggeration)) return;
+    if (currentTerrain?.source === sourceId && currentTerrain?.exaggeration === target.exaggeration) return;
 
     const terrainSource = this.props.map.getSource(sourceId);
     if (terrainSource == null) {


### PR DESCRIPTION
#### Motivation

When viewing terrain in NZTM the terrain is too flat, this is caused by the NZTM projection hacks to allow Maplibre to render NZTM, it offsets the zoom level by 2 which means everything is approx 4x smaller.

#### Modification

When viewing in NZTM set the terrain to be approx 4x higher than what we use in 3857.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
