### PR TITLE
fix(cogify): Fix the dependencies for cogify cli.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19428,17 +19428,19 @@
       "name": "@basemaps/cogify",
       "version": "7.5.0",
       "license": "MIT",
-      "bin": {
-        "cogify": "build/bin.js"
-      },
-      "devDependencies": {
+      "dependencies": {
         "@basemaps/cli": "^7.5.0",
         "@basemaps/config": "^7.5.0",
         "@basemaps/config-loader": "^7.5.0",
         "@basemaps/geo": "^7.5.0",
         "@basemaps/shared": "^7.5.0",
         "cmd-ts": "^0.12.1",
-        "p-limit": "^4.0.0",
+        "p-limit": "^4.0.0"
+      },
+      "bin": {
+        "cogify": "build/bin.js"
+      },
+      "devDependencies": {
         "stac-ts": "^1.0.0"
       },
       "engines": {

--- a/packages/cogify/package.json
+++ b/packages/cogify/package.json
@@ -39,14 +39,16 @@
   "engines": {
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
-  "devDependencies": {
+  "dependencies": {
     "@basemaps/cli": "^7.5.0",
     "@basemaps/config": "^7.5.0",
     "@basemaps/config-loader": "^7.5.0",
     "@basemaps/geo": "^7.5.0",
     "@basemaps/shared": "^7.5.0",
     "cmd-ts": "^0.12.1",
-    "p-limit": "^4.0.0",
+    "p-limit": "^4.0.0"
+  },
+  "devDependencies": {
     "stac-ts": "^1.0.0"
   },
   "publishConfig": {


### PR DESCRIPTION
### Motivation

Cogify is bundled and installed in the @basemaps/cli container. They way calling cogify is from `node_modules`, like `node /app/node_modules/.bin/cogify`. We will require the the dependencies to be installed as well to make it work.

### Modifications
Revert back all the dependencies from devdependencies

### Verification

<!-- TODO: Say how you tested your changes. -->
