### PR TITLE
fix(server): Bundle the the bin file before publish NPM

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -41,6 +41,10 @@ jobs:
       - name: Check Dependencies
         run: node scripts/detect.unlinked.dep.mjs
 
+      - name: Bunlde
+        run: |
+          npx lerna run bundle --stream
+
       - name: (Prod) Create tag
         if: github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'release:')
         run: |


### PR DESCRIPTION
### Motivation

The [@basemaps/server](https://www.npmjs.com/package/@basemaps/server?activeTab=code) npm package is missing the bin file for excusing the command. We need to bundle it first before publish the package. 

### Modifications

Add a bundle command before NPM publish

### Verification

Locally tested. 

- delete the `server/bin/basemaps-server.cjs`
- run `npx lerna run bundle --stream` -> Got a new `server/bin/basemaps-server.cjs` generated.
- run `npm pack --dry-run` -> Got bin file included.
![image](https://github.com/user-attachments/assets/812f27cc-0f0c-47d3-b2fb-c37066f569ea)

