### PR TITLE
feat(landing): Add topo-raster into layer dropdown. BM-1153

### DIFF
--- a/packages/landing/src/components/map.label.tsx
+++ b/packages/landing/src/components/map.label.tsx
@@ -2,7 +2,7 @@ import { IControl } from 'maplibre-gl';
 
 import { Config, GaEvent, gaEvent } from '../config.js';
 
-export const LabelsDisabledLayers = new Set(['topographic', 'topolite']);
+export const LabelsDisabledLayers = new Set(['topographic', 'topolite', 'topo-raster']);
 
 export class MapLabelControl implements IControl {
   map?: maplibregl.Map;

--- a/packages/landing/src/config.map.ts
+++ b/packages/landing/src/config.map.ts
@@ -405,6 +405,13 @@ function addDefaultLayers(output: Map<string, LayerInfo>): void {
     },
 
     {
+      id: 'topo-raster::topo-raster',
+      title: 'NZ Topo Gridless Maps',
+      projections: new Set([EpsgCode.Nztm2000, EpsgCode.Google]),
+      category: 'Basemaps',
+    },
+
+    {
       id: 'elevation',
       title: 'Elevation',
       projections: new Set([EpsgCode.Google]),


### PR DESCRIPTION
### Motivation
We need to add topo-raster style into the layer dropdown and have the labels disabled for it.

### Modifications
Add another hardcode topo-raster style for the layer dropdown. We will need to clean up all the hardcode category in BM-1154

### Verification
![image](https://github.com/user-attachments/assets/67bd2eac-97f9-41e0-a63b-b788ac5b27e5)
