### PR TITLE
feat(landing): allow more tilting so users can see more of the horizon BM-993

### DIFF
--- a/packages/geo/src/__tests__/slug.test.ts
+++ b/packages/geo/src/__tests__/slug.test.ts
@@ -102,8 +102,8 @@ describe('LocationUrl', () => {
 
   it('should fail if pitch is outside of bounds', () => {
     assert.deepEqual(LocationSlug.fromSlug('@-41.2778480,174.7763921,z8,p35'), { ...lonLatZoom, pitch: 35 });
-    assert.deepEqual(LocationSlug.fromSlug('@-41.2778480,174.7763921,z8,p-60.1'), lonLatZoom);
-    assert.deepEqual(LocationSlug.fromSlug('@-41.2778480,174.7763921,z8,p70'), lonLatZoom);
+    assert.deepEqual(LocationSlug.fromSlug('@-41.2778480,174.7763921,z8,p-80.1'), lonLatZoom);
+    assert.deepEqual(LocationSlug.fromSlug('@-41.2778480,174.7763921,z8,p81'), lonLatZoom);
   });
 
   it('toSlug should truncate bearing and pitch', () => {

--- a/packages/geo/src/slug.ts
+++ b/packages/geo/src/slug.ts
@@ -136,7 +136,7 @@ export const LocationSlug = {
    * - -190 <= lon <= 180
    * - 0 <= zoom <= 32
    * - 0 <= bearing <= 360
-   * - -60 <= pitch <= 60
+   * - -PitchMaxDegrees <= pitch <= PitchMaxDegrees
    *
    * @example
    *

--- a/packages/geo/src/slug.ts
+++ b/packages/geo/src/slug.ts
@@ -65,6 +65,9 @@ export const LocationSlug = {
   /** Number of decimal places to fix a pitch */
   PitchFixed: 0,
 
+  /** Max number of degrees of pitch */
+  PitchMaxDegrees: 80,
+
   /**
    * Truncate a lat lon based on the zoom level
    *
@@ -168,7 +171,7 @@ export const LocationSlug = {
         else output.bearing = bearing;
       } else if (c.startsWith('p')) {
         const pitch = parseFloat(c.slice(1));
-        if (isNaN(pitch) || pitch < -60 || pitch > 60) continue;
+        if (isNaN(pitch) || pitch < -LocationSlug.PitchMaxDegrees || pitch > LocationSlug.PitchMaxDegrees) continue;
         else output.pitch = pitch;
       }
     }

--- a/packages/landing/src/components/map.tsx
+++ b/packages/landing/src/components/map.tsx
@@ -230,7 +230,7 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
     this.map = new maplibre.Map({
       container: this.el,
       style,
-      maxPitch: 80, // allow users to see more of the horizon, above 60 is experimental
+      maxPitch: LocationUrl.PitchMaxDegrees, // allow users to see more of the horizon, above 60 is experimental
       center: [location.lon, location.lat], // starting position [lon, lat]
       zoom: location.zoom, // starting zoom
       bearing: cfg.location.bearing ?? 0,

--- a/packages/landing/src/components/map.tsx
+++ b/packages/landing/src/components/map.tsx
@@ -230,6 +230,7 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
     this.map = new maplibre.Map({
       container: this.el,
       style,
+      maxPitch: 80, // allow users to see more of the horizon, above 60 is experimental
       center: [location.lon, location.lat], // starting position [lon, lat]
       zoom: location.zoom, // starting zoom
       bearing: cfg.location.bearing ?? 0,


### PR DESCRIPTION
#### Motivation

Allows users to see more of the horizon by upping the maxPitch from 60 to 80

#### Modification

sets the maxPitch to 80 degrees, this is somewhat experimental 

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
