### PR TITLE
fix(landing): Fix debug hillshade infinite loading. BM-1110

### DIFF
--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -335,11 +335,12 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
       if (currentLayer) map.removeLayer(HillShadeLayerId);
       return;
     }
-    if (currentLayer?.source === sourceId) return;
+
+    const hillShadeSourceId = `${HillShadePrefix}${sourceId}`;
+    if (currentLayer?.source === hillShadeSourceId) return;
 
     // Hillshading from an existing raster-dem source gives very mixed results and looks very blury
     // so add a new source layer to generate from
-    const hillShadeSourceId = `${HillShadePrefix}${sourceId}`;
     const existingSource = map.getSource(hillShadeSourceId);
     if (existingSource == null) {
       const source = map.getSource(sourceId);


### PR DESCRIPTION
### Motivation

Debug.hillshade keep loading network because the skip check with un-prefix hillshade sourceId and get the hillshade layer been removed and added for every rendering. 

### Modifications
Correct the check sourceId with prefixed one.

### Verification
Tested with locally build, was infinite loading before fix, and only load once after fix.
