### PR TITLE
feat(landing): Update new feature pop ups to include google analytics. BM-1113

### DIFF
--- a/packages/landing/src/components/feature.updates.tsx
+++ b/packages/landing/src/components/feature.updates.tsx
@@ -2,7 +2,7 @@ import { clsx } from 'clsx';
 import { Component, ReactNode } from 'react';
 import ReactModal from 'react-modal';
 
-import { Config } from '../config.js';
+import { Config, GaEvent, gaEvent } from '../config.js';
 
 type FeatureUpdatesProps = {
   header: string;
@@ -37,6 +37,7 @@ export class FeatureUpdates extends Component<FeatureUpdatesProps, FeatureUpdate
   handleClose = (): void => {
     this.setState({ showModal: false });
     window.localStorage.setItem(this.props.id, this.props.dismissedKey);
+    gaEvent(GaEvent.Ui, `news:${this.props.id.toLowerCase()}:close`);
   };
 
   override render(): ReactNode {
@@ -46,6 +47,7 @@ export class FeatureUpdates extends Component<FeatureUpdatesProps, FeatureUpdate
     if (!showModal) return null;
     if (Config.map.isDebug) return;
 
+    gaEvent(GaEvent.Ui, `news:${this.props.id.toLowerCase()}:open`);
     return (
       <ReactModal
         isOpen={showModal}

--- a/packages/landing/src/components/new-features/3d.map.tsx
+++ b/packages/landing/src/components/new-features/3d.map.tsx
@@ -10,7 +10,7 @@ const baseUrl = WindowUrl.baseUrl();
  */
 const bigImage = new URL('assets/Lg+3D+Maps+splash.gif', baseUrl).href; // Large gif file location
 const smallImage = new URL('assets/Sml+3D+map+splash.gif', baseUrl).href; // Small gif file location
-const closingDate = new Date('2024-10-30'); // End date for pop up screen
+const closingDate = new Date('2025-01-31'); // End date for pop up screen
 const id = `LINZ_Basemaps_3D_Map`; // Optional to set as Config.Version to disable Modal as default
 const dismissedKey = 'DISMISSED_MODALS_2024_10_3d_map'; // Feature released version can both been major version or minor version
 const recentUpdates = {


### PR DESCRIPTION
### Motivation
We want to capture the event of pop screenshot in google analyst, also try to enable the 3d map pop up for 3 months and see how it goes.

### Modifications
- Add gEvent for both open and close of 3d map pop up
- Set the end date to 31th Jan 2025

### Verification

<!-- TODO: Say how you tested your changes. -->
