### PR TITLE
docs: fix typo in quick-start.md

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -10,4 +10,4 @@ There are three separate quick start guides for these users.
 
 - [User Quick Start](./user-guide/quick-start.md)
 - [Operator Quick Start](./operator-guide/quick-start.md)
-- [Developer Quick Start](./developer-guide/quick-startm.md)
+- [Developer Quick Start](./developer-guide/quick-start.md)


### PR DESCRIPTION
### Motivation

There was a broken link.

### Modifications

Removed a character so there is no longer a broken link.

### Verification

N/A
