### PR TITLE
fix(lambda-tiler): prevent unhandled promise rejections when the rejection is handled BM-1067

### DIFF
--- a/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
+++ b/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
@@ -1,6 +1,6 @@
 import { ConfigTileSetRaster, getAllImagery } from '@basemaps/config';
 import { Bounds, Epsg, TileMatrixSet, TileMatrixSets } from '@basemaps/geo';
-import { Cotar, Env, LogConfig, stringToUrlFolder, Tiff } from '@basemaps/shared';
+import { Cotar, Env, stringToUrlFolder, Tiff } from '@basemaps/shared';
 import { getImageFormat, Tiler } from '@basemaps/tiler';
 import { TileMakerSharp } from '@basemaps/tiler-sharp';
 import { HttpHeader, LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambda';
@@ -109,7 +109,6 @@ export const TileXyzRaster = {
     }
 
     // Remove with typescript >=5.5.0
-
     return (await Promise.all(toLoad)).filter((f) => f != null);
   },
 

--- a/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
+++ b/packages/lambda-tiler/src/routes/tile.xyz.raster.ts
@@ -1,6 +1,6 @@
 import { ConfigTileSetRaster, getAllImagery } from '@basemaps/config';
 import { Bounds, Epsg, TileMatrixSet, TileMatrixSets } from '@basemaps/geo';
-import { Cotar, Env, stringToUrlFolder, Tiff } from '@basemaps/shared';
+import { Cotar, Env, LogConfig, stringToUrlFolder, Tiff } from '@basemaps/shared';
 import { getImageFormat, Tiler } from '@basemaps/tiler';
 import { TileMakerSharp } from '@basemaps/tiler-sharp';
 import { HttpHeader, LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambda';

--- a/packages/lambda-tiler/src/util/__test__/cache.test.ts
+++ b/packages/lambda-tiler/src/util/__test__/cache.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { fsa, FsMemory } from '@chunkd/fs';
+
+import { SourceCache } from '../source.cache.js';
+
+describe('CoSourceCache', () => {
+  it('should not exit if a promise rejection happens', async () => {
+    const cache = new SourceCache(5);
+
+    const mem = new FsMemory();
+    const tiffLoc = new URL('memory://foo/bar.tiff');
+    await mem.write(tiffLoc, Buffer.from('ABC123'));
+    fsa.register('memory://', mem);
+
+    await cache.getCog(tiffLoc).catch(() => null);
+    assert.equal(cache.cache.currentSize, 1);
+  });
+});


### PR DESCRIPTION
### Motivation

Fetching data from remote services can and will error on occasion, the promises to fetch data from tiffs has two `.then()` one of the `.then()` has a associated `.catch()` the other does not, this leads to a `UnhandledPromiseRejection` 

### Modifications

Do not use a `.then()` without `.catch()`

### Verification

Unit test addded.
also checked the code base for more usages of `void ....then()` without .catch and they only occur in the landing page.