### PR TITLE
feat: add elevation control to landing page BM-993

### DIFF
--- a/packages/landing/src/components/map.tsx
+++ b/packages/landing/src/components/map.tsx
@@ -90,7 +90,8 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
    * Only show the elevation on GoogleTMS, as there is no data for other projections yet
    */
   ensureElevationControl(): void {
-    // if (Config.map.isDebug) return;
+    if (Config.map.debug['debug.screenshot']) return;
+    if (Config.map.isDebug) return;
     if (Config.map.tileMatrix === GoogleTms) {
       if (this.controlTerrain != null) return;
       // Ensure the elevation source exists

--- a/packages/landing/src/components/map.tsx
+++ b/packages/landing/src/components/map.tsx
@@ -30,6 +30,7 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
   ignoreNextLocationUpdate = false;
 
   controlScale?: maplibre.ScaleControl | null;
+  controlTerrain?: maplibre.TerrainControl | null;
   controlGeo?: maplibregl.GeolocateControl | null;
 
   updateLocation = (): void => {
@@ -84,6 +85,27 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
       this.map.removeControl(this.controlGeo);
     }
   }
+
+  /**
+   * Only show the elevation on GoogleTMS, as there is no data for other projections yet
+   */
+  ensureElevationControl(): void {
+    // if (Config.map.isDebug) return;
+    if (Config.map.tileMatrix === GoogleTms) {
+      if (this.controlTerrain != null) return;
+      // Ensure the elevation source exists
+      this.addElevationTerrain();
+      this.controlTerrain = new maplibre.TerrainControl({
+        source: 'basemaps-elevation-terrain', // TODO why is this name hard coded
+        exaggeration: 1.2,
+      });
+      this.map.addControl(this.controlTerrain, 'top-left');
+    } else {
+      if (this.controlTerrain == null) return;
+      this.map.removeControl(this.controlTerrain);
+      this.controlTerrain = null;
+    }
+  }
   /**
    * Only show the scale on GoogleTMS
    * As it does not work with the projection logic we are currently using
@@ -105,7 +127,6 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
    * Load elevation terrain for the aerial map in debug mode
    */
   addElevationTerrain = (): void => {
-    if (!Config.map.debug) return;
     if (this.map.getSource('basemaps-elevation-terrain') == null) {
       // Add elevation into terrain for aerial map
       this.map.addSource('basemaps-elevation-terrain', {
@@ -121,6 +142,10 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
           }),
         ],
         tileSize: 256,
+        // TODO should this be hard coded here
+        // Max zoom of 18 prevents the tile server from overzooming the browser
+        // does a better job of the resizing
+        maxzoom: 18,
       });
     }
   };
@@ -128,6 +153,7 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
   updateStyle = (): void => {
     this.ensureGeoControl();
     this.ensureScaleControl();
+    this.ensureElevationControl();
     const tileGrid = getTileGrid(Config.map.tileMatrix.identifier);
     const style = tileGrid.getStyle(Config.map.layerId, Config.map.style, undefined, Config.map.filter.date);
     this.map.setStyle(style);


### PR DESCRIPTION
#### Motivation

Now that the elevation terrain rgb service is live add a elevation toggle to the landing page.

#### Modification

Adds the maplibre elevation control onto the landing page

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
