### PR TITLE
fix(landing): only force wmts to have tileFormat BM-1041

### DIFF
--- a/packages/landing/src/url.ts
+++ b/packages/landing/src/url.ts
@@ -85,7 +85,7 @@ export const WindowUrl = {
 
     // If a image format is directly requested ensure it is passed through to the WMTS
     // only some layers like terrain-rgb need a forced image format
-    if (params.imageFormat && MapOptionType.Wmts) queryParams.set('format', params.imageFormat);
+    if (params.imageFormat && params.urlType === MapOptionType.Wmts) queryParams.set('tileFormat', params.imageFormat);
 
     const q = '?' + queryParams.toString();
 


### PR DESCRIPTION
### Motivation

Due to a typo in the comparision all layers were getting ?format= appended, only WMTs needs it.

### Modifications

Force PNG `tileFormat` format WMTS links with terrain-rgb

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
