### PR TITLE
fix(lambda-tiler): NZTM terrain been multiplied twice. BM-1122

### DIFF
--- a/packages/lambda-tiler/src/routes/__tests__/tile.style.json.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/tile.style.json.test.ts
@@ -2,7 +2,8 @@ import assert from 'node:assert';
 import { afterEach, before, beforeEach, describe, it } from 'node:test';
 
 import { ConfigProviderMemory, SourceRaster, StyleJson } from '@basemaps/config';
-import { Terrain } from '@basemaps/config/src/config/vector.style.js';
+import { DefaultExaggeration, Terrain } from '@basemaps/config/build/config/vector.style.js';
+import { Nztm2000QuadTms } from '@basemaps/geo';
 import { Env } from '@basemaps/shared';
 import { createSandbox } from 'sinon';
 
@@ -441,7 +442,7 @@ describe('/v1/styles', () => {
           },
         ],
         terrain: {
-          exaggeration: 1.1,
+          exaggeration: DefaultExaggeration[Nztm2000QuadTms.identifier],
         },
       },
     };

--- a/packages/lambda-tiler/src/routes/tile.style.json.ts
+++ b/packages/lambda-tiler/src/routes/tile.style.json.ts
@@ -90,7 +90,7 @@ export interface StyleConfig {
 /**
  * Turn on the terrain setting in the style json
  */
-function setStyleTerrain(style: StyleJson, terrain: string, tileMatrix: TileMatrixSet): void {
+export function setStyleTerrain(style: StyleJson, terrain: string, tileMatrix: TileMatrixSet): void {
   const source = Object.keys(style.sources).find((s) => s === terrain);
   if (source == null) throw new LambdaHttpResponse(400, `Terrain: ${terrain} does not exists in the style source.`);
   style.terrain = {

--- a/packages/lambda-tiler/src/util/nztm.style.ts
+++ b/packages/lambda-tiler/src/util/nztm.style.ts
@@ -37,8 +37,5 @@ export function convertStyleToNztmStyle(inputStyle: StyleJson, clone: boolean = 
     }
   }
 
-  /** Based on {@link DefaultExaggeration} offsetting by 2 two levels changes the exaggeration needed by approx 4x */
-  if (style.terrain) style.terrain.exaggeration = style.terrain.exaggeration * 4;
-
   return style;
 }


### PR DESCRIPTION
### Motivation

Basemap terrain exaggeration for NZTM been multiplied twice.
![image](https://github.com/user-attachments/assets/4e7b4a77-431c-4f0e-be5d-206787ae2452)
![image](https://github.com/user-attachments/assets/e8a64789-7e70-4bb9-97f8-c8cac4e06e36)

### Modifications
We have manually multiplied the NZTM terrain exaggeration when converting the style json earlier, however, we got default setting to fix them as 4.4 in `DefaultExaggeration`, so we don't need to covert the exaggeration twice to make it too large.

### Verification
Local test and unit test.
![image](https://github.com/user-attachments/assets/42f35f6f-6410-4ccd-87f6-c007f9faae7f)
