### PR TITLE
ci: Lock the screenshot version to v1.5 to excludes the 3d map tests.

### DIFF
--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -40,7 +40,7 @@ jobs:
           # Wait for the server to start
           timeout 30 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:5000/v1/version)" !=  "200" ]]; do sleep 0.5; done' || false
 
-          docker run --rm --network="host" -v $PWD:$PWD ghcr.io/linz/basemaps-screenshot/cli:v1 --url http://localhost:5000 --output $PWD/.artifacts/visual-snapshots
+          docker run --rm --network="host" -v $PWD:$PWD ghcr.io/linz/basemaps-screenshot/cli:v1.5.0 --url http://localhost:5000 --output $PWD/.artifacts/visual-snapshots
 
       - name: Save snapshots
         uses: getsentry/action-visual-snapshot@v2


### PR DESCRIPTION
#### Motivation

3D map screenshots is currently not stable, we want to enable it after fixed. So we lock the screenshot cli back to v1.5 now.

#### Modification

- Lock screenshot cli to [v1.5
](https://github.com/linz/basemaps-screenshot/commit/f4071b205a16325957280b56138c20b0d7bef13f)
#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [ ] Issue linked in Title
