### PR TITLE
fix(lambda-tiler): Remove the stylejson metadata, sprite, glphys if no required.

### DIFF
--- a/packages/lambda-tiler/src/__tests__/tile.style.json.test.ts
+++ b/packages/lambda-tiler/src/__tests__/tile.style.json.test.ts
@@ -111,6 +111,26 @@ describe('TileStyleJson', () => {
     assert.equal(JSON.stringify(baseStyleJson).includes('?api='), false);
   });
 
+  const rasterStyleJson: StyleJson = {
+    version: 8,
+    id: 'style.id',
+    name: 'style.name',
+    sources: {
+      raster: { type: 'raster', tiles: ['/v1/tiles/aerial/{tileMatrix}/{z}/{x}/{y}.webp'] },
+      terrain: { type: 'raster-dem', tiles: ['/v1/tiles/elevation/{tileMatrix}/{z}/{x}/{y}.png'] },
+    },
+    layers: [],
+  };
+
+  it('should cover raster style Json without metadata, sprite and glyphs', () => {
+    const apiKey = 'abc123';
+    const converted = convertStyleJson(rasterStyleJson, GoogleTms, apiKey, null);
+
+    assert.equal(converted.metadata, null);
+    assert.equal(converted.sprite, null);
+    assert.equal(converted.sprite, null);
+  });
+
   it('should cover for raster styles for NZTM2000Quad', () => {
     const rasterStyleJson: StyleJson = {
       ...baseStyleJson,

--- a/packages/lambda-tiler/src/routes/tile.style.json.ts
+++ b/packages/lambda-tiler/src/routes/tile.style.json.ts
@@ -57,16 +57,19 @@ export function convertStyleJson(
     sources[key] = value;
   }
 
-  return {
+  const styleJson: StyleJson = {
     version: 8,
     id: style.id,
     name: style.name,
     sources,
     layers: layers ? layers : style.layers,
-    metadata: style.metadata ?? {},
-    glyphs: convertRelativeUrl(style.glyphs, undefined, undefined, config),
-    sprite: convertRelativeUrl(style.sprite, undefined, undefined, config),
-  } as StyleJson;
+  };
+
+  if (style.metadata) styleJson.metadata = style.metadata;
+  if (style.glyphs) styleJson.glyphs = convertRelativeUrl(style.glyphs, undefined, undefined, config);
+  if (style.sprite) styleJson.sprite = convertRelativeUrl(style.sprite, undefined, undefined, config);
+
+  return styleJson;
 }
 
 export interface StyleGet {


### PR DESCRIPTION
#### Motivation

We should remove metadata, sprite, glphys if not defined from style config. empty sprite or glphys will broken the maplire.

```json
{
  "version": 8,
  "id": "st_aerial",
  "name": "aerial",
  "sources": {
    "basemaps-aerial": {
      "tileSize": 256,
      "tiles": [
        "[https://dev.basemaps.linz.govt.nz/v1/tiles/aerial/WebMercatorQuad/{z}/{x}/{y}.webp?api=c01hzzbj62y83k27kw7pd89jsw1&config=TmVmbYRQjL9T2JWgyaSie193b4D1qZnBD8hjaSqPFYSsEvEYYhaGYKrcnYE9V7NUW5A8WmuM3FpWejcebdKmVDGzTMLXbMvmCSs2XouTFdCmeHCAfTLyzMmr3YxANL1"
      ],
      "type": "raster"
    },
    "basemaps-terrian": {
      "tileSize": 256,
      "tiles": [
        "https://dev.basemaps.linz.govt.nz/v1/tiles/elevation/WebMercatorQuad/{z}/{x}/{y}.png?api=c01hzzbj62y83k27kw7pd89jsw1&config=TmVmbYRQjL9T2JWgyaSie193b4D1qZnBD8hjaSqPFYSsEvEYYhaGYKrcnYE9V7NUW5A8WmuM3FpWejcebdKmVDGzTMLXbMvmCSs2XouTFdCmeHCAfTLyzMmr3YxANL1"
      ],
      "type": "raster-dem"
    }
  },
  "layers": [
    {
      "id": "basemaps-aerial",
      "source": "basemaps-aerial",
      "type": "raster"
    }
  ],
  "metadata": {},
  "glyphs": "",
  "sprite": ""
}
```

#### Modification

Only add these optional filed if defined in the getStyleJSON Api

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
