### PR TITLE
fix(shared): allow unprefixed query keys

### DIFF
--- a/packages/shared/src/dynamo/dynamo.config.base.ts
+++ b/packages/shared/src/dynamo/dynamo.config.base.ts
@@ -27,7 +27,7 @@ export class ConfigDynamoBase<T extends BaseConfig = BaseConfig> extends Basemap
   /** Ensure the ID is prefixed before querying */
   ensureId(id: string): string {
     if (id.startsWith(this.prefix + '_')) return id;
-    throw new Error(`Trying to query "${id}" expected prefix of ${this.prefix}`);
+    return `${this.prefix}_${id}`;
   }
 
   private get db(): DynamoDB {


### PR DESCRIPTION
### Motivation

all of our unit tests use the memory config provider which ensures the keys start with the correct prefix

### Modifications

In dynamodb configs force the prefix to be added if its not present.

### Verification

updated unit tests
