### PR TITLE
feat(tiler-sharp): reducde the z precision of terrain-rgb to generate much smaller tiles for low z levels BM-1002

### DIFF
--- a/packages/tiler-sharp/src/index.ts
+++ b/packages/tiler-sharp/src/index.ts
@@ -184,7 +184,7 @@ export class TileMakerSharp implements TileMaker {
 
       for (const pipe of ctx.pipeline) {
         const pipelineStart = performance.now();
-        result = await Pipelines[pipe.type]?.process(comp.asset, result);
+        result = await Pipelines[pipe.type]?.process(comp, result);
         ctx.log?.trace(
           {
             pipeline: pipe.type,

--- a/packages/tiler-sharp/src/pipeline/decompressor.ts
+++ b/packages/tiler-sharp/src/pipeline/decompressor.ts
@@ -1,3 +1,4 @@
+import { CompositionTiff } from '@basemaps/tiler';
 import { Tiff } from '@cogeotiff/core';
 
 export interface DecompressedInterleavedFloat {
@@ -26,5 +27,8 @@ export interface Decompressor {
 
 export interface Pipeline {
   type: string;
-  process(source: Tiff, bytes: DecompressedInterleaved): Promise<DecompressedInterleaved> | DecompressedInterleaved;
+  process(
+    source: CompositionTiff,
+    bytes: DecompressedInterleaved,
+  ): Promise<DecompressedInterleaved> | DecompressedInterleaved;
 }

--- a/packages/tiler-sharp/src/pipeline/pipeline.color.ramp.ts
+++ b/packages/tiler-sharp/src/pipeline/pipeline.color.ramp.ts
@@ -1,5 +1,5 @@
 import { DefaultColorRamp } from '@basemaps/config';
-import { Tiff } from '@cogeotiff/core';
+import { CompositionTiff } from '@basemaps/tiler';
 
 import { DecompressedInterleaved, Pipeline } from './decompressor.js';
 
@@ -46,7 +46,7 @@ export const ramp = new ColorRamp(DefaultColorRamp);
 
 export const PipelineColorRamp: Pipeline = {
   type: 'color-ramp',
-  process(source: Tiff, data: DecompressedInterleaved): DecompressedInterleaved {
+  process(comp: CompositionTiff, data: DecompressedInterleaved): DecompressedInterleaved {
     const raw = new Uint8ClampedArray(data.width * data.height * 4);
     const output: DecompressedInterleaved = {
       pixels: raw,
@@ -57,7 +57,7 @@ export const PipelineColorRamp: Pipeline = {
     };
 
     const size = data.width * data.height;
-    const noData = source.images[0].noData;
+    const noData = comp.asset.images[0].noData;
 
     for (let i = 0; i < size; i++) {
       const source = i * data.channels;

--- a/packages/tiler-sharp/src/pipeline/pipeline.terrain.rgb.ts
+++ b/packages/tiler-sharp/src/pipeline/pipeline.terrain.rgb.ts
@@ -1,9 +1,10 @@
-import { Tiff } from '@cogeotiff/core';
+import { CompositionTiff } from '@basemaps/tiler';
 
 import { DecompressedInterleaved, Pipeline } from './decompressor.js';
 
 const MinValue = -10_000;
 const MaxValue = 1_667_721.5;
+
 export interface TerrainRgbRange {
   /** Minimum value that can be encoded */
   MinValue: -10_000;
@@ -11,11 +12,59 @@ export interface TerrainRgbRange {
   MaxValue: 1_667_721.5;
 }
 
+/**
+ * Pre defined bit masks for Red green and blue channels with the number least significant bits removed
+ */
+const Masks = {
+  Bits9: { r: 0b11111111, g: 0b11111110, b: 0b00000000 },
+  Bits8: { r: 0b11111111, g: 0b11111111, b: 0b00000000 },
+  Bits7: { r: 0b11111111, g: 0b11111111, b: 0b10000000 },
+  Bits6: { r: 0b11111111, g: 0b11111111, b: 0b11000000 },
+  Bits5: { r: 0b11111111, g: 0b11111111, b: 0b11100000 },
+  Bits4: { r: 0b11111111, g: 0b11111111, b: 0b11110000 },
+  Bits3: { r: 0b11111111, g: 0b11111111, b: 0b11111000 },
+  Bits2: { r: 0b11111111, g: 0b11111111, b: 0b11111100 },
+  Bits1: { r: 0b11111111, g: 0b11111111, b: 0b11111110 },
+  Bits0: { r: 0b11111111, g: 0b11111111, b: 0b11111111 },
+};
+
+/**
+ * To reduce the output file size down reduce the accuracy of the tile as the resolution gets larger
+ *
+ * By reducing the number of bits in use in the RGB it can greatly increase the compression ration of the output PNG
+ *
+ * Each bit removed doubles the resolution loss, when each output pixel is 1,000+M ~20 metres or resolution loss is not significant
+ *
+ * 9Bits ~ 50M of resolution loss
+ * 8Bits ~ 25.6M of resolution loss
+ *
+ * For a sample Z10 tile this almost halves the file size from 7804 bytes to 4619 bytes
+ */
+export function getResolutionMask(resolution: number): { r: number; g: number; b: number } {
+  // Anything between z0 to ~z5 should be limited to 9bits
+  if (resolution > 4_000) return Masks.Bits9;
+  // Approx z6
+  if (resolution > 2_000) return Masks.Bits8;
+  // Approx z7
+  if (resolution > 1_000) return Masks.Bits7;
+  // Approx z8
+  if (resolution > 600) return Masks.Bits6;
+  // Approx z9
+  if (resolution > 300) return Masks.Bits5;
+  // Approx z10
+  if (resolution > 150) return Masks.Bits4;
+  // Approx z11
+  if (resolution > 75) return Masks.Bits3;
+
+  // full resolution
+  return Masks.Bits0;
+}
+
 export const PipelineTerrainRgb: Pipeline & TerrainRgbRange = {
   type: 'terrain-rgb',
   MinValue,
   MaxValue,
-  process(source: Tiff, data: DecompressedInterleaved): DecompressedInterleaved {
+  process(source: CompositionTiff, data: DecompressedInterleaved): DecompressedInterleaved {
     const raw = new Uint8ClampedArray(data.width * data.height * 4);
     const output: DecompressedInterleaved = {
       pixels: raw,
@@ -25,8 +74,18 @@ export const PipelineTerrainRgb: Pipeline & TerrainRgbRange = {
       height: data.height,
     };
 
+    // Determine the resolution that the terrain RGB will be displayed as
+    const sourceImage = source.asset.images[source.source.imageId];
+    const targetResolution = sourceImage.resolution[0] * (1 / (source.resize?.scale ?? 1));
+
+    // Reduce the precision of the terrain RGB
+    const clamps = getResolutionMask(targetResolution);
+    const clampR = clamps.r;
+    const clampG = clamps.g;
+    const clampB = clamps.b;
+
     const size = data.width * data.height;
-    const noData = source.images[0].noData;
+    const noData = source.asset.images[0].noData;
     const base = -10_000;
     const interval = 0.1;
 
@@ -56,9 +115,9 @@ export const PipelineTerrainRgb: Pipeline & TerrainRgbRange = {
 
       const v = (px - base) / interval;
 
-      raw[target] = (v >> 16) & 0xff; // Math.floor(v / 256 / 256) % 256;
-      raw[target + 1] = (v >> 8) & 0xff; // Math.floor(v / 256) % 256;
-      raw[target + 2] = v % 256;
+      raw[target] = (v >> 16) & clampR;
+      raw[target + 1] = (v >> 8) & clampG;
+      raw[target + 2] = v % 256 & clampB;
       raw[target + 3] = 255;
     }
 


### PR DESCRIPTION
#### Motivation

Terrain RGB tiles can be quite large at low (z0-z10) zoom levels the blue channel of the terrainRGB represents around 25M of vertical accuracy, when viewing tiles where 1 pixel is 1,000m sub meter accurarcy is not required.

from initial test cases this can reude the tile size by 50%+ 

tile z_x_y | Before | After | Bytes saved | % reduction
-- | -- | -- | -- | --
03_7_4 | 3,607 | 2,737 | -870 | -24.12%
04_15_9 | 7,802 | 4,305 | -3,497 | -44.82%
05_31_19 | 23,031 | 8,872 | -14,159 | -61.48%
06_63_39 | 64,024 | 23,827 | -40,197 | -62.78%
07_126_79 | 110,251 | 45,738 | -64,513 | -58.51%
08_252_159 | 66,791 | 28,809 | -37,982 | -56.87%
09_505_319 | 125,658 | 64,711 | -60,947 | -48.50%
10_1010_639 | 143,054 | 91,446 | -51,608 | -36.08%
11_2020_1278 | 98,940 | 62,342 | -36,598 | -36.99%
12_4040_2556 | 29,740 | 29,740 | 0 | 0


 
#### Modification

Truncates the terrainRGB blue channel down to greatly reduce the file size of the output tiles.


#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
