### PR TITLE
feat(landing): Add off for the dem/dsm layer dropdown in debug page. BM-1019

### DIFF
--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -432,7 +432,7 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
       label: 'Layer',
       onChange: this.selectRasterSource,
       value: selectedSource,
-      options: sourceIds,
+      options: [...sourceIds, 'off'],
     });
   }
 


### PR DESCRIPTION
#### Motivation

It would be helpful to view a DEM/DSM as just the hillshade, can we turn off the color-ramp and terrain-rgb visualisations with a “layer: off”? 

#### Modification

Add a off option after the sourceIds, which make it not as default.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
