### PR TITLE
fix(cogify): correct loading path for "cogify" bin

### DIFF
--- a/packages/cogify/package.json
+++ b/packages/cogify/package.json
@@ -20,22 +20,33 @@
   },
   "scripts": {
     "build": "tsc",
+    "bundle": "../../scripts/bundle.mjs package.json",
+    "prepack": "../../scripts/bundle.mjs package.json",
     "test": "node --test"
   },
+  "bundle": [
+    {
+      "entry": "src/bin.ts",
+      "minify": false,
+      "outfile": "dist/index.cjs",
+      "external": [
+        "sharp",
+        "pino-pretty"
+      ]
+    }
+  ],
   "type": "module",
   "engines": {
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
-  "dependencies": {
+  "devDependencies": {
     "@basemaps/cli": "^7.4.0",
     "@basemaps/config": "^7.4.0",
     "@basemaps/config-loader": "^7.4.0",
     "@basemaps/geo": "^7.4.0",
     "@basemaps/shared": "^7.4.0",
     "cmd-ts": "^0.12.1",
-    "p-limit": "^4.0.0"
-  },
-  "devDependencies": {
+    "p-limit": "^4.0.0",
     "stac-ts": "^1.0.0"
   },
   "publishConfig": {


### PR DESCRIPTION
### Motivation

the latest container is currently broken when looking for `cogify` as it is pointing to a file that doesnt exist `./dist/index.cjs`.

The dist/index.cjs is only created after a `npm run bundle` but bundle is not run until after cogify is published to npm.

<!-- TODO: Say why you made your changes. -->

### Modifications

force dist/index.cjs to be created before a `npm pack` can be run using the prepack npm lifecylce event.

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

manually rebuilt with `npm pack` to ensure that a dist/index.cjs exists

