### PR TITLE
feat(doc): Add exclude query parameter for get style API into the documentation. BM-1093

### DIFF
--- a/docs/user-guide/swagger-api.json
+++ b/docs/user-guide/swagger-api.json
@@ -317,6 +317,20 @@
               "example": "topographic"
             },
             "required": true
+          },
+          {
+            "name": "exclude",
+            "in": "query",
+            "description": "Exclude the Layer in style by LayerId",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": "form",
+            "example": ["Background", "hillshade"]
           }
         ],
         "responses": {


### PR DESCRIPTION
### Motivation

exclude query parameter in the getStyle API should expose to the customer facing. So we should add this into basemaps doc as an example

### Modifications

Add exclude parameter into Swagger API example.

### Verification
![image](https://github.com/user-attachments/assets/5e516c56-6892-4a92-927e-1537ff86e7af)