### PR TITLE
fix(lambda-tiler): wmts should support tile pipelines

### DIFF
--- a/packages/lambda-tiler/src/routes/__tests__/wmts.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/wmts.test.ts
@@ -47,8 +47,6 @@ describe('WMTSRouting', () => {
     assert.ok(resourceUrl);
     assert.ok(resourceUrl.includes('amp;pipeline=terrain-rgb'), `includes pipeline=terrain-rgb in ${resourceUrl}`);
     assert.ok(resourceUrl.includes('.png'), `includes .png in ${resourceUrl}`);
-    // assert;
-    console.log(resourceUrl);
   });
 
   it('should default to the aerial layer', async (t) => {

--- a/packages/lambda-tiler/src/routes/tile.wmts.ts
+++ b/packages/lambda-tiler/src/routes/tile.wmts.ts
@@ -69,6 +69,7 @@ export async function wmtsCapabilitiesGet(req: LambdaHttpRequest<WmtsCapabilitie
     imagery,
     formats: Validate.getRequestedFormats(req) ?? [],
     layers: req.params.tileMatrix == null ? tileSet.layers : undefined,
+    pipeline: req.query.get('pipeline'),
   });
 
   const xml = wmts.toXml();

--- a/packages/lambda-tiler/src/wmts.capability.ts
+++ b/packages/lambda-tiler/src/wmts.capability.ts
@@ -241,7 +241,7 @@ export interface WmtsCapabilitiesParams {
   /** Specific layers to add to the WMTS */
   layers?: ConfigLayer[];
   /** Default output pipeline to use */
-  pipeline?: string;
+  pipeline?: string | null;
 }
 
 /**
@@ -280,7 +280,7 @@ export class WmtsCapabilities extends WmtsBuilder {
     this.provider = provider;
   }
 
-  addPipeline(pipeline?: string): void {
+  addPipeline(pipeline: string): void {
     this.pipeline = pipeline;
   }
 
@@ -415,6 +415,6 @@ export class WmtsCapabilities extends WmtsBuilder {
     this.addTileSet(params.tileSet);
     this.addLayers(params.layers);
     this.addProvider(params.provider);
-    this.addPipeline(params.pipeline);
+    if (params.pipeline) this.addPipeline(params.pipeline);
   }
 }

--- a/packages/lambda-tiler/src/wmts.capability.ts
+++ b/packages/lambda-tiler/src/wmts.capability.ts
@@ -38,14 +38,15 @@ export interface WmtsBuilderParams {
   apiKey?: string;
   /** Config location */
   config?: string | null;
-  /** Specific DateRange filter for the wmts layers */
-  filters?: Record<string, string | undefined>;
+  /** Default pipeline to use */
+  pipeline?: string;
 }
 
 export class WmtsBuilder {
   httpBase: string;
   apiKey?: string;
   config?: string | null;
+  pipeline?: string;
   filters?: Record<string, string | undefined>;
 
   /** All the imagery used by the tileSet and tileMatrixes */
@@ -58,7 +59,7 @@ export class WmtsBuilder {
     this.httpBase = params.httpBase;
     this.apiKey = params.apiKey;
     this.config = params.config;
-    this.filters = params.filters;
+    this.pipeline = params.pipeline;
   }
 
   addImagery(...imagery: ConfigImagery[]): void {
@@ -153,17 +154,17 @@ export class WmtsBuilder {
     return V('Style', { isDefault: 'true' }, [V('ows:Title', 'Default Style'), V('ows:Identifier', 'default')]);
   }
 
-  buildResourceUrl(tileSetId: string, suffix: string, addFilter = false): VNodeElement {
+  buildResourceUrl(tileSetId: string, suffix: string): VNodeElement {
     return V('ResourceURL', {
       format: 'image/' + suffix,
       resourceType: 'tile',
-      template: this.buildTileUrl(tileSetId, suffix, addFilter),
+      template: this.buildTileUrl(tileSetId, suffix),
     });
   }
 
-  buildTileUrl(tileSetId: string, suffix: string, addFilter = false): string {
-    let query = { api: this.apiKey, config: this.config };
-    if (addFilter) query = { api: this.apiKey, config: this.config, ...this.filters };
+  buildTileUrl(tileSetId: string, suffix: string): string {
+    // TODO this should restrict the output formats to supported formats in pipelines
+    const query = { api: this.apiKey, config: this.config, pipeline: this.pipeline };
 
     return [
       this.httpBase,
@@ -239,6 +240,8 @@ export interface WmtsCapabilitiesParams {
   formats: ImageFormat[];
   /** Specific layers to add to the WMTS */
   layers?: ConfigLayer[];
+  /** Default output pipeline to use */
+  pipeline?: string;
 }
 
 /**
@@ -275,6 +278,10 @@ export class WmtsCapabilities extends WmtsBuilder {
 
   addProvider(provider?: WmtsProvider): void {
     this.provider = provider;
+  }
+
+  addPipeline(pipeline?: string): void {
+    this.pipeline = pipeline;
   }
 
   toProviderVNode(provider?: WmtsProvider): VNodeElement[] | [] {
@@ -338,7 +345,7 @@ export class WmtsCapabilities extends WmtsBuilder {
       this.buildStyle(),
       ...this.buildFormats(),
       ...this.buildTileMatrixLink(tileSet),
-      ...this.getFormats().map((fmt) => this.buildResourceUrl(layerNameId, fmt, true)),
+      ...this.getFormats().map((fmt) => this.buildResourceUrl(layerNameId, fmt)),
     ]);
   }
 
@@ -408,5 +415,6 @@ export class WmtsCapabilities extends WmtsBuilder {
     this.addTileSet(params.tileSet);
     this.addLayers(params.layers);
     this.addProvider(params.provider);
+    this.addPipeline(params.pipeline);
   }
 }


### PR DESCRIPTION
### Motivation

When viewing elevation via WMTS you need to supply a terrain-rgb pipeline
<!-- TODO: Say why you made your changes. -->

### Modifications

adds a default pipeline to wmts outputs if requested
Removes unused filter logic

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
