### PR TITLE
feat(lambda-tiler): automatically rescale style JSON's into NZTM2000Quad when requests

### DIFF
--- a/packages/lambda-tiler/src/__tests__/tile.style.json.test.ts
+++ b/packages/lambda-tiler/src/__tests__/tile.style.json.test.ts
@@ -145,7 +145,7 @@ describe('TileStyleJson', () => {
     };
 
     const converted = structuredClone(rasterStyleJson);
-    setStyleUrls(rasterStyleJson, Nztm2000QuadTms, 'abc123', null);
+    setStyleUrls(converted, Nztm2000QuadTms, 'abc123', null);
 
     assert.deepEqual(converted.sources['raster'], {
       type: 'raster',
@@ -161,7 +161,7 @@ describe('TileStyleJson', () => {
     const apiKey = '0x9f9f';
     const converted = structuredClone(baseStyleJson);
 
-    setStyleUrls(baseStyleJson, GoogleTms, apiKey, null);
+    setStyleUrls(converted, GoogleTms, apiKey, null);
     assert.equal(converted.sprite, 'https://tiles.test/v1/sprites');
     assert.equal(converted.glyphs, 'https://tiles.test/v1/glyphs');
 
@@ -173,7 +173,7 @@ describe('TileStyleJson', () => {
     const apiKey = '0x9f9f';
     const converted = structuredClone(baseStyleJson);
 
-    setStyleUrls(baseStyleJson, GoogleTms, apiKey, 'config.json');
+    setStyleUrls(converted, GoogleTms, apiKey, 'config.json');
     assert.equal(converted.sprite, 'https://tiles.test/v1/sprites?config=config.json');
     assert.equal(converted.glyphs, 'https://tiles.test/v1/glyphs?config=config.json');
 

--- a/packages/lambda-tiler/src/__tests__/tile.style.json.test.ts
+++ b/packages/lambda-tiler/src/__tests__/tile.style.json.test.ts
@@ -5,7 +5,7 @@ import { StyleJson } from '@basemaps/config';
 import { GoogleTms, Nztm2000QuadTms } from '@basemaps/geo';
 import { Env } from '@basemaps/shared';
 
-import { convertRelativeUrl, convertStyleJson } from '../routes/tile.style.json.js';
+import { convertRelativeUrl, setStyleUrls } from '../routes/tile.style.json.js';
 
 describe('TileStyleJson', () => {
   const host = 'https://tiles.test';
@@ -75,7 +75,8 @@ describe('TileStyleJson', () => {
 
   it('should not destroy the original configuration', () => {
     const apiKey = 'abc123';
-    const converted = convertStyleJson(baseStyleJson, GoogleTms, apiKey, null);
+    const converted = structuredClone(baseStyleJson);
+    setStyleUrls(converted, GoogleTms, apiKey, null);
 
     assert.deepEqual(converted.sources['vector'], {
       type: 'vector',
@@ -92,7 +93,9 @@ describe('TileStyleJson', () => {
 
     assert.equal(JSON.stringify(baseStyleJson).includes(apiKey), false);
 
-    const convertedB = convertStyleJson(baseStyleJson, GoogleTms, '0x1234', null);
+    const convertedB = structuredClone(baseStyleJson);
+
+    setStyleUrls(convertedB, GoogleTms, '0x1234', null);
     assert.deepEqual(convertedB.sources['vector'], {
       type: 'vector',
       url: 'https://tiles.test/v1/tiles/topographic/WebMercatorQuad/tile.json?api=0x1234',
@@ -124,7 +127,8 @@ describe('TileStyleJson', () => {
 
   it('should cover raster style Json without metadata, sprite and glyphs', () => {
     const apiKey = 'abc123';
-    const converted = convertStyleJson(rasterStyleJson, GoogleTms, apiKey, null);
+    const converted = structuredClone(rasterStyleJson);
+    setStyleUrls(rasterStyleJson, GoogleTms, apiKey, null);
 
     assert.equal(converted.metadata, null);
     assert.equal(converted.sprite, null);
@@ -140,7 +144,8 @@ describe('TileStyleJson', () => {
       },
     };
 
-    const converted = convertStyleJson(rasterStyleJson, Nztm2000QuadTms, 'abc123', null);
+    const converted = structuredClone(rasterStyleJson);
+    setStyleUrls(rasterStyleJson, Nztm2000QuadTms, 'abc123', null);
 
     assert.deepEqual(converted.sources['raster'], {
       type: 'raster',
@@ -154,7 +159,9 @@ describe('TileStyleJson', () => {
 
   it('should convert relative glyphs and sprites', () => {
     const apiKey = '0x9f9f';
-    const converted = convertStyleJson(baseStyleJson, GoogleTms, apiKey, null);
+    const converted = structuredClone(baseStyleJson);
+
+    setStyleUrls(baseStyleJson, GoogleTms, apiKey, null);
     assert.equal(converted.sprite, 'https://tiles.test/v1/sprites');
     assert.equal(converted.glyphs, 'https://tiles.test/v1/glyphs');
 
@@ -164,7 +171,9 @@ describe('TileStyleJson', () => {
 
   it('should convert with config', () => {
     const apiKey = '0x9f9f';
-    const converted = convertStyleJson(baseStyleJson, GoogleTms, apiKey, 'config.json');
+    const converted = structuredClone(baseStyleJson);
+
+    setStyleUrls(baseStyleJson, GoogleTms, apiKey, 'config.json');
     assert.equal(converted.sprite, 'https://tiles.test/v1/sprites?config=config.json');
     assert.equal(converted.glyphs, 'https://tiles.test/v1/glyphs?config=config.json');
 

--- a/packages/lambda-tiler/src/routes/__tests__/tile.style.json.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/tile.style.json.test.ts
@@ -411,4 +411,64 @@ describe('/v1/styles', () => {
     assert.equal(res.status, 400, res.statusDescription);
     assert.equal(res.statusDescription.includes('Background1'), true);
   });
+
+  it('should convert NZTM2000Quad styles', async () => {
+    const fakeStyle = {
+      id: 'st_labels',
+      name: 'source',
+      style: {
+        layers: [
+          {
+            minzoom: 5,
+            maxzoom: 5,
+            layout: {
+              'line-width': {
+                stops: [
+                  [16, 0.75],
+                  [24, 1.5],
+                ],
+              },
+            },
+
+            paint: {
+              'line-width': {
+                stops: [
+                  [16, 0.75],
+                  [24, 1.5],
+                ],
+              },
+            },
+          },
+        ],
+        terrain: {
+          exaggeration: 1.1,
+        },
+      },
+    };
+    config.put(fakeStyle);
+
+    const request = mockUrlRequest('/v1/styles/labels.json', `?tileMatrix=NZTM2000Quad`, Api.header);
+    const res = await handler.router.handle(request);
+    assert.equal(res.status, 200, res.statusDescription);
+    const style = JSON.parse(Buffer.from(res.body, 'base64').toString()) as StyleJson;
+    assert.equal(style.layers[0].minzoom, 3);
+    assert.equal(style.layers[0].maxzoom, 3);
+    assert.equal(style.terrain?.exaggeration, 4.4);
+    assert.deepEqual(style.layers[0].layout, {
+      'line-width': {
+        stops: [
+          [14, 0.75],
+          [22, 1.5],
+        ],
+      },
+    });
+    assert.deepEqual(style.layers[0].paint, {
+      'line-width': {
+        stops: [
+          [14, 0.75],
+          [22, 1.5],
+        ],
+      },
+    });
+  });
 });

--- a/packages/lambda-tiler/src/routes/tile.style.json.ts
+++ b/packages/lambda-tiler/src/routes/tile.style.json.ts
@@ -54,7 +54,7 @@ export function convertRelativeUrl(
 }
 
 /**
- * Create a new style JSON that has absolute urls to the current host and API Keys where required
+ * Update the style JSON to have absolute urls to the current host and API Keys where required
  *
  * @param style style to update
  * @param tileMatrix convert the tile matrix to the target tile matrix
@@ -99,7 +99,7 @@ function setStyleTerrain(style: StyleJson, terrain: string, tileMatrix: TileMatr
 }
 
 /**
- * Merge the "labels" layer into the output style
+ * Merge the "labels" layer into the style json
  */
 async function setStyleLabels(req: LambdaHttpRequest<StyleGet>, style: StyleJson): Promise<void> {
   const config = await ConfigLoader.load(req);

--- a/packages/lambda-tiler/src/util/__test__/nztm.style.test.ts
+++ b/packages/lambda-tiler/src/util/__test__/nztm.style.test.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { StyleJson } from '@basemaps/config';
+
+import { convertStyleToNztmStyle } from '../nztm.style.js';
+
+describe('NZTM2000QuadStyle', () => {
+  const fakeStyle: StyleJson = {
+    version: 8,
+    id: 'test',
+    name: 'topographic',
+    sources: {},
+    layers: [],
+    glyphs: '/glyphs',
+    sprite: '/sprite',
+    metadata: { id: 'test' },
+  };
+
+  it('should convert min/maxzooms', () => {
+    const newStyle = convertStyleToNztmStyle({
+      ...fakeStyle,
+      layers: [{ minzoom: 5, maxzoom: 10, id: 'something', type: '' }],
+    });
+
+    assert.deepEqual(newStyle.layers[0], { minzoom: 3, maxzoom: 8, id: 'something', type: '' });
+  });
+
+  it('should offset terrain', () => {
+    const newStyle = convertStyleToNztmStyle({
+      ...fakeStyle,
+      terrain: { exaggeration: 1.1, source: 'abc' },
+    });
+
+    assert.deepEqual(newStyle.terrain, { exaggeration: 4.4, source: 'abc' });
+  });
+
+  it('should convert stops inside of paint and layout', () => {
+    const newStyle = convertStyleToNztmStyle({
+      ...fakeStyle,
+      layers: [
+        {
+          layout: {
+            'line-width': {
+              stops: [
+                [16, 0.75],
+                [24, 1.5],
+              ],
+            },
+          },
+
+          paint: {
+            'line-width': {
+              stops: [
+                [16, 0.75],
+                [24, 1.5],
+              ],
+            },
+          },
+          id: 'something',
+          type: '',
+        },
+      ],
+    });
+
+    assert.deepEqual(newStyle.layers[0], {
+      layout: {
+        'line-width': {
+          stops: [
+            [14, 0.75],
+            [22, 1.5],
+          ],
+        },
+      },
+      paint: {
+        'line-width': {
+          stops: [
+            [14, 0.75],
+            [22, 1.5],
+          ],
+        },
+      },
+      id: 'something',
+      type: '',
+    });
+  });
+});

--- a/packages/lambda-tiler/src/util/__test__/nztm.style.test.ts
+++ b/packages/lambda-tiler/src/util/__test__/nztm.style.test.ts
@@ -17,6 +17,19 @@ describe('NZTM2000QuadStyle', () => {
     metadata: { id: 'test' },
   };
 
+  it('should not modify the source style', () => {
+    const baseStyle = {
+      ...fakeStyle,
+      terrain: { exaggeration: 1.1, source: 'abc' },
+    };
+
+    convertStyleToNztmStyle(baseStyle);
+    assert.equal(baseStyle.terrain?.exaggeration, 1.1);
+
+    convertStyleToNztmStyle(baseStyle, false);
+    assert.equal(baseStyle.terrain?.exaggeration, 4.4);
+  });
+
   it('should convert min/maxzooms', () => {
     const newStyle = convertStyleToNztmStyle({
       ...fakeStyle,

--- a/packages/lambda-tiler/src/util/nztm.style.ts
+++ b/packages/lambda-tiler/src/util/nztm.style.ts
@@ -1,0 +1,43 @@
+import { StyleJson } from '@basemaps/config';
+
+/**
+ * limited checking to cast a unknown paint/layout into one with stops
+ */
+function hasStops(x: unknown): x is { stops: [number, unknown][] } {
+  if (x == null) return false;
+  return Array.isArray((x as { stops: unknown })['stops']);
+}
+
+/**
+ * Convert a style json from a WebMercatorQuad style into a NZTM2000Quad style,
+ * This creates a clone of the source style and does not modify the source
+ *
+ * NZTM2000Quad is offset from WebMercatorQuad by two zoom levels
+ *
+ * @param inputStyle style to convert
+ * @returns a new style converted into NZTM2000Quad zooms
+ */
+export function convertStyleToNztmStyle(inputStyle: StyleJson): StyleJson {
+  const style = structuredClone(inputStyle);
+
+  for (const layer of style.layers) {
+    // Adjust the min/max zoom
+    if (layer.minzoom) layer.minzoom = Math.max(0, layer.minzoom - 2);
+    if (layer.maxzoom) layer.maxzoom = Math.max(0, layer.maxzoom - 2);
+
+    // Check all the pain and layout for "stops" then adjust the stops by two
+    const stylesToCheck = [layer.paint, layer.layout];
+    for (const obj of stylesToCheck) {
+      if (obj == null) continue;
+      for (const val of Object.values(obj)) {
+        if (!hasStops(val)) continue;
+        for (const stop of val.stops) stop[0] = Math.max(0, stop[0] - 2);
+      }
+    }
+  }
+
+  /** Based on {@link DefaultExaggeration} offsetting by 2 two levels changes the exaggeration needed by approx 4x */
+  if (style.terrain) style.terrain.exaggeration = style.terrain.exaggeration * 4;
+
+  return style;
+}

--- a/packages/lambda-tiler/src/util/nztm.style.ts
+++ b/packages/lambda-tiler/src/util/nztm.style.ts
@@ -15,10 +15,11 @@ function hasStops(x: unknown): x is { stops: [number, unknown][] } {
  * NZTM2000Quad is offset from WebMercatorQuad by two zoom levels
  *
  * @param inputStyle style to convert
+ * @param clone Should the input style be cloned or modified
  * @returns a new style converted into NZTM2000Quad zooms
  */
-export function convertStyleToNztmStyle(inputStyle: StyleJson): StyleJson {
-  const style = structuredClone(inputStyle);
+export function convertStyleToNztmStyle(inputStyle: StyleJson, clone: boolean = true): StyleJson {
+  const style = clone ? structuredClone(inputStyle) : inputStyle;
 
   for (const layer of style.layers) {
     // Adjust the min/max zoom


### PR DESCRIPTION
### Motivation

NZTM2000Quad is offset by two zoom levels from web mercator quad, when the stylejsons are created for both projections the style json needs to adjust all the zoom levels by two

### Modifications

Convert styles zoom offsets automatically when asking for a NZTM2000Quad style json
updated comments across the style json endpoint
refactored the style generation into a single point.

### Verification

unit tests