### PR TITLE
feat(landing): add dropdown to configure a hillshade

### DIFF
--- a/packages/landing/src/config.debug.ts
+++ b/packages/landing/src/config.debug.ts
@@ -22,6 +22,9 @@ export interface DebugState {
   'debug.terrain': string | null;
   /** What layer should be visible only */
   'debug.layer': string | null;
+
+  /** Should a hillshade be shown */
+  'debug.hillshade': string | null;
 }
 
 export const DebugDefaults: DebugState = {
@@ -37,6 +40,7 @@ export const DebugDefaults: DebugState = {
   'debug.date': false,
   'debug.terrain': null,
   'debug.layer': null,
+  'debug.hillshade': null,
 };
 
 export class ConfigDebug {

--- a/packages/landing/static/index.css
+++ b/packages/landing/static/index.css
@@ -153,8 +153,8 @@ button {
   position: absolute;
   top: 8px;
   right: 8px;
-  width: 300px;
-  background-color: rgba(255, 255, 255, 0.87);
+  width: 360px;
+  background-color: rgba(255, 255, 255, 0.67);
   padding: 4px 8px;
 }
 


### PR DESCRIPTION
#### Motivation

Hillshades add another level of context to a DEM layer which can be useful when inspecting DEM/DSM sources

#### Modification

Adds a dropdown to the debug page to allow users to select a hillshade layer 

![image](https://github.com/linz/basemaps/assets/1082761/0ade96a3-290a-41ca-a923-0014573fe024)


#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
