### PR TITLE
feat(landing): Add terrain parameter in the url

### DIFF
--- a/packages/_infra/src/edge/index.ts
+++ b/packages/_infra/src/edge/index.ts
@@ -119,10 +119,12 @@ export class EdgeStack extends cdk.Stack {
               'tileMatrix',
               'style',
               'pipeline',
+              'terrain',
               // Deprecated single character query params for style and projection
               's',
               'p',
               'i', // ?i=:imageryId is deprecated and should be removed at some point
+              't',
             ].map(encodeURIComponent),
           },
           lambdaFunctionAssociations: [],

--- a/packages/config/src/config/vector.style.ts
+++ b/packages/config/src/config/vector.style.ts
@@ -40,6 +40,11 @@ export interface Layer {
   'source-layer'?: string;
 }
 
+export interface Terrain {
+  source: string;
+  exaggeration: number;
+}
+
 export type Source = SourceVector | SourceRaster | SourceRasterDem;
 
 export type Sources = Record<string, Source>;
@@ -67,6 +72,9 @@ export interface StyleJson {
 
   /** Layers will be drawn in the order of this array. */
   layers: Layer[];
+
+  /** OPTIONAL - A global modifier that elevates layers and markers based on a DEM data source */
+  terrain?: Terrain;
 }
 
 export interface ConfigVectorStyle extends ConfigBase {

--- a/packages/lambda-tiler/src/__tests__/config.data.ts
+++ b/packages/lambda-tiler/src/__tests__/config.data.ts
@@ -6,8 +6,6 @@ import {
   ConfigProviderMemory,
   ConfigTileSetRaster,
   ConfigTileSetVector,
-  DefaultColorRampOutput,
-  DefaultTerrainRgbOutput,
   TileSetType,
 } from '@basemaps/config';
 import { fsa, FsMemory } from '@basemaps/shared';
@@ -30,23 +28,6 @@ export const TileSetAerial: ConfigTileSetRaster = {
   ],
 };
 
-export const TileSetElevation: ConfigTileSetRaster = {
-  id: 'ts_elevation',
-  name: 'elevation',
-  type: TileSetType.Raster,
-  description: 'elevation__description',
-  title: 'Elevation',
-  category: 'Elevation',
-  layers: [
-    {
-      3857: 'im_01FYWKATAEK2ZTJQ2PX44Y0XNT',
-      title: 'New Zealand 8m DEM (2012)',
-      name: 'new-zealand_2012_dem_8m',
-    },
-  ],
-  outputs: [DefaultTerrainRgbOutput, DefaultColorRampOutput],
-};
-
 export const TileSetVector: ConfigTileSetVector = {
   id: 'ts_topographic',
   type: TileSetType.Vector,
@@ -60,6 +41,22 @@ export const TileSetVector: ConfigTileSetVector = {
       title: 'Vector tiles',
       category: 'Vector Tiles',
       name: 'Vector tiles',
+    },
+  ],
+};
+export const TileSetElevation: ConfigTileSetRaster = {
+  id: 'ts_elevation',
+  name: 'elevation',
+  type: TileSetType.Raster,
+  description: 'elevation__description',
+  title: 'Elevation Imagery',
+  category: 'Elevation',
+  layers: [
+    {
+      2193: 'im_01FYWKAJ86W9P7RWM1VB62KD0H',
+      3857: 'im_01FYWKATAEK2ZTJQ2PX44Y0XNT',
+      title: 'New Zealand 8m DEM (2012)',
+      name: 'new-zealand_2012_dem_8m',
     },
   ],
 };
