### PR TITLE
feat(cogify): error early if no source collection.json is found BM-1047

### DIFF
--- a/packages/cogify/src/cogify/cli/__test__/cli.cover.test.ts
+++ b/packages/cogify/src/cogify/cli/__test__/cli.cover.test.ts
@@ -1,0 +1,60 @@
+import assert from 'node:assert';
+import { beforeEach, describe, it } from 'node:test';
+
+import { fsa, FsMemory, LogConfig } from '@basemaps/shared';
+import { TestTiff } from '@basemaps/test';
+import { StacCollection } from 'stac-ts';
+
+import { BasemapsCogifyCoverCommand } from '../cli.cover.js';
+
+describe('cli.cover', () => {
+  const fsMemory = new FsMemory();
+
+  beforeEach(async () => {
+    LogConfig.get().level = 'silent';
+    fsa.register('memory://', fsMemory);
+    fsMemory.files.clear();
+
+    await fsa.write(new URL('memory://source/google.tiff'), fsa.readStream(TestTiff.Google));
+  });
+
+  const baseArgs = {
+    paths: [new URL('memory://source/')],
+    target: new URL('memory://target/'),
+    preset: 'webp',
+    tileMatrix: 'WebMercatorQuad',
+
+    cutline: undefined,
+    cutlineBlend: 20,
+    baseZoomOffset: undefined,
+    verbose: false,
+    extraVerbose: false,
+    requireStacCollection: false,
+  };
+
+  it('should generate a covering', async () => {
+    const ret = await BasemapsCogifyCoverCommand.handler({ ...baseArgs }).catch((e) => String(e));
+    assert.equal(ret, undefined); // no errors returned
+
+    const files = [...fsMemory.files.keys()];
+    const collectionJsonPath = files.find((f) => f.endsWith('collection.json') && f.startsWith('memory://target/'));
+    assert.ok(collectionJsonPath);
+
+    const collectionJson = JSON.parse(String(fsMemory.files.get(collectionJsonPath)?.buffer ?? '{}')) as StacCollection;
+    assert.equal(collectionJson['description'], 'Missing source STAC');
+  });
+
+  it('should error if no collection.json is found', async () => {
+    const ret = await BasemapsCogifyCoverCommand.handler({
+      ...baseArgs,
+      paths: [new URL('memory://source/')],
+      target: new URL('memory://target/'),
+      preset: 'webp',
+
+      requireStacCollection: true,
+      tileMatrix: 'WebMercatorQuad',
+    }).catch((e) => String(e));
+
+    assert.equal(ret, 'Error: No collection.json found with imagery: memory://source/');
+  });
+});


### PR DESCRIPTION
### Motivation

When importing imagery into basemaps we know if there is a source stac collection at the first step, but we only warn that we cannot find it.

In most of our import processes not having a stac collection should be a errro

<!-- TODO: Say why you made your changes. -->

### Modifications

Add `--require-stac-collection` to throw a error if a stac collection cannot be found when createing a cover

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

Added new integration test to covering creation with and without the new flag.