### PR TITLE
feat(landing): Add capture area into debug page. BM-1048

### DIFF
--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -8,7 +8,7 @@ import { MapAttrState } from '../attribution.js';
 import { Config } from '../config.js';
 import { ConfigData } from '../config.layer.js';
 import { MapConfig } from '../config.map.js';
-import { DebugMap } from '../debug.map.js';
+import { DebugMap, DebugType, debugTypes } from '../debug.map.js';
 import { MapOptionType, WindowUrl } from '../url.js';
 import { onMapLoaded } from './map.js';
 
@@ -130,32 +130,40 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
     this.debugMap.adjustRaster(this.props.map, 'osm', Config.map.debug['debug.layer.osm']);
     this.debugMap.adjustRaster(this.props.map, 'linz-aerial', Config.map.debug['debug.layer.linz-aerial']);
     void this.debugMap.adjustVector(this.props.map, Config.map.debug['debug.layer.linz-topographic']);
-    this.setVectorShown(Config.map.debug['debug.source'], 'source');
-    this.setVectorShown(Config.map.debug['debug.cog'], 'cog');
+    this.setVectorShown(Config.map.debug['debug.source'], debugTypes.source);
+    this.setVectorShown(Config.map.debug['debug.cog'], debugTypes.cog);
+    this.setVectorShown(Config.map.debug['debug.capture-area'], debugTypes['capture-area']);
     this.setTerrainShown(Config.map.debug['debug.terrain']);
     this.setHillShadeShown(Config.map.debug['debug.hillshade']);
     this.setVisibleSource(Config.map.debug['debug.layer']);
     this.renderWMTS();
   }
 
-  /** Show the source bounding box ont he map */
+  /** Show the source bounding box on the map */
   toggleTileBoundary: ChangeEventHandler = (e) => {
     const target = e.target as HTMLInputElement;
     Config.map.setDebug('debug.tile', target.checked);
   };
 
-  /** Show the source bounding box ont he map */
+  /** Show the source bounding box on the map */
   toggleCogs: ChangeEventHandler = (e) => {
     const target = e.target as HTMLInputElement;
     Config.map.setDebug('debug.cog', target.checked);
-    this.setVectorShown(target.checked, 'cog');
+    this.setVectorShown(target.checked, debugTypes.cog);
   };
 
-  /** Show the source bounding box ont he map */
+  /** Show the source bounding box on the map */
   toggleSource: ChangeEventHandler = (e) => {
     const target = e.target as HTMLInputElement;
     Config.map.setDebug('debug.source', target.checked);
-    this.setVectorShown(target.checked, 'source');
+    this.setVectorShown(target.checked, debugTypes.source);
+  };
+
+  /** Show the capture area on the map */
+  toggleCaptureArea: ChangeEventHandler = (e) => {
+    const target = e.target as HTMLInputElement;
+    Config.map.setDebug('debug.capture-area', target.checked);
+    this.setVectorShown(target.checked, debugTypes['capture-area']);
   };
 
   _loadingConfig: Promise<void> = Promise.resolve();
@@ -172,7 +180,7 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
       const imageryId = tileSet.layers[0][projectionCode];
       if (imageryId == null) return;
 
-      void this.debugMap.fetchSourceLayer(imageryId, 'cog').then((cog) => {
+      void this.debugMap.fetchSourceLayer(imageryId, debugTypes.cog).then((cog) => {
         this.setState({ isCog: cog != null });
       });
 
@@ -209,6 +217,7 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
         {this.renderPurple()}
         {this.renderCogToggle()}
         {this.renderSourceToggle()}
+        {this.renderCaptureAreaToggle()}
         {this.renderTileToggle()}
         {this.renderRasterSourceDropdown()}
         {this.renderDemSourceDropdown(demSources)}
@@ -421,6 +430,23 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
     );
   }
 
+  renderCaptureAreaToggle(): ReactNode {
+    if (this.state.imagery == null) return null;
+    const location = WindowUrl.toImageryUrl(this.state.imagery.id, 'capture-area.geojson');
+    return (
+      <Fragment>
+        <div className="debug__info">
+          <label className="debug__label">
+            <a href={location} title="Capture Area geojson">
+              Capture Area
+            </a>
+          </label>
+          <input type="checkbox" onChange={this.toggleCaptureArea} checked={Config.map.debug['debug.capture-area']} />
+        </div>
+      </Fragment>
+    );
+  }
+
   getSourcesIds(type: string): string[] {
     const style = this.props.map.getStyle();
     return Object.keys(style.sources).filter((id) => id.startsWith('basemaps') && style.sources[id].type === type);
@@ -494,13 +520,13 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
     );
   }
 
