### PR TITLE
fix(landing): Only pass terrain request parameter to get style json api. BM-1068

### DIFF
--- a/packages/landing/src/url.ts
+++ b/packages/landing/src/url.ts
@@ -75,7 +75,7 @@ export const WindowUrl = {
     if (params.config != null) queryParams.set('config', ensureBase58(params.config));
     if (params.pipeline != null) queryParams.set('pipeline', params.pipeline);
     if (params.date?.before != null) queryParams.set('date[before]', params.date.before);
-    if (params.terrain != null) queryParams.set('terrain', params.terrain);
+    if (params.terrain != null && params.urlType === MapOptionType.Style) queryParams.set('terrain', params.terrain);
 
     const imageFormat = params.imageFormat ?? WindowUrl.ImageFormat;
     if (params.urlType === MapOptionType.Style) {


### PR DESCRIPTION
### Motivation

We got terrain request parameter been passed to xyz and wmts api which is confusing people and these api also not support terrain. So we should only limit the terrain to pass into get style json only.

### Modifications
Only add terrain for style url.

### Verification
-- Removed from xyz and wmts
![image](https://github.com/user-attachments/assets/b40886ff-e581-4a4a-81ac-4a169a1767ae)
![image](https://github.com/user-attachments/assets/de46ac02-98a0-4ef4-81f4-8eec681468e9)

-- Only keep for style json url.
![image](https://github.com/user-attachments/assets/fc55ad4e-01c7-4068-83fa-81dcd6daef89)


