### PR TITLE
build: set lambda to log as JSON

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,9 +35,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.201",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.201.tgz",
-      "integrity": "sha512-INZqcwDinNaIdb5CtW3ez5s943nX5stGBQS6VOP2JDlOFP81hM3fds/9NDknipqfUkZM43dx+HgVvkXYXXARCQ==",
+      "version": "2.2.208",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.208.tgz",
+      "integrity": "sha512-r4CuHZaiBioU6waWhCNdEL4MO1+rfbcYVS/Ndz1XNGB5cxIRZwAS0Si6qD2D6nsgpPojiruFl67T1t5M9Va8kQ==",
       "dev": true
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
@@ -47,10 +47,45 @@
       "dev": true
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
-      "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
+      "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
       "dev": true
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "38.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-38.0.1.tgz",
+      "integrity": "sha512-KvPe+NMWAulfNVwY7jenFhzhuLhLqJ/OPy5jx7wUstbjnYnjRVLpUHPU3yCjXFE0J8cuJVdx95BJ4rOs66Pi9w==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "dev": true,
+      "dependencies": {
+        "jsonschema": "^1.4.1",
+        "semver": "^7.6.3"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.4.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.6.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "3.0.0",
@@ -6147,9 +6182,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.114.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.114.1.tgz",
-      "integrity": "sha512-iLOCPb3WAJOgVYQ4GvAnrjtScJfPwcczlB4995h3nUYQdHbus0jNffFv13zBShdWct3cuX+bqLuZ4JyEmJ9+rg==",
+      "version": "2.162.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.162.1.tgz",
+      "integrity": "sha512-p9WeiJ7wfiWj0Bpr1HhNdWENf0TxSZN73JtNqvqyaK6SptiLJc+R+ELo0hF3qKT99NWHTCbwWA/JH3BvEXbFxA==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -6162,9 +6197,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.114.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.114.1.tgz",
-      "integrity": "sha512-pJy+Sa3+s6K9I0CXYGU8J5jumw9uQEbl8zPK8EMA+A6hP9qb1JN+a8ohyw6a1O1cb4D5S6gwH+hE7Fq7hGPY3A==",
+      "version": "2.162.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.162.1.tgz",
+      "integrity": "sha512-XiZLVE5ISNajNNmLye8l5w4EGqm6/d8C8shw63QwxaRVYdHl5e+EAaUEmZJpWc4sYtY/sS+GHOfhoKFLjha2rg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -6175,22 +6210,25 @@
         "punycode",
         "semver",
         "table",
-        "yaml"
+        "yaml",
+        "mime-types"
       ],
       "dev": true,
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.201",
+        "@aws-cdk/asset-awscli-v1": "^2.2.202",
         "@aws-cdk/asset-kubectl-v20": "^2.1.2",
-        "@aws-cdk/asset-node-proxy-agent-v6": "^2.0.1",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
+        "@aws-cdk/cloud-assembly-schema": "^38.0.0",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
-        "fs-extra": "^11.1.1",
-        "ignore": "^5.3.0",
+        "fs-extra": "^11.2.0",
+        "ignore": "^5.3.2",
         "jsonschema": "^1.4.1",
+        "mime-types": "^2.1.35",
         "minimatch": "^3.1.2",
         "punycode": "^2.3.1",
