### PR TITLE
fix(lambda-tiler): prefer geojson files to be downloaded  BM-1048

### DIFF
--- a/packages/lambda-tiler/src/routes/__tests__/imagery.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/imagery.test.ts
@@ -4,7 +4,7 @@ import { before, beforeEach, describe, it } from 'node:test';
 import { ConfigProviderMemory } from '@basemaps/config';
 import { fsa, FsMemory } from '@chunkd/fs';
 
-import { FakeData, Imagery3857 } from '../../__tests__/config.data.js';
+import { Imagery3857 } from '../../__tests__/config.data.js';
 import { mockRequest } from '../../__tests__/xyz.util.js';
 import { handler } from '../../index.js';
 import { ConfigLoader } from '../../util/config.loader.js';

--- a/packages/lambda-tiler/src/routes/__tests__/imagery.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/imagery.test.ts
@@ -1,9 +1,27 @@
 import assert from 'node:assert';
-import { describe, it } from 'node:test';
+import { before, beforeEach, describe, it } from 'node:test';
 
+import { ConfigProviderMemory } from '@basemaps/config';
+import { fsa, FsMemory } from '@chunkd/fs';
+
+import { FakeData, Imagery3857 } from '../../__tests__/config.data.js';
+import { mockRequest } from '../../__tests__/xyz.util.js';
+import { handler } from '../../index.js';
+import { ConfigLoader } from '../../util/config.loader.js';
 import { isAllowedFile } from '../imagery.js';
 
 describe('ImageryRoute', () => {
+  const memory = new FsMemory();
+  const config = new ConfigProviderMemory();
+
+  before(() => {
+    fsa.register('memory://imagery/', memory);
+  });
+
+  beforeEach(() => {
+    config.assets = 'fake-s3://assets/';
+  });
+
   it('should allow geojson and json files only', () => {
     assert.equal(isAllowedFile('foo.geojson'), true);
     assert.equal(isAllowedFile('foo.json'), true);
@@ -11,5 +29,37 @@ describe('ImageryRoute', () => {
     assert.equal(isAllowedFile('foo'), false);
     assert.equal(isAllowedFile(''), false);
     assert.equal(isAllowedFile(null as unknown as string), false);
+  });
+
+  it('should force download geojson files', async (t) => {
+    const fakeImagery = { ...Imagery3857 };
+    config.put(fakeImagery);
+    fakeImagery.uri = 'memory://imagery/';
+
+    t.mock.method(ConfigLoader, 'getDefaultConfig', () => Promise.resolve(config));
+    const res404 = await handler.router.handle(mockRequest(`/v1/imagery/${fakeImagery.id}/capture-area.geojson`));
+    assert.equal(res404.status, 404);
+
+    await memory.write(fsa.toUrl('memory://imagery/capture-area.geojson'), JSON.stringify({ hello: 'world' }));
+
+    const res200 = await handler.router.handle(mockRequest(`/v1/imagery/${fakeImagery.id}/capture-area.geojson`));
+    assert.equal(res200.status, 200);
+    assert.equal(res200.headers.get('content-disposition'), 'attachment');
+  });
+
+  it('should fetch stac files', async (t) => {
+    const fakeImagery = { ...Imagery3857 };
+    config.put(fakeImagery);
+    fakeImagery.uri = 'memory://imagery/';
+
+    t.mock.method(ConfigLoader, 'getDefaultConfig', () => Promise.resolve(config));
+    const res404 = await handler.router.handle(mockRequest(`/v1/imagery/${fakeImagery.id}/collection.json`));
+    assert.equal(res404.status, 404);
+
+    await memory.write(fsa.toUrl('memory://imagery/collection.json'), JSON.stringify({ hello: 'world' }));
+
+    const res200 = await handler.router.handle(mockRequest(`/v1/imagery/${fakeImagery.id}/collection.json`));
+    assert.equal(res200.status, 200);
+    assert.equal(res200.headers.get('content-disposition'), undefined);
   });
 });

--- a/packages/lambda-tiler/src/routes/imagery.ts
+++ b/packages/lambda-tiler/src/routes/imagery.ts
@@ -51,6 +51,10 @@ export async function imageryGet(req: LambdaHttpRequest<ImageryGet>): Promise<La
     response.header(HttpHeader.ETag, cacheKey);
     response.header(HttpHeader.ContentEncoding, 'gzip');
     response.header(HttpHeader.CacheControl, 'public, max-age=604800, stale-while-revalidate=86400');
+    // Force geojson files to be downloaded
+    if (requestedFile.endsWith('.geojson')) {
+      response.header('Content-Disposition', 'attachment');
+    }
     response.buffer(isGzip(buf) ? buf : await gzipP(buf), 'application/json');
     req.set('bytes', buf.byteLength);
     return response;


### PR DESCRIPTION
### Motivation

Currently geojson files are generally just shown to the user when clicked from inside a browser most of our usecases want these files locally so it would be preferred if they download
<!-- TODO: Say why you made your changes. -->

### Modifications

Force download all imagery geojson files using content-disposition
<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
