### PR TITLE
feat(landing): add elevation example

### DIFF
--- a/packages/landing/static/examples/index.html
+++ b/packages/landing/static/examples/index.html
@@ -17,6 +17,7 @@
       <li><a href="/examples/index.openlayers.attribution.wmts.3857.html">index.openlayers.attribution.wmts.3857.html</a></li>
       <li><a href="/examples/index.openlayers.wmts.3857.html">index.openlayers.wmts.3857.html</a></li>
       <li><a href="/examples/index.openlayers.xyz.3857.html">index.openlayers.xyz.3857.html</a></li>
+      <li><a href="/examples/index.maplibre.elevation.3857.html">index.maplibre.elevation.3857.html</a></li>
       <li><a href="/examples/index.maplibre.vector.3857.html">index.maplibre.vector.3857.html</a></li>
       <li><a href="/examples/index.maplibre.compare.3857.html">index.maplibre.compare.3857.html</a></li>
       <li><a href="/examples/index.maplibre.opacity.3857.html">index.maplibre.opacity.3857.html</a></li>

--- a/packages/landing/static/examples/index.maplibre.elevation.3857.html
+++ b/packages/landing/static/examples/index.maplibre.elevation.3857.html
@@ -68,7 +68,11 @@
               type: 'hillshade',
               source: 'hillshadeSource',
               layout: { visibility: 'visible' },
-              paint: { 'hillshade-shadow-color': '#473B24' },
+              paint: {
+                'hillshade-shadow-color': '#030303',
+                'hillshade-highlight-color': '#0c0c0c',
+                'hillshade-accent-color': '#dcdcdc',
+              },
             },
           ],
           terrain: {


### PR DESCRIPTION
### Motivation

The elevation example already existed but the colors were slightly too light,


### Modifications

Add the elevation example to the examples index, and darken the hill shade


### Verification

before:
![image](https://github.com/linz/basemaps/assets/1082761/73bf64a1-b495-40c5-a04c-19c40f5683cc)


after: 
![image](https://github.com/linz/basemaps/assets/1082761/1b9943cc-2940-4456-8c69-553c543127f5)

