### PR TITLE
fix(landing): ensure the layer dropdown always showing for all outputs. BM-1001

### DIFF
--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -425,8 +425,7 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
     const sourceIds = this.getSourcesIds('raster');
     if (sourceIds.length <= 1) return;
     // Get default source
-    let selectedSource = this.props.map.getLayer(Config.map.styleId)?.source;
-    if (selectedSource == null) selectedSource = 'off';
+    const selectedSource = this.props.map.getLayer(Config.map.styleId)?.source ?? 'off'; 
 
     return debugSourceDropdown({
       label: 'Layer',

--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -425,7 +425,7 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
     const sourceIds = this.getSourcesIds('raster');
     if (sourceIds.length <= 1) return;
     // Get default source
-    const selectedSource = this.props.map.getLayer(Config.map.styleId)?.source ?? 'off'; 
+    const selectedSource = this.props.map.getLayer(Config.map.styleId)?.source ?? 'off';
 
     return debugSourceDropdown({
       label: 'Layer',

--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -425,8 +425,8 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
     const sourceIds = this.getSourcesIds('raster');
     if (sourceIds.length <= 1) return;
     // Get default source
-    const selectedSource = this.props.map.getLayer(Config.map.styleId)?.source;
-    if (selectedSource == null) return;
+    let selectedSource = this.props.map.getLayer(Config.map.styleId)?.source;
+    if (selectedSource == null) selectedSource = 'off';
 
     return debugSourceDropdown({
       label: 'Layer',

--- a/packages/landing/src/config.map.ts
+++ b/packages/landing/src/config.map.ts
@@ -108,7 +108,7 @@ export class MapConfig extends Emitter<MapConfigEvents> {
 
   /** Used as source and layer id in the Style JSON for a given layer ID */
   get styleId(): string {
-    return `basemaps-${Config.map.style}`;
+    return Config.map.style == null ? `basemaps-${Config.map.layerId}` : `basemaps-${Config.map.style}`;
   }
 
   getDateRangeFromUrl(urlParams: URLSearchParams): FilterDate {


### PR DESCRIPTION
#### Motivation

Outputs layers not showing up when using the `i` query parameter to viewing elevations data. Cause the `Config.map.styleId` will return the empty styleId. 

#### Modification

- Using layerId when `style` query parameter not specified. 
- Showing 'off' when there is no selectedSrouce for the layer dropdown.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title