@@ -279,6 +276,15 @@ export class FakeData {
 
   static tileSetVector(name: string): ConfigTileSetVector {
     const tileSet = JSON.parse(JSON.stringify(TileSetVector)) as ConfigTileSetVector;
+
+    tileSet.name = name;
+    tileSet.id = `ts_${name}`;
+
+    return tileSet;
+  }
+
+  static tileSetElevation(name: string): ConfigTileSetRaster {
+    const tileSet = JSON.parse(JSON.stringify(TileSetElevation)) as ConfigTileSetRaster;
 
     tileSet.name = name;
     tileSet.id = `ts_${name}`;

--- a/packages/lambda-tiler/src/__tests__/config.data.ts
+++ b/packages/lambda-tiler/src/__tests__/config.data.ts
@@ -6,6 +6,8 @@ import {
   ConfigProviderMemory,
   ConfigTileSetRaster,
   ConfigTileSetVector,
+  DefaultColorRampOutput,
+  DefaultTerrainRgbOutput,
   TileSetType,
 } from '@basemaps/config';
 import { fsa, FsMemory } from '@basemaps/shared';
@@ -59,6 +61,7 @@ export const TileSetElevation: ConfigTileSetRaster = {
       name: 'new-zealand_2012_dem_8m',
     },
   ],
+  outputs: [DefaultTerrainRgbOutput, DefaultColorRampOutput],
 };
 
 export const Imagery2193: ConfigImagery = {

--- a/packages/lambda-tiler/src/routes/__tests__/tile.style.json.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/tile.style.json.test.ts
@@ -5,10 +5,11 @@ import { ConfigProviderMemory, SourceRaster, StyleJson } from '@basemaps/config'
 import { Env } from '@basemaps/shared';
 import { createSandbox } from 'sinon';
 
-import { FakeData, TileSetElevation } from '../../__tests__/config.data.js';
+import { FakeData, TileSetAerial, TileSetElevation } from '../../__tests__/config.data.js';
 import { Api, mockRequest, mockUrlRequest } from '../../__tests__/xyz.util.js';
 import { handler } from '../../index.js';
 import { ConfigLoader } from '../../util/config.loader.js';
+import { Terrain } from '@basemaps/config/src/config/vector.style.js';
 
 describe('/v1/styles', () => {
   const host = 'https://tiles.test';
@@ -47,6 +48,10 @@ describe('/v1/styles', () => {
       basemaps_raster_encode: {
         type: 'raster',
         tiles: [`/raster/{z}/{x}/{y}.webp`], // Shouldn't encode the {}
+      },
+      basemaps_terrain: {
+        type: 'raster-dem',
+        tiles: [`/elevation/{z}/{x}/{y}.png?pipeline=terrain-rgb`],
       },
       test_vector: {
         type: 'vector',
@@ -125,6 +130,11 @@ describe('/v1/styles', () => {
     fakeStyle.sources['basemaps_raster_encode'] = {
       type: 'raster',
       tiles: [`${host}/raster/{z}/{x}/{y}.webp?api=${Api.key}`],
+    };
+
+    fakeStyle.sources['basemaps_terrain'] = {
+      type: 'raster-dem',
+      tiles: [`${host}/elevation/{z}/{x}/{y}.png?pipeline=terrain-rgb&api=${Api.key}`],
     };
 
     fakeStyle.sprite = `${host}/sprite`;
@@ -257,11 +267,70 @@ describe('/v1/styles', () => {
       },
     ]);
 
-    const rasterDemSource = body.sources['basemaps-elevation'] as unknown as SourceRaster;
+    const rasterDemSource = body.sources['LINZ-Terrain'] as unknown as SourceRaster;
 
     assert.deepEqual(rasterDemSource.type, 'raster-dem');
     assert.deepEqual(rasterDemSource.tiles, [
       `https://tiles.test/v1/tiles/elevation/WebMercatorQuad/{z}/{x}/{y}.png?api=${Api.key}&config=${configId}&pipeline=terrain-rgb`,
     ]);
+  });
+
+  const fakeStyleConfig = {
+    id: 'test',
+    name: 'test',
+    sources: {
+      basemaps_raster: {
+        type: 'raster',
+        tiles: [`/raster/{z}/{x}/{y}.webp`],
+      },
+      basemaps_terrain: {
+        type: 'raster-dem',
+        tiles: [`/elevation/{z}/{x}/{y}.png?pipeline=terrain-rgb`],
+      },
+    },
+    layers: [
+      {
+        layout: {
+          visibility: 'visible',
+        },
+        paint: {
+          'background-color': 'rgba(206, 229, 242, 1)',
+        },
+        id: 'Background1',
+        type: 'background',
+        minzoom: 0,
+      },
+    ],
+  };
+
+  const fakeAerialRecord = {
+    id: 'st_aerial',
+    name: 'aerial',
+    style: fakeStyleConfig,
+  };
+
+  it('should set terrain via parameter for style config', async () => {
+    const request = mockUrlRequest('/v1/styles/aerial.json', '?terrain=basemaps_terrain', Api.header);
+    config.put(fakeAerialRecord);
+    const res = await handler.router.handle(request);
+    assert.equal(res.status, 200, res.statusDescription);
+
+    const body = JSON.parse(Buffer.from(res.body, 'base64').toString()) as StyleJson;
+    const terrain = body.terrain as unknown as Terrain;
+    assert.deepEqual(terrain.source, 'basemaps_terrain');
+    assert.deepEqual(terrain.exaggeration, 1.2);
+  });
+
+  it('should set terrain via parameter for tileSet config', async () => {
+    config.put(TileSetAerial);
+    config.put(TileSetElevation);
+    const request = mockUrlRequest('/v1/styles/aerial.json', `?terrain=LINZ-Terrain`, Api.header);
+    const res = await handler.router.handle(request);
+    assert.equal(res.status, 200, res.statusDescription);
+
+    const body = JSON.parse(Buffer.from(res.body, 'base64').toString()) as StyleJson;
+    const terrain = body.terrain as unknown as Terrain;
+    assert.deepEqual(terrain.source, 'LINZ-Terrain');
+    assert.deepEqual(terrain.exaggeration, 1.2);
   });
 });

--- a/packages/lambda-tiler/src/routes/__tests__/tile.style.json.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/tile.style.json.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert';
 import { afterEach, before, beforeEach, describe, it } from 'node:test';
 
 import { ConfigProviderMemory, SourceRaster, StyleJson } from '@basemaps/config';
+import { Terrain } from '@basemaps/config/src/config/vector.style.js';
 import { Env } from '@basemaps/shared';
 import { createSandbox } from 'sinon';
 
@@ -9,7 +10,6 @@ import { FakeData, TileSetAerial, TileSetElevation } from '../../__tests__/confi
 import { Api, mockRequest, mockUrlRequest } from '../../__tests__/xyz.util.js';
 import { handler } from '../../index.js';
 import { ConfigLoader } from '../../util/config.loader.js';
-import { Terrain } from '@basemaps/config/src/config/vector.style.js';
 
 describe('/v1/styles', () => {
   const host = 'https://tiles.test';

--- a/packages/landing/src/components/map.tsx
+++ b/packages/landing/src/components/map.tsx
@@ -47,8 +47,11 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
 
   updateTerrainFromEvent = (): void => {
     const terrain = this.map.getTerrain();
-    if (terrain?.source) Config.map.setTerrain(terrain.source);
-    Config.map.setTerrain(terrain?.source ?? null);
+    if (terrain) {
+      Config.map.terrain = terrain.source;
+    } else {
+      Config.map.terrain = null;
+    }
     window.history.pushState(null, '', `?${MapConfig.toUrl(Config.map)}`);
   };
 
@@ -149,17 +152,7 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
       this.map.setMaxBounds();
     }
     // TODO check and only update when Config.map.layer changes.
-    this.updateTerrain();
     this.forceUpdate();
-  };
-
-  updateTerrain = (): void => {
-    if (this.controlTerrain == null) return;
-    if (Config.map.terrain === this.controlTerrain.options.source) {
-      this.map.setTerrain(this.controlTerrain.options);
-    } else {
-      this.map.setTerrain(null);
-    }
   };
 
   updateVisibleLayers = (newLayers: string): void => {
@@ -254,7 +247,6 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
         Config.map.on('tileMatrix', this.updateStyle),
         Config.map.on('layer', this.updateStyle),
         Config.map.on('bounds', this.updateBounds),
-        Config.map.on('terrain', this.updateTerrain),
         // TODO: Disable updateVisibleLayers for now before we need implement date range slider
         // Config.map.on('visibleLayers', this.updateVisibleLayers),
       );

--- a/packages/landing/src/components/map.tsx
+++ b/packages/landing/src/components/map.tsx
@@ -47,11 +47,7 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
 
   updateTerrainFromEvent = (): void => {
     const terrain = this.map.getTerrain();
-    if (terrain) {
-      Config.map.terrain = terrain.source;
-    } else {
-      Config.map.terrain = null;
-    }
+    Config.map.setTerrain(terrain?.source ?? null);
     window.history.pushState(null, '', `?${MapConfig.toUrl(Config.map)}`);
   };
 

--- a/packages/landing/src/components/map.tsx
+++ b/packages/landing/src/components/map.tsx
@@ -4,7 +4,6 @@ import { Component, ReactNode } from 'react';
 
 import { MapAttribution } from '../attribution.js';
 import { Config } from '../config.js';
-import { MapConfig } from '../config.map.js';
 import { getTileGrid, locationTransform } from '../tile.matrix.js';
 import { MapOptionType, WindowUrl } from '../url.js';
 import { Debug } from './debug.js';
@@ -48,7 +47,6 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
   updateTerrainFromEvent = (): void => {
     const terrain = this.map.getTerrain();
     Config.map.setTerrain(terrain?.source ?? null);
-    window.history.pushState(null, '', `?${MapConfig.toUrl(Config.map)}`);
   };
 
   updateBounds = (bounds: maplibregl.LngLatBoundsLike): void => {

--- a/packages/landing/src/config.map.ts
+++ b/packages/landing/src/config.map.ts
@@ -209,7 +209,7 @@ export class MapConfig extends Emitter<MapConfigEvents> {
   setTerrain(terrain: string | null): void {
     if (this.terrain === terrain) return;
     this.terrain = terrain;
-    this.emit('change');
+    window.history.pushState(null, '', `?${MapConfig.toUrl(Config.map)}`);
   }
 
   setTileMatrix(tms: TileMatrixSet): void {

--- a/packages/landing/src/config.map.ts
+++ b/packages/landing/src/config.map.ts
@@ -206,6 +206,12 @@ export class MapConfig extends Emitter<MapConfigEvents> {
     this.emit('change');
   }
 
+  setTerrain(terrain: string | null): void {
+    if (this.terrain === terrain) return;
+    this.terrain = terrain;
+    this.emit('change');
+  }
+
   setTileMatrix(tms: TileMatrixSet): void {
     if (this.tileMatrix.identifier === tms.identifier) return;
     this.emit('tileMatrix', this.tileMatrix);

--- a/packages/landing/src/config.map.ts
+++ b/packages/landing/src/config.map.ts
@@ -210,6 +210,7 @@ export class MapConfig extends Emitter<MapConfigEvents> {
     if (this.terrain === terrain) return;
     this.terrain = terrain;
     window.history.pushState(null, '', `?${MapConfig.toUrl(Config.map)}`);
+    this.emit('change');
   }
 
   setTileMatrix(tms: TileMatrixSet): void {

--- a/packages/landing/src/config.map.ts
+++ b/packages/landing/src/config.map.ts
@@ -53,6 +53,7 @@ export class MapConfig extends Emitter<MapConfigEvents> {
   debug: DebugState = { ...DebugDefaults };
   visibleLayers: string | null = null;
   filter: Filter = { date: { before: undefined } };
+  terrain: string | null = null;
   pipeline: string | null = null;
 
   private _layers?: Promise<Map<string, LayerInfo>>;
@@ -135,6 +136,7 @@ export class MapConfig extends Emitter<MapConfigEvents> {
     this.style = style ?? null;
     this.layerId = layerId.startsWith('im_') ? layerId.slice(3) : layerId;
     this.tileMatrix = tileMatrix;
+    this.terrain = terrain;
 
     if (this.layerId === 'topographic' && this.style == null) this.style = 'topographic';
     this.emit('tileMatrix', this.tileMatrix);
@@ -149,6 +151,7 @@ export class MapConfig extends Emitter<MapConfigEvents> {
     if (opts.tileMatrix.identifier !== GoogleTms.identifier) urlParams.append('tileMatrix', opts.tileMatrix.identifier);
     // Config by far the longest so make it the last parameter
     if (opts.config) urlParams.append('config', ensureBase58(opts.config));
+    if (opts.terrain) urlParams.append('terrain', opts.terrain);
 
     ConfigDebug.toUrl(opts.debug, urlParams);
     return urlParams.toString();

--- a/packages/landing/src/config.map.ts
+++ b/packages/landing/src/config.map.ts
@@ -43,7 +43,6 @@ export interface MapConfigEvents {
   filter: [Filter];
   change: [];
   visibleLayers: [string];
-  terrain: [string | null];
 }
 
 export class MapConfig extends Emitter<MapConfigEvents> {
@@ -123,7 +122,6 @@ export class MapConfig extends Emitter<MapConfigEvents> {
     const config = urlParams.get('c') ?? urlParams.get('config');
     const layerId = urlParams.get('i') ?? style ?? 'aerial';
     const terrain = urlParams.get('t') ?? urlParams.get('terrain');
-    this.setTerrain(terrain);
 
     const projectionParam = (urlParams.get('p') ?? urlParams.get('tileMatrix') ?? GoogleTms.identifier).toLowerCase();
     let tileMatrix = TileMatrixSets.All.find((f) => f.identifier.toLowerCase() === projectionParam);
@@ -136,6 +134,7 @@ export class MapConfig extends Emitter<MapConfigEvents> {
     const previousUrl = MapConfig.toUrl(this);
 
     this.config = config;
+    this.terrain = terrain;
     this.style = style ?? null;
     this.layerId = layerId.startsWith('im_') ? layerId.slice(3) : layerId;
     this.tileMatrix = tileMatrix;
@@ -210,13 +209,6 @@ export class MapConfig extends Emitter<MapConfigEvents> {
   setTileMatrix(tms: TileMatrixSet): void {
     if (this.tileMatrix.identifier === tms.identifier) return;
     this.emit('tileMatrix', this.tileMatrix);
-    this.emit('change');
-  }
-
-  setTerrain(terrain: string | null): void {
-    if (this.terrain === terrain) return;
-    this.terrain = terrain;
-    this.emit('terrain', this.terrain);
     this.emit('change');
   }
 

--- a/packages/landing/src/tile.matrix.ts
+++ b/packages/landing/src/tile.matrix.ts
@@ -18,6 +18,7 @@ export class TileGrid {
     style?: string | null,
     config = Config.map.config,
     date?: FilterDate,
+    terrain = Config.map.terrain,
   ): StyleSpecification | string {
     return WindowUrl.toTileUrl({
       urlType: MapOptionType.Style,
@@ -26,6 +27,7 @@ export class TileGrid {
       style,
       config,
       date,
+      terrain,
     });
   }
 }

--- a/packages/landing/src/url.ts
+++ b/packages/landing/src/url.ts
@@ -34,6 +34,7 @@ export interface TileUrlParams {
   pipeline?: string | null;
   date?: FilterDate;
   imageFormat?: string;
+  terrain?: string | null;
 }
 
 export function ensureBase58(s: null): null;
@@ -73,6 +74,7 @@ export const WindowUrl = {
     if (params.config != null) queryParams.set('config', ensureBase58(params.config));
     if (params.pipeline != null) queryParams.set('pipeline', params.pipeline);
     if (params.date?.before != null) queryParams.set('date[before]', params.date.before);
+    if (params.terrain != null) queryParams.set('terrain', params.terrain);
 
     const imageFormat = params.imageFormat ?? WindowUrl.ImageFormat;
     if (params.urlType === MapOptionType.Style) {


### PR DESCRIPTION
### Motivation

We want a terrain request parameter that shareable for map with 3d terrain enabled. This will need new aerial style config to added after merge. https://github.com/linz/basemaps-config/pull/916

### Modifications

- Add terrain setting in `getStyle` api when `?terrain=LINZ-Terrain`
- Update landing page to lisen the terrain event to set terrain parameter.

![image](https://github.com/linz/basemaps/assets/12163920/00b09fdf-30b0-43fa-8390-8eaaf29a6d37)

### Verification

- Unit tests added for tileset to style and style to style in getStyle Api
- Landing page tested with terrain button to update the request parameter.
