### PR TITLE
fix(landing): Fix the ensure scalecontrol for the NZTM2000quad projection. BM-1004

### DIFF
--- a/packages/landing/src/components/map.tsx
+++ b/packages/landing/src/components/map.tsx
@@ -97,6 +97,7 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
     } else {
       if (this.controlScale == null) return;
       this.map.removeControl(this.controlScale);
+      this.controlScale = null;
     }
   }
 


### PR DESCRIPTION
#### Motivation

`ScaleControl` can't be removed for NZTM200Quad projection which broken the layer dropdown in nztm200quad.

#### Modification

- set `controlScale` to null after remove.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
