### PR TITLE
fix(lambda-tiler): do not join layers where ids would be duplicated

### DIFF
--- a/packages/lambda-tiler/src/routes/__tests__/tile.style.json.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/tile.style.json.test.ts
@@ -400,4 +400,15 @@ describe('/v1/styles', () => {
     assert.equal(body.sources['basemaps_vector']?.type, 'vector');
     assert.equal(body.layers.length, 2);
   });
+
+  it('should error when joining layers with duplicate ids', async () => {
+    const fakeStyle = { id: 'st_labels', name: 'labels', style: fakeVectorStyleConfig };
+    config.put(fakeStyle);
+    config.put(TileSetAerial);
+
+    const request = mockUrlRequest('/v1/styles/labels.json', `?labels=true`, Api.header);
+    const res = await handler.router.handle(request);
+    assert.equal(res.status, 400, res.statusDescription);
+    assert.equal(res.statusDescription.includes('Background1'), true);
+  });
 });

--- a/packages/lambda-tiler/src/routes/tile.style.json.ts
+++ b/packages/lambda-tiler/src/routes/tile.style.json.ts
@@ -105,6 +105,15 @@ async function setStyleLabels(req: LambdaHttpRequest<StyleGet>, style: StyleJson
     return;
   }
 
+  const layerId = new Set<string>();
+  for (const l of style.layers) layerId.add(l.id);
+
+  for (const newLayers of labels.style.layers) {
+    if (layerId.has(newLayers.id)) {
+      throw new LambdaHttpResponse(400, 'Cannot merge styles with duplicate layerIds: ' + newLayers.id);
+    }
+  }
+
   if (style.glyphs == null) style.glyphs = labels.style.glyphs;
   if (style.sprite == null) style.sprite = labels.style.sprite;
   if (style.sky == null) style.sky = labels.style.sky;

--- a/packages/landing/src/components/map.label.tsx
+++ b/packages/landing/src/components/map.label.tsx
@@ -2,7 +2,7 @@ import { IControl } from 'maplibre-gl';
 
 import { Config } from '../config.js';
 
-const LabelsDisabledLayers = new Set(['topographic', 'topolite']);
+export const LabelsDisabledLayers = new Set(['topographic', 'topolite']);
 
 export class MapLabelControl implements IControl {
   map?: maplibregl.Map;

--- a/packages/landing/src/url.ts
+++ b/packages/landing/src/url.ts
@@ -2,6 +2,7 @@ import { base58, isBase58 } from '@basemaps/config/build/base58.js';
 import { GoogleTms, TileMatrixSet } from '@basemaps/geo';
 import { toQueryString } from '@basemaps/shared/build/url.js';
 
+import { LabelsDisabledLayers } from './components/map.label.js';
 import { Config } from './config.js';
 import { FilterDate } from './config.map.js';
 
@@ -77,7 +78,10 @@ export const WindowUrl = {
     if (params.pipeline != null) queryParams.set('pipeline', params.pipeline);
     if (params.date?.before != null) queryParams.set('date[before]', params.date.before);
     if (params.terrain != null && params.urlType === MapOptionType.Style) queryParams.set('terrain', params.terrain);
-    if (params.labels && params.urlType === MapOptionType.Style) queryParams.set('labels', String(params.labels));
+    if (params.labels && params.urlType === MapOptionType.Style) {
+      // Some layers have the label option disabled, do not append the labels request to those layers.
+      if (!LabelsDisabledLayers.has(params.style ?? '')) queryParams.set('labels', String(params.labels));
+    }
 
     const imageFormat = params.imageFormat ?? WindowUrl.ImageFormat;
     if (params.urlType === MapOptionType.Style) {


### PR DESCRIPTION
### Motivation

Joining layers with the labels can cause invaldi style jsons to be created, check that the layer ids do not overlap before joining.

### Modifications

Check all layers have unique layerIds before joining them together

### Verification

unit tests.
