### PR TITLE
feat: apply common aws cicd tags across basemaps infra

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,17 +47,20 @@
     "node_modules/@aws-cdk/asset-awscli-v1": {
       "version": "2.2.201",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.201.tgz",
-      "integrity": "sha512-INZqcwDinNaIdb5CtW3ez5s943nX5stGBQS6VOP2JDlOFP81hM3fds/9NDknipqfUkZM43dx+HgVvkXYXXARCQ=="
+      "integrity": "sha512-INZqcwDinNaIdb5CtW3ez5s943nX5stGBQS6VOP2JDlOFP81hM3fds/9NDknipqfUkZM43dx+HgVvkXYXXARCQ==",
+      "dev": true
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
-      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
+      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg==",
+      "dev": true
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
-      "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg=="
+      "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg==",
+      "dev": true
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "3.0.0",
@@ -3130,6 +3133,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@linzjs/cdk-tags/-/cdk-tags-1.1.0.tgz",
       "integrity": "sha512-vzNb7Y5xrxtv2Pe08pLCWpP1NY2ToLbJICgWvFS6Q+yeE1emGhoY7kturnb0fyT3QrxTpMvS4kSArtOGBKvWlA==",
+      "dev": true,
       "engines": {
         "node": ">=18.0"
       },
@@ -6224,6 +6228,7 @@
         "table",
         "yaml"
       ],
+      "dev": true,
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "^2.2.201",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",
@@ -7417,6 +7422,7 @@
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.3.0.tgz",
       "integrity": "sha512-vbK8i3rIb/xwZxSpTjz3SagHn1qq9BChLEfy5Hf6fB3/2eFbrwt2n9kHwQcS0CPTRBesreeAcsJfMq2229FnbQ==",
+      "dev": true,
       "engines": {
         "node": ">= 16.14.0"
       }
@@ -19661,14 +19667,12 @@
       "name": "@basemaps/infra",
       "version": "7.2.0",
       "license": "MIT",
-      "dependencies": {
-        "@linzjs/cdk-tags": "^1.1.0"
-      },
       "devDependencies": {
         "@aws-sdk/client-acm": "^3.470.0",
         "@aws-sdk/client-cloudformation": "^3.470.0",
         "@basemaps/lambda-tiler": "^7.2.0",
         "@basemaps/shared": "^7.1.0",
+        "@linzjs/cdk-tags": "^1.1.0",
         "aws-cdk": "2.114.x",
         "aws-cdk-lib": "2.114.x",
         "constructs": "^10.3.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,20 +47,17 @@
     "node_modules/@aws-cdk/asset-awscli-v1": {
       "version": "2.2.201",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.201.tgz",
-      "integrity": "sha512-INZqcwDinNaIdb5CtW3ez5s943nX5stGBQS6VOP2JDlOFP81hM3fds/9NDknipqfUkZM43dx+HgVvkXYXXARCQ==",
-      "dev": true
+      "integrity": "sha512-INZqcwDinNaIdb5CtW3ez5s943nX5stGBQS6VOP2JDlOFP81hM3fds/9NDknipqfUkZM43dx+HgVvkXYXXARCQ=="
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
-      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg==",
-      "dev": true
+      "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg=="
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
-      "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg==",
-      "dev": true
+      "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg=="
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "3.0.0",
@@ -3127,6 +3124,18 @@
       "dev": true,
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@linzjs/cdk-tags": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@linzjs/cdk-tags/-/cdk-tags-1.1.0.tgz",
+      "integrity": "sha512-vzNb7Y5xrxtv2Pe08pLCWpP1NY2ToLbJICgWvFS6Q+yeE1emGhoY7kturnb0fyT3QrxTpMvS4kSArtOGBKvWlA==",
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "aws-cdk-lib": "*",
+        "constructs": "*"
       }
     },
     "node_modules/@linzjs/docker-command": {
@@ -6215,7 +6224,6 @@
         "table",
         "yaml"
       ],
-      "dev": true,
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "^2.2.201",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",
@@ -7409,7 +7417,6 @@
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.3.0.tgz",
       "integrity": "sha512-vbK8i3rIb/xwZxSpTjz3SagHn1qq9BChLEfy5Hf6fB3/2eFbrwt2n9kHwQcS0CPTRBesreeAcsJfMq2229FnbQ==",
-      "dev": true,
       "engines": {
         "node": ">= 16.14.0"
       }
@@ -19654,6 +19661,9 @@
       "name": "@basemaps/infra",
       "version": "7.2.0",
       "license": "MIT",
+      "dependencies": {
+        "@linzjs/cdk-tags": "^1.1.0"
+      },
       "devDependencies": {
         "@aws-sdk/client-acm": "^3.470.0",
         "@aws-sdk/client-cloudformation": "^3.470.0",

--- a/packages/_infra/package.json
+++ b/packages/_infra/package.json
@@ -28,11 +28,9 @@
     "@aws-sdk/client-cloudformation": "^3.470.0",
     "@basemaps/lambda-tiler": "^7.2.0",
     "@basemaps/shared": "^7.1.0",
+    "@linzjs/cdk-tags": "^1.1.0",
     "aws-cdk": "2.114.x",
     "aws-cdk-lib": "2.114.x",
     "constructs": "^10.3.0"
-  },
-  "dependencies": {
-    "@linzjs/cdk-tags": "^1.1.0"
   }
 }

--- a/packages/_infra/package.json
+++ b/packages/_infra/package.json
@@ -31,5 +31,8 @@
     "aws-cdk": "2.114.x",
     "aws-cdk-lib": "2.114.x",
     "constructs": "^10.3.0"
+  },
+  "dependencies": {
+    "@linzjs/cdk-tags": "^1.1.0"
   }
 }

--- a/packages/_infra/src/config.ts
+++ b/packages/_infra/src/config.ts
@@ -34,8 +34,10 @@ export const BaseMapsDevConfig: BaseMapsConfig = {
   PublicUrlBase: 'https://dev.basemaps.linz.govt.nz',
   AwsRoleConfigBucket: 'linz-bucket-config',
 };
+/** Is this deployment intended for production */
+export const IsProduction = process.env['NODE_ENV'] === 'production';
 
 export function getConfig(): BaseMapsConfig {
-  if (process.env['NODE_ENV'] === 'production') return BaseMapsProdConfig;
+  if (IsProduction) return BaseMapsProdConfig;
   return BaseMapsDevConfig;
 }

--- a/packages/_infra/src/index.ts
+++ b/packages/_infra/src/index.ts
@@ -2,7 +2,6 @@ import { ACMClient, ListCertificatesCommand } from '@aws-sdk/client-acm';
 import { Env } from '@basemaps/shared';
 import { applyTags, SecurityClassification } from '@linzjs/cdk-tags';
 import { App } from 'aws-cdk-lib';
-import { Classification } from 'aws-cdk-lib/aws-stepfunctions-tasks';
 
 import { EdgeAnalytics } from './analytics/edge.analytics.js';
 import { BaseMapsRegion, getConfig, IsProduction } from './config.js';


### PR DESCRIPTION
#### Motivation

Common CICD tags helps us understand how resources are managed inside our AWS accounts

see https://github.com/linz/cdk-tag for more information on the tags created.

#### Modification

Applies common github CICD tags to all basemaps resources. 

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
