### PR TITLE
fix(config-loader): data type is optional for tiffs

### DIFF
--- a/packages/config-loader/src/json/tiff.config.ts
+++ b/packages/config-loader/src/json/tiff.config.ts
@@ -146,17 +146,17 @@ async function computeTiffSummary(target: URL, tiffs: Tiff[]): Promise<TiffSumma
       firstImage.fetch(TiffTag.GdalNoData),
     ]);
 
-    if (dataType == null || bitsPerSample == null) {
+    if (bitsPerSample == null) {
       throw new Error('Failed to extract band information from : ' + tiff.source.url);
     }
 
-    if (dataType.length !== bitsPerSample.length) {
+    if (dataType && dataType.length !== bitsPerSample.length) {
       throw new Error('Datatype and bits per sample miss match: ' + tiff.source.url);
     }
 
     const imageBands: ImageryBandType[] = [];
-    for (let i = 0; i < dataType.length; i++) {
-      const type = getDataType(dataType[i]);
+    for (let i = 0; i < bitsPerSample.length; i++) {
+      const type = getDataType(dataType ? dataType[i] : SampleFormat.Uint);
       const bits = bitsPerSample[i];
       imageBands.push(`${type}${bits}` as ImageryBandType);
     }


### PR DESCRIPTION
#### Motivation

The tiff tag SampleFormat is optional and should be treated as a uint if not found

ref: https://www.awaresystems.be/imaging/tiff/tifftags/sampleformat.html

> A reader would typically treat an image with undefined data as if the field were not present (i.e. as unsigned integer data).

#### Modification

Assume sample format is a uint when SampleFormat is not defined.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
