### PR TITLE
ci: Enable 3d screenshots in the basemaps. BM-1054

### DIFF
--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -40,7 +40,7 @@ jobs:
           # Wait for the server to start
           timeout 30 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:5000/v1/version)" !=  "200" ]]; do sleep 0.5; done' || false
 
-          docker run --rm --network="host" -v $PWD:$PWD ghcr.io/linz/basemaps-screenshot/cli:v1 --url http://localhost:5000 --output $PWD/.artifacts/visual-snapshots
+          docker run --rm --network="host" -v $PWD:$PWD ghcr.io/linz/basemaps-screenshot/cli:v1.7.0-3-g670e858 --url http://localhost:5000 --output $PWD/.artifacts/visual-snapshots
 
       - name: Save snapshots
         uses: getsentry/action-visual-snapshot@v2

--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -40,7 +40,7 @@ jobs:
           # Wait for the server to start
           timeout 30 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:5000/v1/version)" !=  "200" ]]; do sleep 0.5; done' || false
 
-          docker run --rm --network="host" -v $PWD:$PWD ghcr.io/linz/basemaps-screenshot/cli:v1.7.0-3-g670e858 --url http://localhost:5000 --output $PWD/.artifacts/visual-snapshots
+          docker run --rm --network="host" -v $PWD:$PWD ghcr.io/linz/basemaps-screenshot/cli:v1 --url http://localhost:5000 --output $PWD/.artifacts/visual-snapshots
 
       - name: Save snapshots
         uses: getsentry/action-visual-snapshot@v2

--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -40,7 +40,7 @@ jobs:
           # Wait for the server to start
           timeout 30 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:5000/v1/version)" !=  "200" ]]; do sleep 0.5; done' || false
 
-          docker run --rm --network="host" -v $PWD:$PWD ghcr.io/linz/basemaps-screenshot/cli:v1.5.0 --url http://localhost:5000 --output $PWD/.artifacts/visual-snapshots
+          docker run --rm --network="host" -v $PWD:$PWD ghcr.io/linz/basemaps-screenshot/cli:v1 --url http://localhost:5000 --output $PWD/.artifacts/visual-snapshots
 
       - name: Save snapshots
         uses: getsentry/action-visual-snapshot@v2

--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -40,7 +40,7 @@ jobs:
           # Wait for the server to start
           timeout 30 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:5000/v1/version)" !=  "200" ]]; do sleep 0.5; done' || false
 
-          docker run --rm --network="host" -v $PWD:$PWD ghcr.io/linz/basemaps-screenshot/cli:v1 --url http://localhost:5000 --output $PWD/.artifacts/visual-snapshots
+          docker run --rm --network="host" -v $PWD:$PWD ghcr.io/linz/basemaps-screenshot/cli:v1.7.0-2-g99b800e --url http://localhost:5000 --output $PWD/.artifacts/visual-snapshots
 
       - name: Save snapshots
         uses: getsentry/action-visual-snapshot@v2

--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -40,7 +40,7 @@ jobs:
           # Wait for the server to start
           timeout 30 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:5000/v1/version)" !=  "200" ]]; do sleep 0.5; done' || false
 
-          docker run --rm --network="host" -v $PWD:$PWD ghcr.io/linz/basemaps-screenshot/cli:v1.7.0-2-g99b800e --url http://localhost:5000 --output $PWD/.artifacts/visual-snapshots
+          docker run --rm --network="host" -v $PWD:$PWD ghcr.io/linz/basemaps-screenshot/cli:v1 --url http://localhost:5000 --output $PWD/.artifacts/visual-snapshots
 
       - name: Save snapshots
         uses: getsentry/action-visual-snapshot@v2

--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -121,8 +121,10 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
           loadedDiv.style.height = '1px';
           document.body.appendChild(loadedDiv);
         }
-        void map.on('idle', () => {
-          void addLoadedDiv();
+        void map.on('sourcedata', (e) => {
+          if (e.isSourceLoaded) {
+            void addLoadedDiv();
+          }
         });
       }
     });

