### PR TITLE
feat(lambda-tile): Enable elevation source in the individual raster style json.

### DIFF
--- a/packages/lambda-tiler/src/__tests__/config.data.ts
+++ b/packages/lambda-tiler/src/__tests__/config.data.ts
@@ -277,15 +277,6 @@ export class FakeData {
     return tileSet;
   }
 
-  static tileSetTerrain(name: string): ConfigTileSetRaster {
-    const tileSet = JSON.parse(JSON.stringify(TileSetAerial));
-
-    tileSet.name = name;
-    tileSet.id = `ts_${name}`;
-
-    return tileSet;
-  }
-
   static tileSetVector(name: string): ConfigTileSetVector {
     const tileSet = JSON.parse(JSON.stringify(TileSetVector));
 

--- a/packages/lambda-tiler/src/__tests__/config.data.ts
+++ b/packages/lambda-tiler/src/__tests__/config.data.ts
@@ -6,6 +6,8 @@ import {
   ConfigProviderMemory,
   ConfigTileSetRaster,
   ConfigTileSetVector,
+  DefaultColorRampOutput,
+  DefaultTerrainRgbOutput,
   TileSetType,
 } from '@basemaps/config';
 import { fsa, FsMemory } from '@basemaps/shared';
@@ -27,6 +29,24 @@ export const TileSetAerial: ConfigTileSetRaster = {
     },
   ],
 };
+
+export const TileSetElevation: ConfigTileSetRaster = {
+  id: 'ts_elevation',
+  name: 'elevation',
+  type: TileSetType.Raster,
+  description: 'elevation__description',
+  title: 'Elevation',
+  category: 'Elevation',
+  layers: [
+    {
+      3857: 'im_01FYWKATAEK2ZTJQ2PX44Y0XNT',
+      title: 'New Zealand 8m DEM (2012)',
+      name: 'new-zealand_2012_dem_8m',
+    },
+  ],
+  outputs: [DefaultTerrainRgbOutput, DefaultColorRampOutput],
+};
+
 export const TileSetVector: ConfigTileSetVector = {
   id: 'ts_topographic',
   type: TileSetType.Vector,
@@ -249,6 +269,15 @@ export const Provider: ConfigProvider = {
 
 export class FakeData {
   static tileSetRaster(name: string): ConfigTileSetRaster {
+    const tileSet = JSON.parse(JSON.stringify(TileSetAerial));
+
+    tileSet.name = name;
+    tileSet.id = `ts_${name}`;
+
+    return tileSet;
+  }
+
+  static tileSetTerrain(name: string): ConfigTileSetRaster {
     const tileSet = JSON.parse(JSON.stringify(TileSetAerial));
 
     tileSet.name = name;


### PR DESCRIPTION
#### Motivation

We want the individual raster tileset to include elevation terrain source if there is on exists in the config.

#### Modification

Add default terrain raster-dem source for `tileSetToStyle`.

#### Checklist

_If not applicable, provide explanation of why._

- [x] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
