### PR TITLE
fix(landing): use png for terrain-rgb xyz links BM-1041

### DIFF
--- a/packages/landing/src/components/layer.switcher.dropdown.tsx
+++ b/packages/landing/src/components/layer.switcher.dropdown.tsx
@@ -73,7 +73,7 @@ export class LayerSwitcherDropdown extends Component<unknown, LayerSwitcherDropd
     const layer = this.getLayer(currentLayer);
     if (layer?.pipeline) {
       const [layerId, style] = currentLayer.split('::');
-      Config.map.setLayerId(layerId, style, layer.pipeline);
+      Config.map.setLayerId(layerId, style, layer.pipeline, layer.imageFormat);
     }
   }
 
@@ -99,7 +99,7 @@ export class LayerSwitcherDropdown extends Component<unknown, LayerSwitcherDropd
     if (opt == null) return;
     const layer = this.getLayer(opt.value);
     const [layerId, style] = opt.value.split('::');
-    Config.map.setLayerId(layerId, style, layer?.pipeline);
+    Config.map.setLayerId(layerId, style, layer?.pipeline, layer?.imageFormat);
     gaEvent(GaEvent.Ui, 'layer:' + opt.value);
 
     // Configure the bounds of the map to match the new layer

--- a/packages/landing/src/components/map.tsx
+++ b/packages/landing/src/components/map.tsx
@@ -139,6 +139,7 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
     this.ensureElevationControl();
     const tileGrid = getTileGrid(Config.map.tileMatrix.identifier);
     const style = tileGrid.getStyle(Config.map.layerId, Config.map.style, undefined, Config.map.filter.date);
+    console.log('set-style', style);
     this.map.setStyle(style);
     if (Config.map.tileMatrix !== GoogleTms) {
       this.map.setMaxBounds([-179.9, -85, 179.9, 85]);

--- a/packages/landing/src/components/map.tsx
+++ b/packages/landing/src/components/map.tsx
@@ -139,7 +139,6 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
     this.ensureElevationControl();
     const tileGrid = getTileGrid(Config.map.tileMatrix.identifier);
     const style = tileGrid.getStyle(Config.map.layerId, Config.map.style, undefined, Config.map.filter.date);
-    console.log('set-style', style);
     this.map.setStyle(style);
     if (Config.map.tileMatrix !== GoogleTms) {
       this.map.setMaxBounds([-179.9, -85, 179.9, 85]);

--- a/packages/landing/src/config.map.ts
+++ b/packages/landing/src/config.map.ts
@@ -143,7 +143,7 @@ export class MapConfig extends Emitter<MapConfigEvents> {
 
     if (this.layerId === 'topographic' && this.style == null) this.style = 'topographic';
     this.emit('tileMatrix', this.tileMatrix);
-    this.emit('layer', this.layerId, this.style, this.pipeline);
+    this.emit('layer', this.layerId, this.style, this.pipeline, this.imageFormat);
     if (previousUrl !== MapConfig.toUrl(this)) this.emit('change');
   }
 
@@ -233,7 +233,7 @@ export class MapConfig extends Emitter<MapConfigEvents> {
     layer: string,
     style: string | null = null,
     pipeline: string | null = null,
-    imageFormat: string | null = null,
+    imageFormat: ImageFormat | null = null,
   ): void {
     if (
       this.layerId === layer &&
@@ -247,7 +247,6 @@ export class MapConfig extends Emitter<MapConfigEvents> {
     this.style = style;
     this.imageFormat = imageFormat;
     this.pipeline = pipeline;
-    console.log('set-layer', { layer, style, pipeline, imageFormat });
     this.emit('layer', this.layerId, this.style, this.pipeline, this.imageFormat);
     this.emit('change');
   }
@@ -274,7 +273,7 @@ export interface LayerInfo {
   /** Is a pipeline required for the layer */
   pipeline?: string;
   /** Is a image format required for the layer */
-  imageFormat?: string;
+  imageFormat?: ImageFormat;
 }
 
 async function loadAllLayers(): Promise<Map<string, LayerInfo>> {

--- a/packages/landing/src/url.ts
+++ b/packages/landing/src/url.ts
@@ -33,7 +33,7 @@ export interface TileUrlParams {
   config?: string | null;
   pipeline?: string | null;
   date?: FilterDate;
-  imageFormat?: string;
+  imageFormat?: string | null;
   terrain?: string | null;
 }
 
@@ -82,6 +82,10 @@ export const WindowUrl = {
         queryParams.set('tileMatrix', params.tileMatrix.identifier);
       if (imageFormat !== 'webp') queryParams.set('format', imageFormat);
     }
+
+    // If a image format is directly requested ensure it is passed through to the WMTS
+    // only some layers like terrain-rgb need a forced image format
+    if (params.imageFormat && MapOptionType.Wmts) queryParams.set('format', params.imageFormat);
 
     const q = '?' + queryParams.toString();
 


### PR DESCRIPTION
### Motivation

When copying XYZ terrain-rgb links, only lossless formats (PNG) are supported by default all links are webp.

<!-- TODO: Say why you made your changes. -->

### Modifications

Force PNG for XYZ and WMTS terrain-rgb links

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->

Tested in local debug mode.
