### PR TITLE
fix(landing): Need to pass config parameter into imagery api

### DIFF
--- a/packages/landing/src/url.ts
+++ b/packages/landing/src/url.ts
@@ -64,7 +64,8 @@ export const WindowUrl = {
   },
 
   toImageryUrl(layerId: string, imageryType: string): string {
-    return `${this.baseUrl()}/v1/imagery/${layerId}/${imageryType}`;
+    const query = toQueryString({ config: ensureBase58(Config.map.config) });
+    return `${this.baseUrl()}/v1/imagery/${layerId}/${imageryType}${query}`;
   },
 
   toTileUrl(params: TileUrlParams): string {


### PR DESCRIPTION
### Motivation

Debug page cog and capture-area checkbox should get the geojson file from target config parameter. 

### Modifications
This will fix the problem of not found gejson file with a config paramemeter

### Verification

<!-- TODO: Say how you tested your changes. -->
