### PR TITLE
fix(lambda-tiler): content type for jpg should be image/jpeg

### DIFF
--- a/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
+++ b/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
@@ -151,7 +151,7 @@ export const TileXyzRaster = {
     const response = new LambdaHttpResponse(200, 'ok');
     response.header(HttpHeader.ETag, cacheKey);
     response.header(HttpHeader.CacheControl, 'public, max-age=604800, stale-while-revalidate=86400');
-    response.buffer(res.buffer, 'image/' + xyz.tileType);
+    response.buffer(res.buffer, `image/${format}`);
     return response;
   },
 };

--- a/packages/smoke/src/tile.test.ts
+++ b/packages/smoke/src/tile.test.ts
@@ -28,7 +28,7 @@ describe('tile', () => {
     it(`should serve a ${ext} tile`, async () => {
       const res = await ctx.req(`/v1/tiles/aerial/WebMercatorQuad/6/62/40.${ext}?api=${ctx.apiKey}`);
       assert.equal(res.status, 200);
-      assert.equal(res.headers.get('content-type'), `image/${ext}`);
+      assert.equal(res.headers.get('content-type'), `image/${ext === 'jpg' ? 'jpeg' : ext}`);
     });
   }
 


### PR DESCRIPTION
#### Motivation

image/jpeg is the correct mime type for jpeg images, 

#### Modification

converts image/jpg into image/jpeg when users request '.jpg' tiles.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
