### PR TITLE
fix(lambda-tiler): tile matrix not supported is a 400 not 500

### DIFF
--- a/packages/lambda-tiler/src/__tests__/tile.style.json.test.ts
+++ b/packages/lambda-tiler/src/__tests__/tile.style.json.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, it } from 'node:test';
 import { StyleJson } from '@basemaps/config';
 import { GoogleTms, Nztm2000QuadTms } from '@basemaps/geo';
 import { Env } from '@basemaps/shared';
+import { LambdaHttpResponse } from '@linzjs/lambda';
 
 import { convertRelativeUrl, convertStyleJson } from '../routes/tile.style.json.js';
 
@@ -153,13 +154,9 @@ describe('TileStyleJson', () => {
   });
 
   it('should thrown error for NZTM2000Quad with vector source', () => {
-    const expected = new Error(
-      'TileMatrix is not supported for the vector source /v1/tiles/topographic/{tileMatrix}/tile.json.',
-    );
-
     const converted = (): StyleJson => convertStyleJson(baseStyleJson, Nztm2000QuadTms, 'abc123', null);
 
-    assert.throws(converted, expected);
+    assert.throws(converted, LambdaHttpResponse);
   });
 
   it('should convert relative glyphs and sprites', () => {

--- a/packages/lambda-tiler/src/routes/tile.style.json.ts
+++ b/packages/lambda-tiler/src/routes/tile.style.json.ts
@@ -47,7 +47,9 @@ export function convertStyleJson(
   const sources: Sources = JSON.parse(JSON.stringify(style.sources));
   for (const [key, value] of Object.entries(sources)) {
     if (value.type === 'vector') {
-      if (tileMatrix !== GoogleTms) throw new Error(`TileMatrix is not supported for the vector source ${value.url}.`);
+      if (tileMatrix !== GoogleTms) {
+        throw new LambdaHttpResponse(400, `TileMatrix is not supported for the vector source ${value.url}.`);
+      }
       value.url = convertRelativeUrl(value.url, tileMatrix, apiKey, config);
     } else if ((value.type === 'raster' || value.type === 'raster-dem') && Array.isArray(value.tiles)) {
       for (let i = 0; i < value.tiles.length; i++) {


### PR DESCRIPTION
#### Motivation

Invalid tile matrix to tile set relationship is a configuration problem and should not be a 500 error


#### Modification

swaps the 500 response to 400.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