--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -122,7 +122,7 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
           document.body.appendChild(loadedDiv);
         }
 
-        async function removeLoadedDiv(): Promise<void> {
+        function removeLoadedDiv(): void {
           // Check map-loaded div and remove if exists
           const id = 'map-loaded';
           const loadedDiv = document.getElementById(id);

--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -108,11 +108,14 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
       if (Config.map.debug['debug.screenshot']) {
         async function addLoadedDiv(): Promise<void> {
           // Ensure hillshade source is loaded
+          const hillShadeSourceId = `${HillShadePrefix}${Config.map.debug['debug.hillshade']}`;
           if (Config.map.debug['debug.hillshade']) {
-            if (!map.isSourceLoaded(`${HillShadePrefix}${Config.map.debug['debug.hillshade']}`)) return;
+            if (map.getSource(hillShadeSourceId) == null) return;
+            if (!map.isSourceLoaded(hillShadeSourceId)) return;
           }
           // Ensure terrain source is loaded
           if (Config.map.debug['debug.terrain']) {
+            if (map.getSource(Config.map.debug['debug.terrain']) == null) return;
             if (!map.isSourceLoaded(Config.map.debug['debug.terrain'])) return;
           }
           // Ensure the attribution data has loaded
@@ -128,12 +131,11 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
 
         void map.on('sourcedata', (e) => {
           if (e.source.type !== 'raster-dem') return;
-          if (e.isSourceLoaded) {
-            void addLoadedDiv();
-          }
+          void addLoadedDiv();
         });
 
         void map.on('idle', () => {
+          this.updateFromConfig();
           void addLoadedDiv();
         });
       }
@@ -364,6 +366,7 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
       source: hillShadeSourceId,
       paint: { 'hillshade-shadow-color': '#040404' },
     });
+    map;
   }
 
   setTerrainShown(sourceId: string | null): void {

--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -107,18 +107,18 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
 
       if (Config.map.debug['debug.screenshot']) {
         async function addLoadedDiv(): Promise<void> {
-          // Ensure hillshade source is loaded
-          const hillShadeSourceId = `${HillShadePrefix}${Config.map.debug['debug.hillshade']}`;
-          if (Config.map.debug['debug.hillshade']) {
-            if (map.getSource(hillShadeSourceId) == null) return;
-            if (!map.isSourceLoaded(hillShadeSourceId)) return;
-          }
-          // Ensure terrain source is loaded
-          if (Config.map.debug['debug.terrain']) {
-            if (map.getSource(Config.map.debug['debug.terrain']) == null) return;
-            if (!map.isSourceLoaded(Config.map.debug['debug.terrain'])) return;
-          }
-          // Ensure the attribution data has loaded
+          // // Ensure hillshade source is loaded
+          // const hillShadeSourceId = `${HillShadePrefix}${Config.map.debug['debug.hillshade']}`;
+          // if (Config.map.debug['debug.hillshade']) {
+          //   if (map.getSource(hillShadeSourceId) == null) return;
+          //   if (!map.isSourceLoaded(hillShadeSourceId)) return;
+          // }
+          // // Ensure terrain source is loaded
+          // if (Config.map.debug['debug.terrain']) {
+          //   if (map.getSource(Config.map.debug['debug.terrain']) == null) return;
+          //   if (!map.isSourceLoaded(Config.map.debug['debug.terrain'])) return;
+          // }
+          // // Ensure the attribution data has loaded
           await MapAttrState.getCurrentAttribution();
           await new Promise((r) => setTimeout(r, 250));
           // Jam a div into the page once the map has loaded so tools like playwright can see the map has finished loading
@@ -129,12 +129,13 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
           document.body.appendChild(loadedDiv);
         }
 
-        void map.on('sourcedata', (e) => {
-          if (e.source.type !== 'raster-dem') return;
-          void addLoadedDiv();
-        });
+        // void map.on('sourcedata', (e) => {
+        //   if (e.source.type !== 'raster-dem') return;
+        //   void addLoadedDiv();
+        // });
 
-        void map.on('idle', () => {
+        void map.once('idle', () => {
+          // Ensure hillshade and terrain source is loaded
           this.updateFromConfig();
           void addLoadedDiv();
         });

--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -107,6 +107,10 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
 
       if (Config.map.debug['debug.screenshot']) {
         async function addLoadedDiv(): Promise<void> {
+          // Skip if map-loaded exists
+          const id = 'map-loaded';
+          const existingDiv = document.getElementById(id);
+          if (existingDiv) return;
           // Ensure the attribution data has loaded
           await MapAttrState.getCurrentAttribution();
           await new Promise((r) => setTimeout(r, 250));
@@ -118,7 +122,19 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
           document.body.appendChild(loadedDiv);
         }
 
-        void map.once('idle', () => {
+        async function removeLoadedDiv(): Promise<void> {
+          // Check map-loaded div and remove if exists
+          const id = 'map-loaded';
+          const loadedDiv = document.getElementById(id);
+          if (loadedDiv) loadedDiv.remove();
+        }
+
+        void map.on('data', () => {
+          // Remove the map-loaded div if exists
+          void removeLoadedDiv();
+        });
+
+        void map.on('idle', () => {
           // Ensure hillshade and terrain source is loaded
           this.updateFromConfig();
           void addLoadedDiv();

--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -111,6 +111,10 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
           if (Config.map.debug['debug.hillshade']) {
             if (!map.isSourceLoaded(`${HillShadePrefix}${Config.map.debug['debug.hillshade']}`)) return;
           }
+          // Ensure terrain source is loaded
+          if (Config.map.debug['debug.terrain']) {
+            if (!map.isSourceLoaded(Config.map.debug['debug.terrain'])) return;
+          }
           // Ensure the attribution data has loaded
           await MapAttrState.getCurrentAttribution();
           await new Promise((r) => setTimeout(r, 250));
@@ -121,10 +125,16 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
           loadedDiv.style.height = '1px';
           document.body.appendChild(loadedDiv);
         }
+
         void map.on('sourcedata', (e) => {
+          if (e.source.type !== 'raster-dem') return;
           if (e.isSourceLoaded) {
             void addLoadedDiv();
           }
+        });
+
+        void map.on('idle', () => {
+          void addLoadedDiv();
         });
       }
     });

--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -454,7 +454,7 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
     );
   }
 
-  getSourcesIds(type: string): string[] {
+  getSourcesIds(type: 'raster' | 'raster-dem'): string[] {
     const style = this.props.map.getStyle();
     if (type === 'raster-dem') {
       return Object.keys(style.sources).filter(

--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -107,18 +107,7 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
 
       if (Config.map.debug['debug.screenshot']) {
         async function addLoadedDiv(): Promise<void> {
-          // // Ensure hillshade source is loaded
-          // const hillShadeSourceId = `${HillShadePrefix}${Config.map.debug['debug.hillshade']}`;
-          // if (Config.map.debug['debug.hillshade']) {
-          //   if (map.getSource(hillShadeSourceId) == null) return;
-          //   if (!map.isSourceLoaded(hillShadeSourceId)) return;
-          // }
-          // // Ensure terrain source is loaded
-          // if (Config.map.debug['debug.terrain']) {
-          //   if (map.getSource(Config.map.debug['debug.terrain']) == null) return;
-          //   if (!map.isSourceLoaded(Config.map.debug['debug.terrain'])) return;
-          // }
-          // // Ensure the attribution data has loaded
+          // Ensure the attribution data has loaded
           await MapAttrState.getCurrentAttribution();
           await new Promise((r) => setTimeout(r, 250));
           // Jam a div into the page once the map has loaded so tools like playwright can see the map has finished loading
@@ -128,11 +117,6 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
           loadedDiv.style.height = '1px';
           document.body.appendChild(loadedDiv);
         }
-
-        // void map.on('sourcedata', (e) => {
-        //   if (e.source.type !== 'raster-dem') return;
-        //   void addLoadedDiv();
-        // });
 
         void map.once('idle', () => {
           // Ensure hillshade and terrain source is loaded
@@ -367,7 +351,6 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
       source: hillShadeSourceId,
       paint: { 'hillshade-shadow-color': '#040404' },
     });
-    map;
   }
 
   setTerrainShown(sourceId: string | null): void {

--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -121,7 +121,9 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
         }
 
         void map.once('idle', () => {
-          if (Config.map.debug['debug.terrain'] || Config.map.debug['debug.hillshade']) {
+          const isTerrainOn = Config.map.debug['debug.terrain'] != null && Config.map.debug['debug.terrain'] !== 'off';
+          const isHSOn = Config.map.debug['debug.hillshade'] != null && Config.map.debug['debug.hillshade'] !== 'off';
+          if (isTerrainOn || isHSOn) {
             // Ensure hillshade and terrain source is loaded and wait for 2s
             this.updateFromConfig();
             setTimeout(() => void addLoadedDiv(), 2000);
@@ -319,16 +321,15 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
   };
 
   setHillShadeShown(sourceId: string | null): void {
+    Config.map.setDebug('debug.hillshade', sourceId);
     const map = this.props.map;
     const isTurnOff = sourceId === 'off' || sourceId == null;
 
     const currentLayer = map.getLayer(HillShadeLayerId);
     if (isTurnOff) {
-      Config.map.setDebug('debug.hillshade', null);
       if (currentLayer) map.removeLayer(HillShadeLayerId);
       return;
     }
-    Config.map.setDebug('debug.hillshade', sourceId);
     if (currentLayer?.source === sourceId) return;
 
     // Hillshading from an existing raster-dem source gives very mixed results and looks very blury
@@ -390,12 +391,9 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
     const isTurnOff = sourceId === 'off' || sourceId == null;
     const currentTerrain = map.getTerrain();
     if (isTurnOff) {
-      Config.map.setDebug('debug.terrain', null);
       map.setTerrain(null);
       return;
     }
-
-    Config.map.setDebug('debug.terrain', sourceId);
 
     const target = getTerrainForSource(sourceId, Config.map.tileMatrix);
     // no changes

--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -107,6 +107,7 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
 
       if (Config.map.debug['debug.screenshot']) {
         async function addLoadedDiv(): Promise<void> {
+          if (!map.loaded()) return;
           // Ensure the attribution data has loaded
           await MapAttrState.getCurrentAttribution();
           await new Promise((r) => setTimeout(r, 250));
@@ -117,7 +118,7 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
           loadedDiv.style.height = '1px';
           document.body.appendChild(loadedDiv);
         }
-        void map.once('idle', () => {
+        void map.on('idle', () => {
           void addLoadedDiv();
         });
       }

--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -107,7 +107,10 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
 
       if (Config.map.debug['debug.screenshot']) {
         async function addLoadedDiv(): Promise<void> {
-          if (!map.loaded()) return;
+          // Ensure hillshade source is loaded
+          if (Config.map.debug['debug.hillshade']) {
+            if (!map.isSourceLoaded(`${HillShadePrefix}${Config.map.debug['debug.hillshade']}`)) return;
+          }
           // Ensure the attribution data has loaded
           await MapAttrState.getCurrentAttribution();
           await new Promise((r) => setTimeout(r, 250));


### PR DESCRIPTION
### Motivation

We want to fix the 3d screenshots in PR.

### Modifications
- When setting 3d in screenshots, we want to force load config from url and wait for 2s.
- Updated to the latest screenshot cli which removes bearing and pitch to save computing.
- Only do 5 tests on 3d map screenshots to keep the workflow running around 4 mins.
- Stop showing `debug.terrain` and `debug.terrain` in url when it is `off`

### Verification

<!-- TODO: Say how you tested your changes. -->
