### PR TITLE
feat(layer): add option to limit layer list by extent BM-883

### DIFF
--- a/packages/landing/src/components/layer.switcher.dropdown.tsx
+++ b/packages/landing/src/components/layer.switcher.dropdown.tsx
@@ -121,11 +121,13 @@ export class LayerSwitcherDropdown extends Component<unknown, LayerSwitcherDropd
 
   onZoomExtentChange: ChangeEventHandler<unknown> = (e) => {
     const target = e.target as HTMLInputElement;
+    gaEvent(GaEvent.Ui, 'layer-list:zoomToExtent:' + target.checked);
     this.setState({ zoomToExtent: target.checked });
   };
 
   onLimitToExtent: ChangeEventHandler<unknown> = (e) => {
     const target = e.target as HTMLInputElement;
+    gaEvent(GaEvent.Ui, 'layer-list:limitToExtent:' + target.checked);
     this.setState({ limitToExtent: target.checked });
   };
 

--- a/packages/landing/src/components/layer.switcher.dropdown.tsx
+++ b/packages/landing/src/components/layer.switcher.dropdown.tsx
@@ -145,11 +145,11 @@ export class LayerSwitcherDropdown extends Component<unknown, LayerSwitcherDropd
         <div className="lui-input-group-wrapper" style={{ display: 'flex', justifyContent: 'space-around' }}>
           <div className="lui-checkbox-container">
             <input type="checkbox" onChange={this.onFilterExtentChange} checked={this.state.filterToExtent} />
-            <label title="Filter the layer list to approximately the current map extent">Filter to Extent</label>
+            <label title="Filter the layer list to approximately the current map extent">Filter by map view</label>
           </div>
           <div className="lui-checkbox-container">
             <input type="checkbox" onChange={this.onZoomExtentChange} checked={this.state.zoomToExtent} />
-            <label title="On layer change zoom to the extent of the layer">Zoom to Extent</label>
+            <label title="On layer change zoom to the extent of the layer">Zoom to layer</label>
           </div>
         </div>
       </div>

--- a/packages/landing/src/components/layer.switcher.dropdown.tsx
+++ b/packages/landing/src/components/layer.switcher.dropdown.tsx
@@ -30,7 +30,9 @@ export interface Option {
 
 export interface LayerSwitcherDropdownState {
   layers?: Map<string, LayerInfo>;
+  /** Should the map be zoomed to the extent of the layer when the layer is changed */
   zoomToExtent: boolean;
+  /** Should the drop down be limited to the approximate extent of the map */
   limitToExtent: boolean;
   currentLayer: string;
 }
@@ -198,13 +200,13 @@ export class LayerSwitcherDropdown extends Component<unknown, LayerSwitcherDropd
 /**
  * Determine if the bounds in EPSG:3857 intersects the provided layer
  *
- * TODO: It would be good to then use a more comprehensinve intersection if the bounding box intersects,
+ * TODO: It would be good to then use a more comprehensive intersection if the bounding box intersects,
  * there are complex polygons inside the attribution layer that could be used but they do not have all
  * the polygons
  *
  * @param bounds Bounding box in EPSG:3857
  * @param layer layer to check
- * @returns true if it intesects, false otherwise
+ * @returns true if it intersects, false otherwise
  */
 function doesLayerIntersect(bounds: Bounds, layer: LayerInfo): boolean {
   // No layer information assume it intersects

--- a/packages/landing/src/components/layer.switcher.dropdown.tsx
+++ b/packages/landing/src/components/layer.switcher.dropdown.tsx
@@ -161,7 +161,7 @@ export class LayerSwitcherDropdown extends Component<unknown, LayerSwitcherDropd
           <div className="lui-checkbox-container">
             <input type="checkbox" onChange={this.onFilterExtentChange} checked={this.state.filterToExtent} />
             <label title="Filter the layer list to approximately the current map extent">
-              Filter by map view{' '}
+              Filter by map view
               {ret.hidden > 0 ? (
                 <p>
                   <b>{ret.hidden}</b> layers hidden

--- a/packages/landing/src/components/layer.switcher.dropdown.tsx
+++ b/packages/landing/src/components/layer.switcher.dropdown.tsx
@@ -1,11 +1,9 @@
 import { Bounds, GoogleTms, Projection } from '@basemaps/geo';
-import { Point } from 'maplibre-gl';
 import { ChangeEventHandler, Component, ReactNode } from 'react';
 import Select from 'react-select';
 
 import { Config, GaEvent, gaEvent } from '../config.js';
 import { LayerInfo, MapConfig } from '../config.map.js';
-import { MapLocation } from '../url.js';
 
 type CategoryMap = Map<string, { label: string; options: { label: string; value: string }[] }>;
 

--- a/packages/landing/static/index.css
+++ b/packages/landing/static/index.css
@@ -45,6 +45,19 @@ button {
   margin-top: 8px;
 }
 
+.layers-title {
+  display: flex;
+  justify-content: space-between;
+}
+
+.layers-title p {
+  margin: 0;
+}
+
+.lui-menu-drawer .lui-checkbox-container p {
+  margin-top: 2px;
+}
+
 .lui-menu-drawer .about-links {
   list-style: none;
   padding: 0;
@@ -74,6 +87,7 @@ button {
 .lui-menu-drawer h6 {
   border-bottom: 1px solid #eaeaea;
   padding-bottom: 4px;
+  margin-top: 24px;
   margin-bottom: 8px;
 }
 


### PR DESCRIPTION
### Motivation

When browsing around the map the layers list is very long and its hard to know could be shown from the current view

### Modifications

Add a checkbox to limit the layer list by the approximate bounding box of the map.

### Verification

![image](https://github.com/user-attachments/assets/cd8936dd-be34-436d-a11a-1f995c0fbba0)

