### PR TITLE
fix(lambda-tiler): ensure wmts limits extent to the bounding box of the tile matrix extent BM-1012

### DIFF
--- a/packages/lambda-tiler/src/__tests__/wmts.capability.test.ts
+++ b/packages/lambda-tiler/src/__tests__/wmts.capability.test.ts
@@ -271,7 +271,6 @@ describe('WmtsCapabilities', () => {
     assert.equal(wgs84?.find('ows:LowerCorner')?.toString(), '<ows:LowerCorner>-180 -85.051129</ows:LowerCorner>');
     assert.equal(wgs84?.find('ows:UpperCorner')?.toString(), '<ows:UpperCorner>180 85.051129</ows:UpperCorner>');
 
-    console.log();
   });
 
   it('should limit a bounding box to the tileMatrix extent NZTM2000Quad', () => {

--- a/packages/lambda-tiler/src/__tests__/wmts.capability.test.ts
+++ b/packages/lambda-tiler/src/__tests__/wmts.capability.test.ts
@@ -257,7 +257,6 @@ describe('WmtsCapabilities', () => {
     const wgs84 = raw.find('Contents', 'Layer', 'ows:WGS84BoundingBox');
     const epsg3857 = raw.find('Contents', 'Layer', 'ows:BoundingBox');
 
-    console.log(epsg3857?.toString());
     assert.equal(
       epsg3857?.find('ows:LowerCorner')?.toString(),
       `<ows:LowerCorner>-20037508.3428 -20037508.3428</ows:LowerCorner>`,
@@ -267,10 +266,8 @@ describe('WmtsCapabilities', () => {
       `<ows:UpperCorner>20037508.3428 20037508.3428</ows:UpperCorner>`,
     );
 
-    console.log(wgs84?.toString());
     assert.equal(wgs84?.find('ows:LowerCorner')?.toString(), '<ows:LowerCorner>-180 -85.051129</ows:LowerCorner>');
     assert.equal(wgs84?.find('ows:UpperCorner')?.toString(), '<ows:UpperCorner>180 85.051129</ows:UpperCorner>');
-
   });
 
   it('should limit a bounding box to the tileMatrix extent NZTM2000Quad', () => {
@@ -308,7 +305,6 @@ describe('WmtsCapabilities', () => {
       `<ows:UpperCorner>10438190.1652 6758167.443</ows:UpperCorner>`,
     );
 
-    console.log(wgs84?.toString());
     assert.equal(wgs84?.find('ows:LowerCorner')?.toString(), '<ows:LowerCorner>-180 -49.929855</ows:LowerCorner>');
     assert.equal(wgs84?.find('ows:UpperCorner')?.toString(), '<ows:UpperCorner>180 2.938603</ows:UpperCorner>');
   });

--- a/packages/lambda-tiler/src/__tests__/wmts.capability.test.ts
+++ b/packages/lambda-tiler/src/__tests__/wmts.capability.test.ts
@@ -229,6 +229,91 @@ describe('WmtsCapabilities', () => {
     );
   });
 
+  it('should limit a bounding box to the tileMatrix extent WebMercatorQuad', () => {
+    const wmts = new WmtsCapabilities({ httpBase: 'https://basemaps.test', apiKey });
+
+    const bigImagery = new Map();
+    bigImagery.set(Imagery3857.id, {
+      ...Imagery3857,
+      bounds: {
+        // These bounds are slightly outside the extent bounds of 3857 (approx 0.3m offset)
+        // {x: -20037508.34 y:-20037508.34, width: 40075016.6855784 , height: 40075016.6855784 }
+        x: -20037508.6276,
+        y: -20037508.6276,
+        width: 40075016.9626,
+        height: 40075014.197799996,
+      },
+    });
+
+    wmts.fromParams({
+      provider: Provider,
+      tileMatrix: [GoogleTms],
+      tileSet: TileSetAerial,
+      imagery: bigImagery,
+      formats: ['png'],
+    });
+    const raw = wmts.toVNode();
+
+    const wgs84 = raw.find('Contents', 'Layer', 'ows:WGS84BoundingBox');
+    const epsg3857 = raw.find('Contents', 'Layer', 'ows:BoundingBox');
+
+    console.log(epsg3857?.toString());
+    assert.equal(
+      epsg3857?.find('ows:LowerCorner')?.toString(),
+      `<ows:LowerCorner>-20037508.3428 -20037508.3428</ows:LowerCorner>`,
+    );
+    assert.equal(
+      epsg3857?.find('ows:UpperCorner')?.toString(),
+      `<ows:UpperCorner>20037508.3428 20037508.3428</ows:UpperCorner>`,
+    );
+
+    console.log(wgs84?.toString());
+    assert.equal(wgs84?.find('ows:LowerCorner')?.toString(), '<ows:LowerCorner>-180 -85.051129</ows:LowerCorner>');
+    assert.equal(wgs84?.find('ows:UpperCorner')?.toString(), '<ows:UpperCorner>180 85.051129</ows:UpperCorner>');
+
+    console.log();
+  });
+
+  it('should limit a bounding box to the tileMatrix extent NZTM2000Quad', () => {
+    const wmts = new WmtsCapabilities({ httpBase: 'https://basemaps.test', apiKey });
+    const bigImagery = new Map();
+
+    bigImagery.set(Imagery2193.id, {
+      ...Imagery2193,
+      bounds: {
+        // These bounds are slightly outside the extent bounds of NZTM2000Quad (approx 0.3m offset)
+        x: -3260586.9214,
+        y: 419435.7552,
+        width: 10018754.086099999,
+        height: 10018754.086099999,
+      },
+    });
+
+    wmts.fromParams({
+      provider: Provider,
+      tileMatrix: [Nztm2000QuadTms],
+      tileSet: TileSetAerial,
+      imagery: bigImagery,
+      formats: ['png'],
+    });
+    const raw = wmts.toVNode();
+
+    const wgs84 = raw.find('Contents', 'Layer', 'ows:WGS84BoundingBox');
+    const crsBounds = raw.find('Contents', 'Layer', 'ows:BoundingBox');
+    assert.equal(
+      crsBounds?.find('ows:LowerCorner')?.toString(),
+      `<ows:LowerCorner>419435.9938 -3260586.7284</ows:LowerCorner>`,
+    );
+    assert.equal(
+      crsBounds?.find('ows:UpperCorner')?.toString(),
+      `<ows:UpperCorner>10438190.1652 6758167.443</ows:UpperCorner>`,
+    );
+
+    console.log(wgs84?.toString());
+    assert.equal(wgs84?.find('ows:LowerCorner')?.toString(), '<ows:LowerCorner>-180 -49.929855</ows:LowerCorner>');
+    assert.equal(wgs84?.find('ows:UpperCorner')?.toString(), '<ows:UpperCorner>180 2.938603</ows:UpperCorner>');
+  });
+
   it('should include output the correct TileMatrix', () => {
     const wmts = new WmtsCapabilities({
       httpBase: 'https://basemaps.test',
@@ -512,11 +597,12 @@ describe('WmtsCapabilities', () => {
         .split('\n')
         .map((c) => c.trim()),
     );
+
     assert.deepEqual(boundingBox[0][1], '<ows:LowerCorner>-180 -85.0511</ows:LowerCorner>');
-    assert.equal(boundingBox[0][2], '<ows:UpperCorner>180 0</ows:UpperCorner>');
+    assert.equal(boundingBox[0][2], '<ows:UpperCorner>180 85.0511</ows:UpperCorner>');
 
     assert.deepEqual(boundingBox[1][1], '<ows:LowerCorner>-180 -85.0511</ows:LowerCorner>');
-    assert.equal(boundingBox[1][2], '<ows:UpperCorner>180 0</ows:UpperCorner>');
+    assert.equal(boundingBox[1][2], '<ows:UpperCorner>180 85.0511</ows:UpperCorner>');
   });
 
   it('should work with NZTM2000Quad', () => {

--- a/packages/lambda-tiler/src/__tests__/wmts.capability.test.ts
+++ b/packages/lambda-tiler/src/__tests__/wmts.capability.test.ts
@@ -237,7 +237,7 @@ describe('WmtsCapabilities', () => {
       ...Imagery3857,
       bounds: {
         // These bounds are slightly outside the extent bounds of 3857 (approx 0.3m offset)
-        // {x: -20037508.34 y:-20037508.34, width: 40075016.6855784 , height: 40075016.6855784 }
+        // expected bounds: {x: -20037508.34 y:-20037508.34, width: 40075016.6855784 , height: 40075016.6855784 }
         x: -20037508.6276,
         y: -20037508.6276,
         width: 40075016.9626,

--- a/packages/lambda-tiler/src/wmts.capability.ts
+++ b/packages/lambda-tiler/src/wmts.capability.ts
@@ -96,7 +96,6 @@ export class WmtsBuilder {
   buildWgs84BoundingBox(tms: TileMatrixSet, layers: Bounds[]): VNodeElement {
     let bbox: BBox | null = null;
 
-    // console.log(layers);
     if (layers.length > 0) {
       let bounds = layers[0];
       for (let i = 1; i < layers.length; i++) {

--- a/packages/smoke/src/base.ts
+++ b/packages/smoke/src/base.ts
@@ -30,7 +30,19 @@ async function req(path: string, opts?: RequestInit): Promise<Response> {
   const res = await fetch(target, opts);
 
   // eslint-disable-next-line no-console
-  console.log({ url: target.href, status: res.status, ...opts, duration: performance.now() - startTime }, 'Fetch:Done');
+  console.log(
+    // Create a fake log line approximating the pino log format
+    JSON.stringify({
+      pid: 0,
+      time: new Date().toISOString(),
+      level: 30,
+      msg: 'Fetch:Done',
+      url: target.href,
+      status: res.status,
+      ...opts,
+      duration: performance.now() - startTime,
+    }),
+  );
   return res;
 }
 

--- a/packages/smoke/src/wmts.test.ts
+++ b/packages/smoke/src/wmts.test.ts
@@ -28,13 +28,23 @@ test(`GET /v1/tiles/aerial/WebMercatorQuad/WMTSCapabilities.xml`, async () => {
 
   assert.ok(
     xml.includes(
-      `<ows:BoundingBox crs="urn:ogc:def:crs:EPSG::3857"><ows:LowerCorner>-20037508.3428 -20037508.3428</ows:LowerCorner><ows:UpperCorner>20037508.3428 20037508.3428</ows:UpperCorner></ows:BoundingBox>`,
+      [
+        `<ows:BoundingBox crs="urn:ogc:def:crs:EPSG::3857">`,
+        `<ows:LowerCorner>-20037508.3428 -20037508.3428</ows:LowerCorner>`,
+        `<ows:UpperCorner>20037508.3428 20037508.3428</ows:UpperCorner>`,
+        `</ows:BoundingBox>`,
+      ].join(''),
     ),
   );
 
   assert.ok(
     xml.includes(
-      `<ows:WGS84BoundingBox crs="urn:ogc:def:crs:OGC:2:84"><ows:LowerCorner>-180 -85.051129</ows:LowerCorner><ows:UpperCorner>180 85.051129</ows:UpperCorner></ows:WGS84BoundingBox>`,
+      [
+        `<ows:WGS84BoundingBox crs="urn:ogc:def:crs:OGC:2:84">`,
+        `<ows:LowerCorner>-180 -85.051129</ows:LowerCorner>`,
+        `<ows:UpperCorner>180 85.051129</ows:UpperCorner>`,
+        `</ows:WGS84BoundingBox>`,
+      ].join(''),
     ),
   );
 


### PR DESCRIPTION
#### Motivation

As we recently changed the basemaps configuration to use the raw tiff values for extent rather than the name of the tile, the extents of each layer has slightly changed.

This works for most layers except ones which cover the entire world, for example `0-0-0.tiff` this can lead to slight floating point errors in the extents between the TileMatrix and the tiff.

#### Modification

If the imagery extent is outside the bounds of the tile matrix fall back to the extent of the tile matrix.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
