### PR TITLE
build: Upgrade the maplibre to v4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10141,9 +10141,9 @@
       }
     },
     "node_modules/geojson-vt": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
-      "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
+      "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
       "dev": true
     },
     "node_modules/get-caller-file": {
@@ -13190,9 +13190,9 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.4.1.tgz",
-      "integrity": "sha512-tD+wn8qWSLCGhABKBrbewmgFfyopZDz+fkYXeOM8vdBhnf126DvMPyaYGGoKvoF4QuswCsgikETd2c39wK+OQw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.5.0.tgz",
+      "integrity": "sha512-qOS1hn4d/pn2i0uva4S5Oz+fACzTkgBKq+NpwT/Tqzi4MSyzcWNtDELzLUSgWqHfNIkGCl5CZ/w7dtis+t4RCw==",
       "dev": true,
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
@@ -13211,7 +13211,7 @@
         "@types/pbf": "^3.0.5",
         "@types/supercluster": "^7.1.3",
         "earcut": "^2.2.4",
-        "geojson-vt": "^3.2.1",
+        "geojson-vt": "^4.0.2",
         "gl-matrix": "^3.4.3",
         "global-prefix": "^3.0.0",
         "kdbush": "^4.0.2",
@@ -19564,7 +19564,7 @@
         "@servie/events": "^3.0.0",
         "@types/proj4": "^2.5.2",
         "@types/react-dom": "^18.0.6",
-        "maplibre-gl": "^4.4.1",
+        "maplibre-gl": "^4.5.0",
         "mime-types": "^2.1.35",
         "proj4": "^2.8.0",
         "react": "^18.2.0",

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -37,7 +37,7 @@
     "@servie/events": "^3.0.0",
     "@types/proj4": "^2.5.2",
     "@types/react-dom": "^18.0.6",
-    "maplibre-gl": "^4.4.1",
+    "maplibre-gl": "^4.5.0",
     "mime-types": "^2.1.35",
     "proj4": "^2.8.0",
     "react": "^18.2.0",


### PR DESCRIPTION
### Motivation

Upgrade maplibre to latest version, so we can have sky box support. https://github.com/maplibre/maplibre-gl-js/pull/3645

### Modifications


### Verification

