### PR TITLE
fix(server): Copy the static health check files into server container

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -50,6 +50,7 @@ jobs:
           # Files are packed into the base directory
           cp *.tgz packages/server/
           cp *.tgz packages/cli/
+          cp -r packages/lambda-tiler/static/ packages/server/
           cp -r packages/lambda-tiler/static/ packages/cli/
 
       - name: Log in to registry

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -13,7 +13,7 @@ COPY ./basemaps-landing*.tgz /app/basemaps/
 COPY ./basemaps-server*.tgz /app/basemaps/
 
 # Copy the static files for v1/health check
-COPY ./static/ /app/static/
+COPY ./static/ /app/basemaps/static/
 
 RUN npm install ./basemaps-landing*.tgz
 RUN npm install ./basemaps-server*.tgz

--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -12,6 +12,9 @@ WORKDIR /app/basemaps
 COPY ./basemaps-landing*.tgz /app/basemaps/
 COPY ./basemaps-server*.tgz /app/basemaps/
 
+# Copy the static files for v1/health check
+COPY ./static/ /app/static/
+
 RUN npm install ./basemaps-landing*.tgz
 RUN npm install ./basemaps-server*.tgz
 


### PR DESCRIPTION
### Motivation

Server container failed v1/health endpoint check because missing the static files from lambda-tiler.

### Modifications

Copy the file into the server container

### Verification
#### Failure without static files
![image](https://github.com/user-attachments/assets/caad587c-84a7-4f3c-ad6b-5ba4303e4691)
#### Success with static files
![image](https://github.com/user-attachments/assets/03620ad1-dabf-48b7-b18d-690881b3a96b)
