### PR TITLE
fix(lambda-tiler): only use a compose pipeline if a pipeline is defined

### DIFF
--- a/packages/lambda-tiler/src/routes/preview.ts
+++ b/packages/lambda-tiler/src/routes/preview.ts
@@ -162,7 +162,10 @@ export async function renderPreview(req: LambdaHttpRequest, ctx: PreviewRenderCo
   // Load all the tiff tiles and resize/them into the correct locations
   req.timer.start('compose:overlay');
   const overlays = (await Promise.all(
-    compositions.map((comp) => TilerSharp.composeTilePipeline(comp, tileContext)),
+    compositions.map((comp) => {
+      if (tileContext.pipeline) return TilerSharp.composeTilePipeline(comp, tileContext);
+      return TilerSharp.composeTileTiff(comp, tileContext.resizeKernel);
+    }),
   ).then((items) => items.filter((f) => f != null))) as SharpOverlay[];
   req.timer.end('compose:overlay');
 

--- a/packages/server/src/route.layers.ts
+++ b/packages/server/src/route.layers.ts
@@ -11,7 +11,7 @@ import { getPreviewUrl, V } from '@basemaps/shared';
 export async function createLayersHtml(mem: BasemapsConfigProvider): Promise<string> {
   const allLayers = await Promise.all([mem.TileSet.get('ts_all'), mem.TileSet.get('ts_elevation')]);
 
-  const allSourceLayers = allLayers.flatMap((m) => m?.layers) as ConfigLayer[];
+  const allSourceLayers = allLayers.flatMap((m) => m?.layers).filter(Boolean) as ConfigLayer[];
   if (allSourceLayers == null) return 'No layers found.';
 
   const allImagery = await getAllImagery(mem, allSourceLayers, [...Epsg.Codes.values()]);


### PR DESCRIPTION
#### Motivation

Previews for RGBA datasets are currently broken as the decompressor does not know how to decompress 4 band RGBA

#### Modification

Only use the pipeline decompressor if a pipeline is defined.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
