### PR TITLE
feat(config): Update the config to support sky in the style json. BM-1052

### DIFF
--- a/packages/config-loader/src/json/parse.style.ts
+++ b/packages/config-loader/src/json/parse.style.ts
@@ -11,6 +11,7 @@ export const zStyleJson = z.object({
 
   // TODO it would be good to actually validate all the styles
   layers: z.array(z.unknown()),
+  sky: z.unknown(),
 });
 
 export type StyleJsonConfigSchema = z.infer<typeof zStyleJson>;

--- a/packages/config/src/config/vector.style.ts
+++ b/packages/config/src/config/vector.style.ts
@@ -40,6 +40,24 @@ export interface Layer {
   'source-layer'?: string;
 }
 
+/** Sky MapLibre Style Spec, all valuables support interpolate expressions, as unknown format */
+export interface Sky {
+  /** The base color for the sky. Optional Defaults to #88C6FC */
+  'sky-color'?: unknown;
+  /** The base color at the horizon. Optional Defaults to #ffffff */
+  'horizon-color'?: unknown;
+  /** The base color for the fog. Requires 3D terrain. Optional Defaults to #ffffff */
+  'fog-color'?: unknown;
+  /** How to blend the fog over the 3D terrain. Optional number in range [0, 1]. Defaults to 0.5 */
+  'fog-ground-blend'?: unknown;
+  /** How to blend the fog color and the horizon color. Optional number in range [0, 1]. Defaults to 0.8. */
+  'horizon-fog-blend'?: unknown;
+  /** How to blend the the sky color and the horizon color. Optional number in range [0, 1]. Defaults to 0.8. */
+  'sky-horizon-blend'?: unknown;
+  /** How to blend the atmosphere. Optional number in range [0, 1]. Defaults to 0.8. */
+  'atmosphere-blend'?: unknown;
+}
+
 export interface Terrain {
   source: string;
   exaggeration: number;
@@ -72,6 +90,9 @@ export interface StyleJson {
 
   /** Layers will be drawn in the order of this array. */
   layers: Layer[];
+
+  /** The map's sky configuration */
+  sky?: Sky;
 
   /** OPTIONAL - A global modifier that elevates layers and markers based on a DEM data source */
   terrain?: Terrain;

--- a/packages/config/src/config/vector.style.ts
+++ b/packages/config/src/config/vector.style.ts
@@ -43,19 +43,19 @@ export interface Layer {
 /** Sky MapLibre Style Spec, all valuables support interpolate expressions, as unknown format */
 export interface Sky {
   /** The base color for the sky. Optional Defaults to #88C6FC */
-  'sky-color'?: unknown;
+  'sky-color'?: string | unknown[];
   /** The base color at the horizon. Optional Defaults to #ffffff */
-  'horizon-color'?: unknown;
+  'horizon-color'?: string | unknown[];
   /** The base color for the fog. Requires 3D terrain. Optional Defaults to #ffffff */
-  'fog-color'?: unknown;
+  'fog-color'?: string | unknown[];
   /** How to blend the fog over the 3D terrain. Optional number in range [0, 1]. Defaults to 0.5 */
-  'fog-ground-blend'?: unknown;
+  'fog-ground-blend'?: number | unknown[];
   /** How to blend the fog color and the horizon color. Optional number in range [0, 1]. Defaults to 0.8. */
-  'horizon-fog-blend'?: unknown;
+  'horizon-fog-blend'?: number | unknown[];
   /** How to blend the the sky color and the horizon color. Optional number in range [0, 1]. Defaults to 0.8. */
-  'sky-horizon-blend'?: unknown;
+  'sky-horizon-blend'?: number | unknown[];
   /** How to blend the atmosphere. Optional number in range [0, 1]. Defaults to 0.8. */
-  'atmosphere-blend'?: unknown;
+  'atmosphere-blend'?: number | unknown[];
 }
 
 export interface Terrain {

--- a/packages/lambda-tiler/src/routes/tile.style.json.ts
+++ b/packages/lambda-tiler/src/routes/tile.style.json.ts
@@ -70,6 +70,7 @@ export function convertStyleJson(
   if (style.metadata) styleJson.metadata = style.metadata;
   if (style.glyphs) styleJson.glyphs = convertRelativeUrl(style.glyphs, undefined, undefined, config);
   if (style.sprite) styleJson.sprite = convertRelativeUrl(style.sprite, undefined, undefined, config);
+  if (style.sky) styleJson.sky = style.sky;
 
   return styleJson;
 }


### PR DESCRIPTION
### Motivation

Update the config style parser and loader to include sky in the stylejson.

### Modifications

Add sky type into stylejson

### Verification

![image](https://github.com/linz/basemaps/assets/12163920/1d75956e-ffcf-40a0-8000-cb5064762d69)
![image](https://github.com/linz/basemaps/assets/12163920/852a5d68-de74-429a-8ff3-8ef1d90fb1b4)
