### PR TITLE
revert(config): Add resizeKernel into the config tileset then disable fastShrinkOnLoad.

### DIFF
--- a/packages/config-loader/src/json/json.config.ts
+++ b/packages/config-loader/src/json/json.config.ts
@@ -247,7 +247,6 @@ export class ConfigJson {
     if (tileSet.type === TileSetType.Raster) {
       if (ts.outputs) tileSet.outputs = ts.outputs;
       if (ts.background) tileSet.background = ts.background;
-      if (ts.resizeKernel) tileSet.resizeKernel = ts.resizeKernel;
     }
 
     if (ts.format) {

--- a/packages/config-loader/src/json/parse.tile.set.ts
+++ b/packages/config-loader/src/json/parse.tile.set.ts
@@ -1,4 +1,4 @@
-import { ConfigTileSetOutputParser, parseRgba, TileResizeKernel, TileSetType } from '@basemaps/config';
+import { ConfigTileSetOutputParser, parseRgba, TileSetType } from '@basemaps/config';
 import { z } from 'zod';
 
 export function validateColor(str: string): boolean {
@@ -57,8 +57,6 @@ const zLayerConfig = z
     },
   );
 
-const TileResizeKernel = z.enum(['nearest', 'mitchell', 'lanczos3', 'lanczos2']);
-
 export const zTileSetConfig = z.object({
   type: z.nativeEnum(TileSetType),
   id: z.string(),
@@ -70,7 +68,6 @@ export const zTileSetConfig = z.object({
   minZoom: zZoom.optional(),
   maxZoom: zZoom.optional(),
   format: z.string().optional(),
-  resizeKernel: z.object({ in: TileResizeKernel, out: TileResizeKernel }).optional(),
   outputs: z.array(ConfigTileSetOutputParser).optional(),
 });
 

--- a/packages/config/src/config/tile.set.ts
+++ b/packages/config/src/config/tile.set.ts
@@ -31,7 +31,7 @@ export interface ConfigLayer extends Partial<Record<EpsgCode, string>> {
   maxZoom?: number;
 }
 
-export type TileResizeKernel = 'nearest' | 'mitchell' | 'lanczos3' | 'lanczos2';
+export type TileResizeKernel = 'nearest' | 'lanczos3' | 'lanczos2';
 
 export interface ConfigTileSetBase extends ConfigBase {
   /** Human friendly display name for the tileset */

--- a/packages/tiler-sharp/src/index.ts
+++ b/packages/tiler-sharp/src/index.ts
@@ -144,12 +144,7 @@ export class TileMakerSharp implements TileMaker {
 
     if (resize) {
       const resizeOptions = { fit: Sharp.fit.cover, kernel: resize.scaleX > 1 ? resizeKernel.in : resizeKernel.out };
-      if (resize.scale <= 0.1251) {
-        // If the scale is less than 0.125, we need to disable fastShrinkOnLoad to prevent edge artifacts for topo raster map
-        sharp.resize(resize.width, resize.height, { ...resizeOptions, fastShrinkOnLoad: false });
-      } else {
-        sharp.resize(resize.width, resize.height, resizeOptions);
-      }
+      sharp.resize(resize.width, resize.height, resizeOptions);
     }
 
     if (crop) sharp.extract({ top: crop.y, left: crop.x, width: crop.width, height: crop.height });

--- a/packages/tiler/src/raster.ts
+++ b/packages/tiler/src/raster.ts
@@ -7,7 +7,7 @@ export interface TileMaker {
   compose(ctx: TileMakerContext): Promise<{ buffer: Buffer; metrics: Metrics }>;
 }
 
-export type ResizeKernelType = 'nearest' | 'mitchell' | 'lanczos3' | 'lanczos2';
+export type ResizeKernelType = 'nearest' | 'lanczos3' | 'lanczos2';
 export type TileMakerResizeKernel = { in: ResizeKernelType; out: ResizeKernelType };
 
 export interface TileMakerContext {


### PR DESCRIPTION
### Motivation

We are adding the background in the imagery importing process(#3379), so we don't need this for fixing the edge effects.

### Modifications

This reverts commit bd3357e5c6dee34a6e458a2ac956643468f8fb2c.

### Verification

<!-- TODO: Say how you tested your changes. -->
