### PR TITLE
fix(tiler-sharp): clamp elevation to the bounds of terrain rgb BM-1028

### DIFF
--- a/packages/tiler-sharp/src/pipeline/pipeline.terrain.rgb.ts
+++ b/packages/tiler-sharp/src/pipeline/pipeline.terrain.rgb.ts
@@ -2,8 +2,19 @@ import { Tiff } from '@cogeotiff/core';
 
 import { DecompressedInterleaved, Pipeline } from './decompressor.js';
 
-export const PipelineTerrainRgb: Pipeline = {
+const MinValue = -10_000;
+const MaxValue = 1_667_721.5;
+export interface TerrainRgbRange {
+  /** Minimum value that can be encoded */
+  MinValue: -10_000;
+  /** Maximum value that can be encoded */
+  MaxValue: 1_667_721.5;
+}
+
+export const PipelineTerrainRgb: Pipeline & TerrainRgbRange = {
   type: 'terrain-rgb',
+  MinValue,
+  MaxValue,
   process(source: Tiff, data: DecompressedInterleaved): DecompressedInterleaved {
     const raw = new Uint8ClampedArray(data.width * data.height * 4);
     const output: DecompressedInterleaved = {
@@ -26,9 +37,25 @@ export const PipelineTerrainRgb: Pipeline = {
 
       if (noData != null && px === noData) continue;
 
+      const target = i * 4;
+
+      // If the value is below the minimum value, set it to 0,0,0,255 (RGBA)
+      if (px <= MinValue) {
+        raw[target + 3] = 255;
+        continue;
+      }
+
+      // If the value is above the max value clamp it to 255,255,255,255 (RGBA)
+      if (px >= MaxValue) {
+        raw[target] = 255;
+        raw[target + 1] = 255;
+        raw[target + 2] = 255;
+        raw[target + 3] = 255;
+        continue;
+      }
+
       const v = (px - base) / interval;
 
-      const target = i * 4;
       raw[target] = (v >> 16) & 0xff; // Math.floor(v / 256 / 256) % 256;
       raw[target + 1] = (v >> 8) & 0xff; // Math.floor(v / 256) % 256;
       raw[target + 2] = v % 256;


### PR DESCRIPTION
#### Motivation

Very small height values are overflowing terrain rgb, eg the Mariana trench which cause rendering artifacts.

![image](https://github.com/linz/basemaps/assets/1082761/8d8e935e-c3ce-440c-bfb1-c0a299ad2864)


#### Modification

clamps the values of terrain rgb to the possible pixel ranges (0,0,0 -> 255,255,255)

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