-        "semver": "^7.5.4",
-        "table": "^6.8.1",
+        "semver": "^7.6.3",
+        "table": "^6.8.2",
         "yaml": "1.10.2"
       },
       "engines": {
@@ -6207,15 +6245,15 @@
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
-      "version": "8.12.0",
+      "version": "8.17.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -6316,8 +6354,14 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/aws-cdk-lib/node_modules/fast-uri": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
-      "version": "11.1.1",
+      "version": "11.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6337,7 +6381,7 @@
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
-      "version": "5.3.0",
+      "version": "5.3.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6387,16 +6431,25 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/aws-cdk-lib/node_modules/lru-cache": {
-      "version": "6.0.0",
+    "node_modules/aws-cdk-lib/node_modules/mime-db": {
+      "version": "1.52.0",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-types": {
+      "version": "2.1.35",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
       "dependencies": {
-        "yallist": "^4.0.0"
+        "mime-db": "1.52.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">= 0.6"
       }
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
@@ -6430,13 +6483,10 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
-      "version": "7.5.4",
+      "version": "7.6.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -6488,7 +6538,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/table": {
-      "version": "6.8.1",
+      "version": "6.8.2",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -6511,21 +6561,6 @@
       "engines": {
         "node": ">= 10.0.0"
       }
-    },
-    "node_modules/aws-cdk-lib/node_modules/uri-js": {
-      "version": "4.4.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/aws-cdk-lib/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
       "version": "1.10.2",
@@ -7333,13 +7368,10 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.3.0.tgz",
-      "integrity": "sha512-vbK8i3rIb/xwZxSpTjz3SagHn1qq9BChLEfy5Hf6fB3/2eFbrwt2n9kHwQcS0CPTRBesreeAcsJfMq2229FnbQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 16.14.0"
-      }
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.2.tgz",
+      "integrity": "sha512-wsNxBlAott2qg8Zv87q3eYZYgheb9lchtBfjHzzLHtXbttwSrHPs1NNQbBrmbb1YZvYg2+Vh0Dor76w4mFxJkA==",
+      "dev": true
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -19306,9 +19338,9 @@
         "@basemaps/lambda-tiler": "^7.11.0",
         "@basemaps/shared": "^7.11.0",
         "@linzjs/cdk-tags": "^1.7.0",
-        "aws-cdk": "2.114.x",
-        "aws-cdk-lib": "2.114.x",
-        "constructs": "^10.3.0"
+        "aws-cdk": "2.162.x",
+        "aws-cdk-lib": "2.162.x",
+        "constructs": "^10.4.2"
       },
       "engines": {
         "node": ">=16.0.0"

--- a/packages/_infra/package.json
+++ b/packages/_infra/package.json
@@ -29,8 +29,8 @@
     "@basemaps/lambda-tiler": "^7.11.0",
     "@basemaps/shared": "^7.11.0",
     "@linzjs/cdk-tags": "^1.7.0",
-    "aws-cdk": "2.114.x",
-    "aws-cdk-lib": "2.114.x",
-    "constructs": "^10.3.0"
+    "aws-cdk": "2.162.x",
+    "aws-cdk-lib": "2.162.x",
+    "constructs": "^10.4.2"
   }
 }

--- a/packages/_infra/src/analytics/edge.analytics.ts
+++ b/packages/_infra/src/analytics/edge.analytics.ts
@@ -2,7 +2,7 @@ import { Env } from '@basemaps/shared';
 import { Duration, Stack, StackProps } from 'aws-cdk-lib';
 import { Rule, Schedule } from 'aws-cdk-lib/aws-events';
 import { LambdaFunction } from 'aws-cdk-lib/aws-events-targets';
-import lf from 'aws-cdk-lib/aws-lambda';
+import lambda from 'aws-cdk-lib/aws-lambda';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { BlockPublicAccess, Bucket } from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
@@ -18,7 +18,7 @@ export interface EdgeAnalyticsProps extends StackProps {
  * Every hour create analytics based off the logs given to us from cloudwatch
  */
 export class EdgeAnalytics extends Stack {
-  public lambda: lf.Function;
+  public lambda: lambda.Function;
 
   public constructor(scope: Construct, id: string, props: EdgeAnalyticsProps) {
     super(scope, id, props);
@@ -31,12 +31,12 @@ export class EdgeAnalytics extends Stack {
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
     });
 
-    this.lambda = new lf.Function(this, 'AnalyticLambda', {
-      runtime: lf.Runtime.NODEJS_18_X,
+    this.lambda = new lambda.Function(this, 'AnalyticLambda', {
+      runtime: lambda.Runtime.NODEJS_18_X,
       memorySize: 2048,
       timeout: Duration.minutes(10),
       handler: 'index.handler',
-      code: lf.Code.fromAsset(CODE_PATH),
+      code: lambda.Code.fromAsset(CODE_PATH),
       environment: {
         [Env.Analytics.CloudFrontId]: distributionId,
         [Env.Analytics.CacheBucket]: `s3://${cacheBucket.bucketName}`,
@@ -44,6 +44,7 @@ export class EdgeAnalytics extends Stack {
         AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
       },
       logRetention: RetentionDays.ONE_MONTH,
+      loggingFormat: lambda.LoggingFormat.JSON,
     });
 
     cacheBucket.grantReadWrite(this.lambda);

--- a/packages/_infra/src/serve/lambda.tiler.ts
+++ b/packages/_infra/src/serve/lambda.tiler.ts
@@ -54,6 +54,7 @@ export class LambdaTiler extends Construct {
       architecture: lambda.Architecture.ARM_64,
       environment,
       logRetention: RetentionDays.ONE_MONTH,
+      loggingFormat: lambda.LoggingFormat.JSON,
     });
 
     this.functionUrl = new lambda.FunctionUrl(this, 'LambdaCogUrl', {


### PR DESCRIPTION
### Motivation

since the end of 2023, lambda functions can now output JSON as their logging format, since all of our other logs are structured move to JSON logs for everything

### Modifications

Convert lambda functions to log as JSON


### Verification

Need to verify everything is working correctly after deploy, eg alerts/log shipping
