### PR TITLE
fix(cogify): Fix the elevation target path to include dem/dsm. BM-1040

### DIFF
--- a/packages/cogify/src/cogify/__test__/covering.test.ts
+++ b/packages/cogify/src/cogify/__test__/covering.test.ts
@@ -3,8 +3,8 @@ import { describe, it } from 'node:test';
 
 import { GoogleTms, QuadKey } from '@basemaps/geo';
 
-import { addChildren, addSurrounding } from '../covering.js';
 import { gsdToMeter } from '../cli/cli.cover.js';
+import { addChildren, addSurrounding } from '../covering.js';
 
 describe('getChildren', () => {
   it('should get children', () => {

--- a/packages/cogify/src/cogify/__test__/covering.test.ts
+++ b/packages/cogify/src/cogify/__test__/covering.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from 'node:test';
 import { GoogleTms, QuadKey } from '@basemaps/geo';
 
 import { addChildren, addSurrounding } from '../covering.js';
+import { gsdToMeter } from '../cli/cli.cover.js';
 
 describe('getChildren', () => {
   it('should get children', () => {
@@ -55,5 +56,17 @@ describe('SurroundingTiles', () => {
       { z: 2, x: 3, y: 0 }, // South -- Wrapping South to NOrth
       { z: 2, x: 2, y: 3 }, // West
     ]);
+  });
+
+  describe('gsdToMeter', () => {
+    it('Should convert gsd to correct meter', () => {
+      assert.equal(gsdToMeter(1), 1);
+      assert.equal(gsdToMeter(305.223), 305);
+      assert.equal(gsdToMeter(8.01), 8);
+      assert.equal(gsdToMeter(0.1), 0.1);
+      assert.equal(gsdToMeter(0.1001), 0.1);
+      assert.equal(gsdToMeter(0.2005), 0.201);
+      assert.equal(gsdToMeter(0.0005), 0.001);
+    });
   });
 });

--- a/packages/cogify/src/cogify/cli/cli.cover.ts
+++ b/packages/cogify/src/cogify/cli/cli.cover.ts
@@ -16,6 +16,13 @@ import { createFileStats } from '../stac.js';
 
 const SupportedTileMatrix = [GoogleTms, Nztm2000QuadTms];
 
+// Round gsd to 3 decimals without trailing zero, or integer if larger than 1
+function gsdToMeter(gsd: number): number {
+  if (gsd > 1) return Math.round(gsd);
+  if (gsd < 0.001) return 0.001;
+  return parseFloat(gsd.toFixed(3));
+}
+
 export const BasemapsCogifyCoverCommand = command({
   name: 'cogify-cover',
   version: CliInfo.version,
@@ -80,7 +87,7 @@ export const BasemapsCogifyCoverCommand = command({
     if (im.collection != null) {
       const geoCategory = im.collection['linz:geospatial_category'];
       if (geoCategory === 'dem' || geoCategory === 'dsm') {
-        im.name = `${im.name}_${geoCategory}_${parseFloat(im.gsd.toFixed(3))}m`; //Round gsd to 3 decimals without trailing zero
+        im.name = `${im.name}_${geoCategory}_${gsdToMeter(im.gsd)}m`;
         args.target = new URL('elevation/', args.target);
       }
     }

--- a/packages/cogify/src/cogify/cli/cli.cover.ts
+++ b/packages/cogify/src/cogify/cli/cli.cover.ts
@@ -80,7 +80,8 @@ export const BasemapsCogifyCoverCommand = command({
     if (im.collection != null) {
       const geoCategory = im.collection['linz:geospatial_category'];
       if (geoCategory === 'dem' || geoCategory === 'dsm') {
-        im.name = `${im.name}_${geoCategory}_${im.gsd}m`;
+        im.name = `${im.name}_${geoCategory}_${parseFloat(im.gsd.toFixed(3))}m`; //Round gsd to 3 decimals without trailing zero
+        args.target = new URL('elevation/', args.target);
       }
     }
 

--- a/packages/cogify/src/cogify/cli/cli.cover.ts
+++ b/packages/cogify/src/cogify/cli/cli.cover.ts
@@ -17,7 +17,7 @@ import { createFileStats } from '../stac.js';
 const SupportedTileMatrix = [GoogleTms, Nztm2000QuadTms];
 
 // Round gsd to 3 decimals without trailing zero, or integer if larger than 1
-function gsdToMeter(gsd: number): number {
+export function gsdToMeter(gsd: number): number {
   if (gsd > 1) return Math.round(gsd);
   if (gsd < 0.001) return 0.001;
   return parseFloat(gsd.toFixed(3));

--- a/packages/cogify/src/cogify/cli/cli.cover.ts
+++ b/packages/cogify/src/cogify/cli/cli.cover.ts
@@ -77,13 +77,13 @@ export const BasemapsCogifyCoverCommand = command({
     const res = await createTileCover(ctx);
 
     // Find the dem/dsm prefix for the nz-elevation bucket source and update imagery name to include prefix
-    if (im.url.hostname === 'nz-elevation') {
-      const prefix = im.url.pathname.split('/')[3];
-      if (!(prefix.includes('dem') || prefix.includes('dsm'))) {
-        throw new Error(`Invalid source path from nz-elevation bucket: ${im.url.href}`);
+    if (im.collection != null) {
+      const geoCategory = im.collection['linz:geospatial_category'];
+      if (geoCategory === 'dem' || geoCategory === 'dsm') {
+        im.name = `${im.name}_${geoCategory}_${im.gsd}m`;
       }
-      im.name = `${im.name}_${prefix}`;
     }
+
     const targetPath = new URL(`${tms.projection.code}/${im.name}/${CliId}/`, args.target);
 
     const sourcePath = new URL('source.geojson', targetPath);

--- a/packages/cogify/src/cogify/cli/cli.cover.ts
+++ b/packages/cogify/src/cogify/cli/cli.cover.ts
@@ -76,7 +76,17 @@ export const BasemapsCogifyCoverCommand = command({
 
     const res = await createTileCover(ctx);
 
-    const targetPath = new URL(`${tms.projection.code}/${im.name}/${CliId}/`, args.target);
+    // Find the dem/dsm prefix for the nz-elevation bucket source
+    let prefix;
+    if (im.url.hostname === 'nz-elevation') {
+      prefix = im.url.pathname.split('/')[3];
+      if (!(prefix.includes('dem') || prefix.includes('dsm'))) {
+        throw new Error(`Invalid source path from nz-elevation bucket: ${im.url.href}`);
+      }
+    }
+
+    const fullName = prefix ? `${im.name}_${prefix}` : im.name;
+    const targetPath = new URL(`${tms.projection.code}/${fullName}/${CliId}/`, args.target);
 
     const sourcePath = new URL('source.geojson', targetPath);
     const sourceData = JSON.stringify(res.source, null, 2);

--- a/packages/cogify/src/cogify/cli/cli.cover.ts
+++ b/packages/cogify/src/cogify/cli/cli.cover.ts
@@ -76,17 +76,15 @@ export const BasemapsCogifyCoverCommand = command({
 
     const res = await createTileCover(ctx);
 
-    // Find the dem/dsm prefix for the nz-elevation bucket source
-    let prefix;
+    // Find the dem/dsm prefix for the nz-elevation bucket source and update imagery name to include prefix
     if (im.url.hostname === 'nz-elevation') {
-      prefix = im.url.pathname.split('/')[3];
+      const prefix = im.url.pathname.split('/')[3];
       if (!(prefix.includes('dem') || prefix.includes('dsm'))) {
         throw new Error(`Invalid source path from nz-elevation bucket: ${im.url.href}`);
       }
+      im.name = `${im.name}_${prefix}`;
     }
-
-    const fullName = prefix ? `${im.name}_${prefix}` : im.name;
-    const targetPath = new URL(`${tms.projection.code}/${fullName}/${CliId}/`, args.target);
+    const targetPath = new URL(`${tms.projection.code}/${im.name}/${CliId}/`, args.target);
 
     const sourcePath = new URL('source.geojson', targetPath);
     const sourceData = JSON.stringify(res.source, null, 2);


### PR DESCRIPTION
#### Motivation

The nz-elevation stac imagery name doesn't include the `dem_1m` prefix. We need to add it into basemaps imagery name and s3 path

#### Modification

Find the prefix from the nz-elevation source, and update the imageryName

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