-  trackMouseMove(layerId: string, type: 'source' | 'cog'): void {
-    const sourceId = `${layerId}_${type}`;
+  trackMouseMove(layerId: string, type: DebugType): void {
+    const sourceId = `${layerId}_${type.name}`;
     const layerFillId = `${sourceId}_fill`;
     const map = this.props.map;
 
     let lastFeatureId: string | number | undefined;
-    const stateName = type === 'source' ? `featureSource` : `featureCog`;
+    const stateName = type.name === `feature-${type.name}`;
 
     // Onclick copy the location into the clipboard
     map.on('click', layerFillId, (e) => {
@@ -544,51 +570,74 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
     });
   }
 
-  setVectorShown(isShown: boolean, type: 'source' | 'cog'): void {
+  setVectorShown(isShown: boolean, type: DebugType): void {
     const map = this.props.map;
 
     map.showTileBoundaries = Config.map.debug['debug.tile'];
 
     const layerId = Config.map.layerId;
-    const sourceId = `${layerId}_${type}`;
+    const sourceId = `${layerId}_${type.name}`;
     const layerFillId = `${sourceId}_fill`;
     const layerLineId = `${sourceId}_line`;
+    const layerLineBlack = `${sourceId}_line_black`;
     if (isShown === false) {
-      if (map.getLayer(layerFillId) == null) return;
+      if (map.getLayer(layerLineId) == null) return;
       map.removeLayer(layerFillId);
       map.removeLayer(layerLineId);
+      map.removeLayer(layerLineBlack);
       return;
     }
 
     if (map.getLayer(layerLineId) != null) return;
 
-    const color = type === 'source' ? '#ff00ff' : '#ff0000';
-
     if (this.state.imagery == null) return;
     void this.debugMap.loadSourceLayer(this.props.map, layerId, this.state.imagery, type).then(() => {
       if (map.getLayer(layerLineId) != null) return;
       // Fill is needed to make the mouse move work even though it has opacity 0
-      map.addLayer({
-        id: layerFillId,
-        type: 'fill',
-        source: sourceId,
-        paint: {
-          'fill-opacity': ['case', ['boolean', ['feature-state', 'hover'], false], 0.25, 0],
-          'fill-color': color,
-        },
-      });
-      this.trackMouseMove(layerId, type);
+      if (type.fill) {
+        // fillable line polygons
+        map.addLayer({
+          id: layerFillId,
+          type: 'fill',
+          source: sourceId,
+          paint: {
+            'fill-opacity': ['case', ['boolean', ['feature-state', 'hover'], false], 0.25, 0],
+            'fill-color': type.color,
+          },
+        });
+        this.trackMouseMove(layerId, type);
+        map.addLayer({
+          id: layerLineId,
+          type: 'line',
+          source: sourceId,
+          paint: {
+            'line-color': type.color,
+            'line-opacity': ['case', ['boolean', ['feature-state', 'hover'], false], 1, 0.5],
+            'line-width': ['case', ['boolean', ['feature-state', 'hover'], false], 2, 1],
+          },
+        });
+      } else {
+        // Two color with black dashed type lines
+        map.addLayer({
+          id: layerLineId,
+          type: 'line',
+          source: sourceId,
+          paint: {
+            'line-color': '#000000',
+            'line-width': 4,
+          },
+        });
 
-      map.addLayer({
-        id: layerLineId,
-        type: 'line',
-        source: sourceId,
-        paint: {
-          'line-color': color,
-          'line-opacity': ['case', ['boolean', ['feature-state', 'hover'], false], 1, 0.5],
-          'line-width': ['case', ['boolean', ['feature-state', 'hover'], false], 2, 1],
-        },
-      });
+        map.addLayer({
+          id: layerLineBlack,
+          type: 'line',
+          source: sourceId,
+          paint: {
+            'line-color': '#FF7500',
+            'line-width': 2,
+          },
+        });
+      }
     });
   }
 }

--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -265,7 +265,7 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
 
   renderCogToggle(): ReactNode {
     if (this.state.imagery == null) return null;
-    const cogLocation = WindowUrl.toImageryUrl(this.state.imagery.id, 'covering.geojson');
+    const cogLocation = WindowUrl.toImageryUrl(this.state.imagery.id, debugTypes.cog.file);
     if (!this.state.isCog) return;
     return (
       <Fragment>
@@ -432,7 +432,7 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
 
   renderCaptureAreaToggle(): ReactNode {
     if (this.state.imagery == null) return null;
-    const location = WindowUrl.toImageryUrl(this.state.imagery.id, 'capture-area.geojson');
+    const location = WindowUrl.toImageryUrl(this.state.imagery.id, debugTypes['capture-area'].file);
     return (
       <Fragment>
         <div className="debug__info">
@@ -617,9 +617,9 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
           },
         });
       } else {
-        // Two color with black dashed type lines
+        // Add a black double weighted line behind the layer line
         map.addLayer({
-          id: layerLineId,
+          id: layerLineBlack,
           type: 'line',
           source: sourceId,
           paint: {
@@ -629,11 +629,11 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
         });
 
         map.addLayer({
-          id: layerLineBlack,
+          id: layerLineId,
           type: 'line',
           source: sourceId,
           paint: {
-            'line-color': '#FF7500',
+            'line-color': type.color,
             'line-width': 2,
           },
         });

--- a/packages/landing/src/config.debug.ts
+++ b/packages/landing/src/config.debug.ts
@@ -6,6 +6,8 @@ export interface DebugState {
   'debug.source': boolean;
   /** Should the cog outlines be shown */
   'debug.cog': boolean;
+  /** Should the capture area be shown */
+  'debug.capture-area': boolean;
   /** Should the map tile boundaries be shown */
   'debug.tile': boolean;
   /** Should things be hidden to make a better screenshot */
@@ -33,6 +35,7 @@ export const DebugDefaults: DebugState = {
   'debug.source': false,
   'debug.tile': false,
   'debug.cog': false,
+  'debug.capture-area': false,
   'debug.screenshot': false,
   'debug.layer.linz-aerial': 0,
   'debug.layer.linz-topographic': 0,
@@ -72,6 +75,7 @@ export class ConfigDebug {
     isChanged = setKey(opt, 'debug.tile', url.get('debug.tile') != null) || isChanged;
     isChanged = setKey(opt, 'debug.source', url.get('debug.source') != null) || isChanged;
     isChanged = setKey(opt, 'debug.cog', url.get('debug.cog') != null) || isChanged;
+    isChanged = setKey(opt, 'debug.capture-area', url.get('debug.capture-area') != null) || isChanged;
     isChanged = setKey(opt, 'debug.screenshot', url.get('debug.screenshot') != null) || isChanged;
     isChanged = setNum(opt, 'debug.layer.linz-aerial', url.get('debug.layer.linz-aerial')) || isChanged;
     isChanged = setNum(opt, 'debug.layer.linz-topographic', url.get('debug.layer.linz-topographic')) || isChanged;

--- a/packages/landing/src/debug.map.ts
+++ b/packages/landing/src/debug.map.ts
@@ -1,5 +1,6 @@
 import { ConfigImagery } from '@basemaps/config/build/config/imagery.js';
 import { GoogleTms } from '@basemaps/geo';
+import { BBoxFeature } from '@linzjs/geojson';
 import { BBoxFeatureCollection } from '@linzjs/geojson/build/types.js';
 import { StyleSpecification } from 'maplibre-gl';
 import { FormEventHandler } from 'react';
@@ -8,7 +9,6 @@ import { Config } from './config.js';
 import { ConfigData } from './config.layer.js';
 import { projectGeoJson } from './tile.matrix.js';
 import { MapOptionType, WindowUrl } from './url.js';
-import { BBoxFeature } from '@linzjs/geojson';
 
 export interface DebugType {
   name: string;
@@ -40,12 +40,7 @@ export const debugTypes = {
 
 export class DebugMap {
   _layerLoading: Map<string, Promise<void>> = new Map();
-  loadSourceLayer(
-    map: maplibregl.Map,
-    layerId: string,
-    imagery: ConfigImagery,
-    type: DebugType,
-  ): Promise<void> {
+  loadSourceLayer(map: maplibregl.Map, layerId: string, imagery: ConfigImagery, type: DebugType): Promise<void> {
     const layerKey = `${layerId}-${type.name}`;
     let existing = this._layerLoading.get(layerKey);
     if (existing == null) {
@@ -55,12 +50,7 @@ export class DebugMap {
     return existing;
   }
 
-  async _loadSourceLayer(
-    map: maplibregl.Map,
-    layerId: string,
-    imagery: ConfigImagery,
-    type: DebugType,
-  ): Promise<void> {
+  async _loadSourceLayer(map: maplibregl.Map, layerId: string, imagery: ConfigImagery, type: DebugType): Promise<void> {
     const sourceId = `${layerId}_${type.name}`;
     const layerFillId = `${sourceId}_fill`;
     if (map.getLayer(layerFillId) != null) return;

--- a/packages/landing/src/debug.map.ts
+++ b/packages/landing/src/debug.map.ts
@@ -33,7 +33,7 @@ export const debugTypes = {
   'capture-area': {
     name: 'capture-area',
     file: 'capture-area.geojson',
-    color: '#00FFFF',
+    color: '#FF7500',
     fill: false,
   },
 };

--- a/packages/landing/src/debug.map.ts
+++ b/packages/landing/src/debug.map.ts
@@ -8,11 +8,45 @@ import { Config } from './config.js';
 import { ConfigData } from './config.layer.js';
 import { projectGeoJson } from './tile.matrix.js';
 import { MapOptionType, WindowUrl } from './url.js';
+import { BBoxFeature } from '@linzjs/geojson';
+
+export interface DebugType {
+  name: string;
+  file: string;
+  color: string;
+  fill: boolean;
+}
+
+export const debugTypes = {
+  source: {
+    name: 'source',
+    file: 'source.geojson',
+    color: '#ff00ff',
+    fill: true,
+  },
+  cog: {
+    name: 'cog',
+    file: 'covering.geojson',
+    color: '#ff0000',
+    fill: true,
+  },
+  'capture-area': {
+    name: 'capture-area',
+    file: 'capture-area.geojson',
+    color: '#00FFFF',
+    fill: false,
+  },
+};
 
 export class DebugMap {
   _layerLoading: Map<string, Promise<void>> = new Map();
-  loadSourceLayer(map: maplibregl.Map, layerId: string, imagery: ConfigImagery, type: 'source' | 'cog'): Promise<void> {
-    const layerKey = `${layerId}-${type}`;
+  loadSourceLayer(
+    map: maplibregl.Map,
+    layerId: string,
+    imagery: ConfigImagery,
+    type: DebugType,
+  ): Promise<void> {
+    const layerKey = `${layerId}-${type.name}`;
     let existing = this._layerLoading.get(layerKey);
     if (existing == null) {
       existing = this._loadSourceLayer(map, layerId, imagery, type);
@@ -25,33 +59,38 @@ export class DebugMap {
     map: maplibregl.Map,
     layerId: string,
     imagery: ConfigImagery,
-    type: 'source' | 'cog',
+    type: DebugType,
   ): Promise<void> {
-    const sourceId = `${layerId}_${type}`;
+    const sourceId = `${layerId}_${type.name}`;
     const layerFillId = `${sourceId}_fill`;
     if (map.getLayer(layerFillId) != null) return;
 
     let data = await this.fetchSourceLayer(imagery.id, type);
-    if (data == null && type === 'source') {
+    if (data == null && type.name === 'source') {
       data = ConfigData.getGeoJson(imagery);
     }
+
     if (data == null) return;
 
     if (Config.map.tileMatrix.projection !== GoogleTms.projection) projectGeoJson(data, Config.map.tileMatrix);
 
     let id = 0;
     // Ensure there is a id on each feature
-    for (const f of data.features) f.id = id++;
+    if (data.type === 'Feature') {
+      data.id = id;
+    } else if (data.type === 'FeatureCollection') {
+      for (const f of data.features) f.id = id++;
+    }
 
     map.addSource(sourceId, { type: 'geojson', data });
   }
 
-  _source: Map<string, Promise<BBoxFeatureCollection>> = new Map();
-  async fetchSourceLayer(imageryId: string, type: string): Promise<BBoxFeatureCollection | undefined> {
-    const id = `${imageryId}_${type}`;
+  _source: Map<string, Promise<BBoxFeatureCollection | BBoxFeature>> = new Map();
+  async fetchSourceLayer(imageryId: string, type: DebugType): Promise<BBoxFeatureCollection | BBoxFeature | undefined> {
+    const id = `${imageryId}_${type.name}`;
     let existing = this._source.get(id);
     if (existing == null) {
-      const sourceUri = WindowUrl.toImageryUrl(imageryId, type === 'source' ? 'source.geojson' : 'covering.geojson');
+      const sourceUri = WindowUrl.toImageryUrl(imageryId, type.file);
       existing = fetch(sourceUri).then((r) => {
         if (r.ok) return r.json();
         return;

--- a/packages/landing/src/tile.matrix.ts
+++ b/packages/landing/src/tile.matrix.ts
@@ -117,7 +117,7 @@ function projectFeature(f: GeoJSON.Feature, targetTileMatrix: TileMatrixSet): vo
         }
       }
     }
-  } else{
+  } else {
     throw new Error(`Geometry feature type: ${f.geometry.type} not supported`);
   }
 }


### PR DESCRIPTION
### Motivation

Load capture-area.json into the debug checkbox if exist, and make it easier to download for imagery data managers to use.

### Modifications
Add new checkbox for capture area and show a doubled line the polygon on the map.

### Verification
![image](https://github.com/linz/basemaps/assets/12163920/fc8b32bc-c3b7-478e-85c7-0dc21dad215f)
![image](https://github.com/linz/basemaps/assets/12163920/6728c17d-4e61-488b-ba0a-0b7517e14ca6)
