### PR TITLE
fix(smoke): Smoke test is missing ulid dependency to running inside the container.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19037,7 +19037,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/ulid/-/ulid-2.3.0.tgz",
       "integrity": "sha512-keqHubrlpvT6G2wH0OEfSW4mquYRcbe/J8NMmveoQOjUqmo+hXtO+ORCpWhdbZ7k72UtY61BL7haGxW6enBnjw==",
-      "license": "MIT",
       "bin": {
         "ulid": "bin/cli.js"
       }
@@ -20054,6 +20053,9 @@
       "name": "@basemaps/smoke",
       "version": "7.3.0",
       "license": "MIT",
+      "dependencies": {
+        "ulid": "^2.3.0"
+      },
       "engines": {
         "node": ">=18.0.0"
       }

--- a/packages/smoke/package.json
+++ b/packages/smoke/package.json
@@ -23,5 +23,8 @@
   "files": [
     "build/",
     "bin/"
-  ]
+  ],
+  "dependencies": {
+    "ulid": "^2.3.0"
+  }
 }


### PR DESCRIPTION
#### Motivation

Smoke test should be able to running in the cli container, but it is missing the ulid depenency.

#### Modification

Install ulid for smoke

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
