### PR TITLE
fix(lambda-tiler): do not keep failed tiffs in memory

### DIFF
--- a/packages/lambda-tiler/src/util/__test__/cache.test.ts
+++ b/packages/lambda-tiler/src/util/__test__/cache.test.ts
@@ -6,7 +6,7 @@ import { fsa, FsMemory } from '@chunkd/fs';
 import { SourceCache } from '../source.cache.js';
 
 describe('CoSourceCache', () => {
-  it('should not exit if a promise rejection happens', async () => {
+  it('should not exit if a promise rejection happens for tiff', async () => {
     const cache = new SourceCache(5);
 
     const mem = new FsMemory();
@@ -14,7 +14,23 @@ describe('CoSourceCache', () => {
     await mem.write(tiffLoc, Buffer.from('ABC123'));
     fsa.register('memory://', mem);
 
-    await cache.getCog(tiffLoc).catch(() => null);
-    assert.equal(cache.cache.currentSize, 1);
+    let failCount = 0;
+    await cache.getCog(tiffLoc).catch(() => failCount++);
+    assert.equal(cache.cache.currentSize, 0);
+    assert.equal(failCount, 1);
+  });
+
+  it('should not exit if a promise rejection happens for tar', async () => {
+    const cache = new SourceCache(5);
+
+    const mem = new FsMemory();
+    const tiffLoc = new URL('memory://foo/bar.tar');
+    await mem.write(tiffLoc, Buffer.from('ABC123'));
+    fsa.register('memory://', mem);
+
+    let failCount = 0;
+    await cache.getCotar(tiffLoc).catch(() => failCount++);
+    assert.equal(cache.cache.currentSize, 0);
+    assert.equal(failCount, 1);
   });
 });

--- a/packages/lambda-tiler/src/util/source.cache.ts
+++ b/packages/lambda-tiler/src/util/source.cache.ts
@@ -31,6 +31,7 @@ export class SourceCache {
     }
     const value = Tiff.create(fsa.source(location));
     this.cache.set(location.href, { type: 'cog', value, size: 1 });
+    value.catch(() => this.cache.delete(location.href));
     return value;
   }
 
@@ -43,6 +44,7 @@ export class SourceCache {
     }
     const value = Cotar.fromTar(fsa.source(location));
     this.cache.set(location.href, { type: 'cotar', value, size: 1 });
+    value.catch(() => this.cache.delete(location.href));
     return value;
   }
 }

--- a/packages/lambda-tiler/src/util/swapping.lru.ts
+++ b/packages/lambda-tiler/src/util/swapping.lru.ts
@@ -41,6 +41,11 @@ export class SwappingLru<T extends { size: number }> {
     this.clears++;
   }
 
+  delete(id: string): void {
+    this.cacheA.delete(id);
+    this.cacheB.delete(id);
+  }
+
   set(id: string, tiff: T): void {
     this.cacheA.set(id, tiff);
     this.check();


### PR DESCRIPTION
### Motivation

when requests fail, sometimes they can be retried later and succeed, right now we are caching the error state.

### Modifications

On error remove the cached tiff/tar from the cache

### Verification

added unit tests.
