### PR TITLE
fix(landing): put back the sourceId tracking logic BM-1062

### DIFF
--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -61,6 +61,11 @@ function debugSourceDropdown(ctx: DropDownContext): ReactNode {
   );
 }
 
+/** Upper case the first character of the string */
+function upperCaseFirstChar(c: string): string {
+  return c[0].toUpperCase() + c.slice(1);
+}
+
 function debugSlider(label: 'osm' | 'linz-topographic' | 'linz-aerial', onInput: FormEventHandler): ReactNode {
   return (
     <input
@@ -564,7 +569,8 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
     const map = this.props.map;
 
     let lastFeatureId: string | number | undefined;
-    const stateName = type.name === `feature-${type.name}`;
+    // State names are `featureSource` or `featureCog` etc.
+    const stateName = `feature${upperCaseFirstChar(type.name)}`;
 
     // Onclick copy the location into the clipboard
     map.on('click', layerFillId, (e) => {


### PR DESCRIPTION
### Motivation

Source id tracking logic was broken in commit 07b8aebd6dbc25045647739999f2d3e5f2602106 with https://github.com/linz/basemaps/commit/07b8aebd6dbc25045647739999f2d3e5f2602106#diff-935afb39a4daeb9c30850cda3e20eecf1fb8f5086b9172fef9a5e8539e5e99f5R529

### Modifications

return the state name back to `featureSource` and `featureCog`

### Verification

Tested locally hover is now working as expected.
