### PR TITLE
fix(lambda-tiler): allow .jpg for jpeg images

### DIFF
--- a/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
+++ b/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
@@ -1,5 +1,5 @@
 import { ConfigTileSetRaster, getAllImagery } from '@basemaps/config';
-import { Bounds, Epsg, ImageFormat, TileMatrixSet, TileMatrixSets } from '@basemaps/geo';
+import { Bounds, Epsg, TileMatrixSet, TileMatrixSets } from '@basemaps/geo';
 import { Cotar, Env, stringToUrlFolder, Tiff } from '@basemaps/shared';
 import { getImageFormat, Tiler } from '@basemaps/tiler';
 import { TileMakerSharp } from '@basemaps/tiler-sharp';

--- a/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
+++ b/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
@@ -1,7 +1,7 @@
 import { ConfigTileSetRaster, getAllImagery } from '@basemaps/config';
 import { Bounds, Epsg, ImageFormat, TileMatrixSet, TileMatrixSets } from '@basemaps/geo';
 import { Cotar, Env, stringToUrlFolder, Tiff } from '@basemaps/shared';
-import { Tiler } from '@basemaps/tiler';
+import { getImageFormat, Tiler } from '@basemaps/tiler';
 import { TileMakerSharp } from '@basemaps/tiler-sharp';
 import { HttpHeader, LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambda';
 import pLimit from 'p-limit';
@@ -132,10 +132,13 @@ export const TileXyzRaster = {
     const tiler = new Tiler(xyz.tileMatrix);
     const layers = await tiler.tile(assets, xyz.tile.x, xyz.tile.y, xyz.tile.z);
 
+    const format = getImageFormat(xyz.tileType);
+    if (format == null) return new LambdaHttpResponse(400, 'Invalid image format: ' + xyz.tileType);
+
     const res = await TileComposer.compose({
       layers,
       pipeline: tileOutput.pipeline,
-      format: xyz.tileType as ImageFormat,
+      format,
       background: tileOutput.background ?? tileSet.background ?? DefaultBackground,
       resizeKernel: tileOutput.resizeKernel ?? tileSet.resizeKernel ?? DefaultResizeKernel,
       metrics: req.timer,

--- a/packages/smoke/src/tile.test.ts
+++ b/packages/smoke/src/tile.test.ts
@@ -24,7 +24,7 @@ describe('tile', () => {
     assert.equal(res.status, 200, res.statusText);
   });
 
-  for (const ext of ['png', 'jpeg', 'avif']) {
+  for (const ext of ['png', 'jpeg', 'avif', 'jpg']) {
     it(`should serve a ${ext} tile`, async () => {
       const res = await ctx.req(`/v1/tiles/aerial/WebMercatorQuad/6/62/40.${ext}?api=${ctx.apiKey}`);
       assert.equal(res.status, 200);


### PR DESCRIPTION
#### Motivation

.jpg is currently throwing a error , we should allow .jpg tiles

> Error: Invalid image format "jpg"


#### Modification

allow jpg as a valid extension

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
