### PR TITLE
fix(shared): retry dynamodb queries more times BM-1008

### DIFF
--- a/packages/shared/src/dynamo/dynamo.config.ts
+++ b/packages/shared/src/dynamo/dynamo.config.ts
@@ -9,6 +9,7 @@ import {
   ConfigTileSet,
   ConfigVectorStyle,
 } from '@basemaps/config';
+import { ConfiguredRetryStrategy } from '@smithy/util-retry';
 
 import { ConfigDynamoBase } from './dynamo.config.base.js';
 import { ConfigDynamoCached } from './dynamo.config.cached.js';
@@ -28,7 +29,13 @@ export class ConfigProviderDynamo extends BasemapsConfigProvider {
 
   constructor(tableName: string) {
     super();
-    this.dynamo = new DynamoDB({ region: 'ap-southeast-2' });
+    this.dynamo = new DynamoDB({
+      region: 'ap-southeast-2',
+      retryStrategy: new ConfiguredRetryStrategy(
+        5, // max attempts.
+        (attempt: number) => 100 + attempt * 250, // 100, 350, 600, 850, 1100ms
+      ),
+    });
     this.tableName = tableName;
   }
 


### PR DESCRIPTION
#### Motivation

Dynamo is sometimes erroring with throttling exception, we currently have retries set at 3 retires

```
stack: ThrottlingException: Throughput exceeds the current capacity of your table or index. 
DynamoDB is automatically scaling your table or index so please try again shortly.
If exceptions persist, check if you have a hot key: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/bp-partition-key-design.html
    at qke (/var/task/index.js:20:5520)
````

#### Modification

Increase the retry count to 5, so that it retries more before erroring.


#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
