### PR TITLE
feat(infra): add responder team tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3115,9 +3115,9 @@
       }
     },
     "node_modules/@linzjs/cdk-tags": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@linzjs/cdk-tags/-/cdk-tags-1.6.0.tgz",
-      "integrity": "sha512-fCScruPStgN5+7j7rN7iztA4pCenlI5sd7W94lvyrmojdhq1Y+213c6oI7Y0V77LK0kR77oEGGoNEL8wbcu7cg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@linzjs/cdk-tags/-/cdk-tags-1.7.0.tgz",
+      "integrity": "sha512-HlsBA4CoBFVyX5XS2J5kT/l9ij+DmW6AnUJi1IYL5KOv5sVg36CJacyqfFI8hnLZmoildXWT/7cA3eLO6snzZg==",
       "dev": true,
       "engines": {
         "node": ">=18.0"
@@ -19298,7 +19298,7 @@
         "@aws-sdk/client-cloudformation": "^3.470.0",
         "@basemaps/lambda-tiler": "^7.7.0",
         "@basemaps/shared": "^7.7.0",
-        "@linzjs/cdk-tags": "^1.6.0",
+        "@linzjs/cdk-tags": "^1.7.0",
         "aws-cdk": "2.114.x",
         "aws-cdk-lib": "2.114.x",
         "constructs": "^10.3.0"

--- a/packages/_infra/package.json
+++ b/packages/_infra/package.json
@@ -28,7 +28,7 @@
     "@aws-sdk/client-cloudformation": "^3.470.0",
     "@basemaps/lambda-tiler": "^7.7.0",
     "@basemaps/shared": "^7.7.0",
-    "@linzjs/cdk-tags": "^1.6.0",
+    "@linzjs/cdk-tags": "^1.7.0",
     "aws-cdk": "2.114.x",
     "aws-cdk-lib": "2.114.x",
     "constructs": "^10.3.0"

--- a/packages/_infra/src/index.ts
+++ b/packages/_infra/src/index.ts
@@ -1,6 +1,6 @@
 import { ACMClient, ListCertificatesCommand } from '@aws-sdk/client-acm';
 import { Env } from '@basemaps/shared';
-import { applyTags, SecurityClassification } from '@linzjs/cdk-tags';
+import { applyTags, SecurityClassification, TagsBase } from '@linzjs/cdk-tags';
 import { App } from 'aws-cdk-lib';
 
 import { EdgeAnalytics } from './analytics/edge.analytics.js';
@@ -21,13 +21,14 @@ async function findCertForDomain(region: string, domain: string): Promise<string
 async function main(): Promise<void> {
   const basemaps = new App();
 
-  const commonTags = {
+  const commonTags: TagsBase = {
     application: 'basemaps',
     environment: IsProduction ? 'prod' : 'nonprod',
     group: 'li',
     impact: 'moderate',
     classification: SecurityClassification.Unclassified,
-  } as const;
+    responderTeam: 'LINZ - Basemaps',
+  };
 
   /** Using VPC lookups requires a hard coded AWS "account" */
   const account = Env.get(DeployEnv.CdkAccount);


### PR DESCRIPTION
### Motivation

To better monitor the basemaps service a responder team needs to be set so that others inside LINZ know who to contact if something goes wrong.

### Modifications

Sets the responder team to "LINZ - Basemaps"

### Verification

<!-- TODO: Say how you tested your changes. -->
