### PR TITLE
fix(cli): Copy static files into cli container for health smoke test.

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -50,6 +50,7 @@ jobs:
           # Files are packed into the base directory
           cp *.tgz packages/server/
           cp *.tgz packages/cli/
+          cp -r packages/lambda-tiler/static/ packages/cli/
 
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -22,6 +22,9 @@ COPY ./basemaps-landing*.tgz /app/
 COPY ./basemaps-cogify*.tgz /app/
 COPY ./basemaps-smoke*.tgz /app/
 
+# Copy the static files for v1/health check
+COPY ./static/ /app/static/
+
 RUN npm install ./basemaps-landing*.tgz ./basemaps-cogify*.tgz ./basemaps-smoke*.tgz
 
 COPY dist/index.cjs /app/


### PR DESCRIPTION
#### Motivation

Running smoke test inside basemaps container missing static files for health endpoint test.

#### Modification

Copy the static files into basemaps container.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
