### PR TITLE
fix(landing): hide label button on debug page as its broken BM-20

### DIFF
--- a/packages/landing/src/components/map.label.tsx
+++ b/packages/landing/src/components/map.label.tsx
@@ -47,12 +47,22 @@ export class MapLabelControl implements IControl {
     Config.map.setLabels(labelState);
   };
 
+  /** Is the label button hidden from view */
+  isDisabled(): boolean {
+    // Most vector styles have overlaps with the labels and make them useless
+    if (Config.map.style && LabelsDisabledLayers.has(Config.map.style)) return true;
+    // Labels use the merge style feature and need the production configuration to work
+    if (Config.map.config) return true;
+
+    return false;
+  }
+
   updateLabelIcon = (): void => {
     if (this.button == null) return;
     this.button.classList.remove('maplibregl-ctrl-labels-enabled');
 
     // Topographic style disables the button
-    if (Config.map.style && LabelsDisabledLayers.has(Config.map.style)) {
+    if (this.isDisabled()) {
       this.button.classList.add('display-none');
       this.button.title = 'Topographic style does not support layers';
       return;

--- a/packages/landing/src/components/map.label.tsx
+++ b/packages/landing/src/components/map.label.tsx
@@ -52,7 +52,7 @@ export class MapLabelControl implements IControl {
     // Most vector styles have overlaps with the labels and make them useless
     if (Config.map.style && LabelsDisabledLayers.has(Config.map.style)) return true;
     // Labels use the merge style feature and need the production configuration to work
-    if (Config.map.config) return true;
+    if (Config.map.isDebug && Config.map.config) return true;
 
     return false;
   }


### PR DESCRIPTION
### Motivation

the labels view requires the "labels" style to exist, this generally does not exist inside of custom configs.

### Modifications

Hide the label button when custom configs on the debug page.

### Verification

Manually tested with current debug page.