### PR TITLE
feat(cli): expose the smoke checker in the CLI container so linz/basemaps-config can use it BM-1010

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20040,9 +20040,6 @@
       "name": "@basemaps/smoke",
       "version": "7.2.0",
       "license": "MIT",
-      "dependencies": {
-        "@basemaps/shared": "^7.1.0"
-      },
       "engines": {
         "node": ">=18.0.0"
       }

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -20,8 +20,9 @@ RUN npm install sharp@0.33.0
 # Install the landing assets
 COPY ./basemaps-landing*.tgz /app/
 COPY ./basemaps-cogify*.tgz /app/
+COPY ./basemaps-smoke*.tgz /app/
 
-RUN npm install ./basemaps-landing*.tgz ./basemaps-cogify*.tgz
+RUN npm install ./basemaps-landing*.tgz ./basemaps-cogify*.tgz ./basemaps-smoke*.tgz
 
 COPY dist/index.cjs /app/
 

--- a/packages/smoke/package.json
+++ b/packages/smoke/package.json
@@ -24,7 +24,5 @@
     "build/",
     "bin/"
   ],
-  "dependencies": {
-    "@basemaps/shared": "^7.1.0"
-  }
+  "dependencies": {}
 }

--- a/packages/smoke/src/base.ts
+++ b/packages/smoke/src/base.ts
@@ -1,9 +1,7 @@
 import assert from 'node:assert';
 
-import { LogConfig } from '@basemaps/shared';
 import ulid from 'ulid';
 
-const logger = LogConfig.get();
 /** Fresh API Key to use */
 const apiKey = 'c' + ulid.ulid().toLowerCase().slice(0, 22) + 'test';
 
@@ -27,14 +25,16 @@ if (!host.protocol.startsWith('http')) throw new Error(`Invalid host: ${host}`);
  */
 async function req(path: string, opts?: RequestInit): Promise<Response> {
   const target = new URL(path, host);
-  logger.trace({ path, url: target.href }, 'Fetch');
+
   const startTime = performance.now();
   const res = await fetch(target, opts);
-  logger.info({ url: target.href, status: res.status, ...opts, duration: performance.now() - startTime }, 'Fetch:Done');
+
+  // eslint-disable-next-line no-console
+  console.log({ url: target.href, status: res.status, ...opts, duration: performance.now() - startTime }, 'Fetch:Done');
   return res;
 }
 
-export const ctx = { logger, host, Cors, apiKey, req };
+export const ctx = { host, Cors, apiKey, req };
 
 /** Validate that the response was not a cached response */
 export function assertCacheMiss(res: Response): void {


### PR DESCRIPTION
#### Motivation

A configuration change in https://github.com/linz/basemaps-config broke the smoke check tests, It would be nice to run the smoke checker on config changes before deploying them.

#### Modification

Exposes the smoke checker as a package inside the basemaps/cli container so it can be used by https://github.com/linz/basemaps-config

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
