### PR TITLE
feat(landing): adjust layers dropdown BM-1079

### DIFF
--- a/packages/landing/src/components/layer.switcher.dropdown.tsx
+++ b/packages/landing/src/components/layer.switcher.dropdown.tsx
@@ -10,10 +10,10 @@ type CategoryMap = Map<string, { label: string; options: { label: string; value:
 
 const Categories = [
   'Basemaps',
+  'Scanned Aerial Imagery Basemaps',
   'Satellite Imagery',
   'Urban Aerial Photos',
   'Rural Aerial Photos',
-  'Scanned Aerial Imagery Basemaps',
   'Scanned Aerial Imagery',
   'Event',
   'Bathymetry',
@@ -225,6 +225,7 @@ export class LayerSwitcherDropdown extends Component<unknown, LayerSwitcherDropd
         return 1;
       }),
     );
+
     return { options: [...orderedCategories.values()], current, hidden, total };
   }
 }

--- a/packages/landing/src/config.map.ts
+++ b/packages/landing/src/config.map.ts
@@ -394,6 +394,13 @@ function addDefaultLayers(output: Map<string, LayerInfo>): void {
     },
 
     {
+      id: 'topographic::topolite',
+      title: 'Topolite',
+      projections: new Set([EpsgCode.Google]),
+      category: 'Basemaps',
+    },
+
+    {
       id: 'elevation',
       title: 'Elevation',
       projections: new Set([EpsgCode.Google]),


### PR DESCRIPTION
### Motivation

As a Basemaps user, I want the `Topolite` layer and the `Scanned Aerial Imagery Basemaps` category to appear at the top of the `Layers` dropdown for easier access.

### Modifications

1. Reordered the categories as they are shown in the `Layers` dropdown.
2. Added the `Topolite` layer to the list of default layers.

### Verification

1. Moved the `Scanned Aerial Imagery Basemaps` category to the top of the `Layers` dropdown below the `Basemaps` category.

| Before | After |
| - | - |
| ![][img_1] | ![][img_2] |

[img_1]: https://github.com/user-attachments/assets/4a147b31-422e-4aff-927f-57ad76e18b64
[img_2]: https://github.com/user-attachments/assets/29dc0513-93aa-495d-b1aa-04dc8c69ead3

2. Added the `Topolite` layer to the list of default layers.

| Before | After |
| - | - |
| ![][img_3] | ![][img_4] |

[img_3]: https://github.com/user-attachments/assets/a3ebc0ba-5118-43af-b2f4-3c43ec88d264
[img_4]: https://github.com/user-attachments/assets/efa34417-0b36-41c4-9e40-8af3a13c0b5a

3. When the user selected the `Topolite` layer: 

| The `StyleJSON` and `XYZ` fields display the expected values. |
| - |
| ![][img_5] |

[img_5]: https://github.com/user-attachments/assets/e8579c11-73f0-42d0-8b31-56b02091d402

| The `style` parameter in the URL reflects the intended value. |
| - |
| `.../@-41.8899962,174.0492437,z5?style=topolite&i=topographic` |


