### PR TITLE
fix(landing): Fix the map switcher that setting bearing and pitch to 0. BM-1063

### DIFF
--- a/packages/landing/src/components/map.switcher.tsx
+++ b/packages/landing/src/components/map.switcher.tsx
@@ -78,8 +78,8 @@ export class MapSwitcher extends Component {
 
     this.map.setZoom(Math.max(location.zoom - 4, 0));
     this.map.setCenter([location.lon, location.lat]);
-    if (Config.map.location.bearing != null) this.map.setBearing(Config.map.location.bearing);
-    if (Config.map.location.pitch != null) this.map.setPitch(Config.map.location.pitch);
+    Config.map.location.bearing == null ? this.map.setBearing(0) : this.map.setBearing(Config.map.location.bearing);
+    Config.map.location.pitch == null ? this.map.setPitch(0) : this.map.setPitch(Config.map.location.pitch);
     this.forceUpdate();
   };
 

--- a/packages/landing/src/components/map.switcher.tsx
+++ b/packages/landing/src/components/map.switcher.tsx
@@ -79,7 +79,7 @@ export class MapSwitcher extends Component {
     this.map.setZoom(Math.max(location.zoom - 4, 0));
     this.map.setCenter([location.lon, location.lat]);
     this.map.setBearing(Config.map.location.bearing ?? 0);
-    Config.map.location.pitch == null ? this.map.setPitch(0) : this.map.setPitch(Config.map.location.pitch);
+    this.map.setPitch(Config.map.location.pitch ?? 0);
     this.forceUpdate();
   };
 

--- a/packages/landing/src/components/map.switcher.tsx
+++ b/packages/landing/src/components/map.switcher.tsx
@@ -78,7 +78,7 @@ export class MapSwitcher extends Component {
 
     this.map.setZoom(Math.max(location.zoom - 4, 0));
     this.map.setCenter([location.lon, location.lat]);
-    Config.map.location.bearing == null ? this.map.setBearing(0) : this.map.setBearing(Config.map.location.bearing);
+    this.map.setBearing(Config.map.location.bearing ?? 0);
     Config.map.location.pitch == null ? this.map.setPitch(0) : this.map.setPitch(Config.map.location.pitch);
     this.forceUpdate();
   };


### PR DESCRIPTION
### Motivation
Landing page map switcher on the bottom left doesn't set the map location when bearing or pitch is 0.

### Modifications
The map switcher sets the bearing and pitch by the update location from config. But it is skip setting when pitch or bearing is null. We should also set to 0 if null.

### Verification
