### PR TITLE
feat(landing): Add LINZ-Terrain-Prod for debug 3d map with production elevation data. BM-1058

### DIFF
--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -30,7 +30,7 @@ const HillShadeLayerId = 'debug-hillshade';
 /** dynamic hillshade sources are prefixed with this key */
 const HillShadePrefix = '__hillshade-';
 /** dynamic linz-elevation source key */
-const elevationProdId = 'linz-elevation-prod';
+const elevationProdId = 'LINZ-Terrain-Prod';
 
 interface DropDownContext {
   /** Label for the drop down */

--- a/packages/landing/src/config.map.ts
+++ b/packages/landing/src/config.map.ts
@@ -154,7 +154,8 @@ export class MapConfig extends Emitter<MapConfigEvents> {
     if (opts.tileMatrix.identifier !== GoogleTms.identifier) urlParams.append('tileMatrix', opts.tileMatrix.identifier);
     // Config by far the longest so make it the last parameter
     if (opts.config) urlParams.append('config', ensureBase58(opts.config));
-    if (opts.terrain) urlParams.append('terrain', opts.terrain);
+    // We don't need to set terrain parameter for debug, as we got debug.terrain parameter to replace
+    if (opts.terrain && !opts.isDebug) urlParams.append('terrain', opts.terrain);
 
     ConfigDebug.toUrl(opts.debug, urlParams);
     return urlParams.toString();


### PR DESCRIPTION
### Motivation

We want debug page to view terrain for individual config files that doesn't have elevation tileset inside. Using the same logic of linz-aerial slider and get the elevation data from the production or dev config based on the host.

### Modifications

Add a new LINZ-Terrain-Prod source layer in the terrain and hillshade dropdown that points to the basemaps production data for debugging.

### Verification
![image](https://github.com/user-attachments/assets/a8888c20-8e52-4c00-b5c2-f938b3c7a3d3)
