### PR TITLE
feat(lambda-tiler): Ensure terrain source for all style json configs.

### DIFF
--- a/packages/lambda-tiler/src/routes/__tests__/tile.style.json.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/tile.style.json.test.ts
@@ -275,7 +275,54 @@ describe('/v1/styles', () => {
     ]);
   });
 
-  const fakeStyleConfig = {
+  const fakeVectorStyleConfig = {
+    id: 'test',
+    name: 'test',
+    sources: {
+      basemaps_vector: {
+        type: 'vector',
+        url: `/vector`,
+      },
+    },
+    layers: [
+      {
+        layout: {
+          visibility: 'visible',
+        },
+        paint: {
+          'background-color': 'rgba(206, 229, 242, 1)',
+        },
+        id: 'Background1',
+        type: 'background',
+        minzoom: 0,
+      },
+    ],
+  };
+
+  const fakeVectorRecord = {
+    id: 'st_topolite',
+    name: 'topolite',
+    style: fakeVectorStyleConfig,
+  };
+
+  it('should ensure terrain for all style config', async () => {
+    const request = mockUrlRequest('/v1/styles/topolite.json', '?terrain=LINZ-Terrain', Api.header);
+    config.put(fakeVectorRecord);
+    config.put(TileSetElevation);
+
+    const res = await handler.router.handle(request);
+    assert.equal(res.status, 200, res.statusDescription);
+
+    const body = JSON.parse(Buffer.from(res.body, 'base64').toString()) as StyleJson;
+    const rasterDemSource = body.sources['LINZ-Terrain'] as unknown as SourceRaster;
+
+    assert.deepEqual(rasterDemSource.type, 'raster-dem');
+    assert.deepEqual(rasterDemSource.tiles, [
+      `https://tiles.test/v1/tiles/elevation/WebMercatorQuad/{z}/{x}/{y}.png?api=${Api.key}&pipeline=terrain-rgb`,
+    ]);
+  });
+
+  const fakeAerialStyleConfig = {
     id: 'test',
     name: 'test',
     sources: {
@@ -306,7 +353,7 @@ describe('/v1/styles', () => {
   const fakeAerialRecord = {
     id: 'st_aerial',
     name: 'aerial',
-    style: fakeStyleConfig,
+    style: fakeAerialStyleConfig,
   };
 
   it('should set terrain via parameter for style config', async () => {

--- a/packages/lambda-tiler/src/routes/tile.style.json.ts
+++ b/packages/lambda-tiler/src/routes/tile.style.json.ts
@@ -268,6 +268,9 @@ export async function styleJsonGet(req: LambdaHttpRequest<StyleGet>): Promise<La
     styleConfig.style.layers.filter((f) => !excluded.has(f.id.toLowerCase())),
   );
 
+  // Ensure elevation for style json config
+  await ensureTerrain(req, tileMatrix, apiKey, style);
+
   // Add terrain in style
   if (terrain) setStyleTerrain(style, terrain);
 

--- a/packages/lambda-tiler/src/routes/tile.style.json.ts
+++ b/packages/lambda-tiler/src/routes/tile.style.json.ts
@@ -269,6 +269,7 @@ export async function styleJsonGet(req: LambdaHttpRequest<StyleGet>): Promise<La
   );
 
   // Ensure elevation for style json config
+  // TODO: We should remove this after adding terrain source into style configs. PR-916
   await ensureTerrain(req, tileMatrix, apiKey, style);
 
   // Add terrain in style


### PR DESCRIPTION
### Motivation

We need to ensure a terrain source in all style json configs before the production release. Then we could do another config release for add terrain source into style config. https://github.com/linz/basemaps-config/pull/916

### Modifications

Check and add terrain source for get style config api.

### Verification

![image](https://github.com/linz/basemaps/assets/12163920/01544ba9-469f-4a5f-ba9a-9d97502e2fc3)
