### PR TITLE
feat(cogify): Update the configs for lerc presets to include 1cm/2cm lerc. BM-1035

### DIFF
--- a/packages/cogify/src/preset.ts
+++ b/packages/cogify/src/preset.ts
@@ -24,36 +24,37 @@ const webP: Preset = {
   },
 };
 
-const lerc10mm: Preset = {
-  name: 'lerc_10mm',
-  options: {
-    blockSize: 512,
-    compression: 'lerc',
-    maxZError: 0.01,
-    maxZErrorOverview: 0.1,
-    warpResampling: 'bilinear',
-    overviewResampling: 'bilinear',
-  },
-};
-
 const lerc1mm: Preset = {
   name: 'lerc_1mm',
   options: {
     blockSize: 512,
     compression: 'lerc',
     maxZError: 0.001,
-    maxZErrorOverview: 0.1,
+    maxZErrorOverview: 0.01,
     warpResampling: 'bilinear',
     overviewResampling: 'bilinear',
   },
 };
+
+const lerc1cm: Preset = {
+  name: 'lerc_1cm',
+  options: {
+    blockSize: 512,
+    compression: 'lerc',
+    maxZError: 0.1,
+    maxZErrorOverview: 0.2,
+    warpResampling: 'bilinear',
+    overviewResampling: 'bilinear',
+  },
+};
+
 const lerc1m: Preset = {
   name: 'lerc_1m',
   options: {
     blockSize: 512,
     compression: 'lerc',
     maxZError: 1,
-    maxZErrorOverview: 4,
+    maxZErrorOverview: 2,
     warpResampling: 'bilinear',
     overviewResampling: 'bilinear',
   },
@@ -71,8 +72,8 @@ const lzw: Preset = {
 
 export const Presets = {
   [webP.name]: webP,
-  [lerc10mm.name]: lerc10mm,
   [lerc1mm.name]: lerc1mm,
+  [lerc1cm.name]: lerc1cm,
   [lerc1m.name]: lerc1m,
   [lzw.name]: lzw,
 };

--- a/packages/cogify/src/preset.ts
+++ b/packages/cogify/src/preset.ts
@@ -36,25 +36,13 @@ const lerc1mm: Preset = {
   },
 };
 
-const lerc1cm: Preset = {
-  name: 'lerc_1cm',
+const lerc10mm: Preset = {
+  name: 'lerc_10mm',
   options: {
     blockSize: 512,
     compression: 'lerc',
-    maxZError: 0.1,
-    maxZErrorOverview: 0.2,
-    warpResampling: 'bilinear',
-    overviewResampling: 'bilinear',
-  },
-};
-
-const lerc1m: Preset = {
-  name: 'lerc_1m',
-  options: {
-    blockSize: 512,
-    compression: 'lerc',
-    maxZError: 1,
-    maxZErrorOverview: 2,
+    maxZError: 0.01,
+    maxZErrorOverview: 0.02,
     warpResampling: 'bilinear',
     overviewResampling: 'bilinear',
   },
@@ -73,7 +61,6 @@ const lzw: Preset = {
 export const Presets = {
   [webP.name]: webP,
   [lerc1mm.name]: lerc1mm,
-  [lerc1cm.name]: lerc1cm,
-  [lerc1m.name]: lerc1m,
+  [lerc10mm.name]: lerc10mm,
   [lzw.name]: lzw,
 };


### PR DESCRIPTION
#### Motivation

After testing with different config, we decide to use 1cm/2cm on the lerc config.

#### Modification

- Update existing 1mm/10mm lerc config

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
