### PR TITLE
fix(landing): Fix the set the tileset id same as style when only style parameter been set.

### DIFF
--- a/packages/landing/src/config.map.ts
+++ b/packages/landing/src/config.map.ts
@@ -123,7 +123,7 @@ export class MapConfig extends Emitter<MapConfigEvents> {
     const urlParams = new URLSearchParams(search);
     const style = urlParams.get('s') ?? urlParams.get('style');
     const config = urlParams.get('c') ?? urlParams.get('config');
-    const layerId = urlParams.get('i') ?? 'aerial';
+    const layerId = urlParams.get('i') ?? style ?? 'aerial';
     const date = this.getDateRangeFromUrl(urlParams);
     if (this.filter.date.before !== date.before) {
       this.filter.date = date;


### PR DESCRIPTION
#### Motivation

We are able to get individual imagery by the `?style=` request parameter only, but this will not populate to the related virtual tilesetId and set default as `ts_aerial`. 

#### Modification

- We can set `layerId` as style id first before set as default `aerial`.

#### Checklist

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
