### PR TITLE
fix(cli): Fix the check vector diff outputs. BM-1013

### DIFF
--- a/packages/cli/src/cli/config/config.diff.ts
+++ b/packages/cli/src/cli/config/config.diff.ts
@@ -141,7 +141,7 @@ export async function diffVectorUpdate(
     // Find layer updates
     for (const l of ldsLayers) {
       const existingLayer = existingLdsLayers.get(l['lds:id']);
-      const change = getVectorChanges(l, undefined);
+      const change = getVectorChanges(l, existingLayer);
       if (change != null) changes.push(change);
       if (existingLayer != null) existingLdsLayers.delete(l['lds:id']);
     }


### PR DESCRIPTION
#### Motivation

The check vector update output is not working as expected, and take everything as new inserts.

#### Modification

- Fix it as it didn't take the existing one into comparison.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
