### PR TITLE
fix(landing): Fix the zoom to extend by using maplibre to adjust AntiMeridian. BM-1155

### DIFF
--- a/packages/landing/src/components/map.tsx
+++ b/packages/landing/src/components/map.tsx
@@ -49,27 +49,26 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
   };
 
   updateBounds = (bounds: maplibregl.LngLatBoundsLike): void => {
-    if (Config.map.tileMatrix !== GoogleTms) {
-      // Transform bounds to current tileMatrix
-      const lngLatBounds: maplibregl.LngLatBounds = maplibre.LngLatBounds.convert(bounds);
-      const upperLeft = lngLatBounds.getNorthEast();
-      const lowerRight = lngLatBounds.getSouthWest();
-      const zoom = this.map.getZoom();
-      const upperLeftLocation = locationTransform(
-        { lat: upperLeft.lat, lon: upperLeft.lng, zoom },
-        Config.map.tileMatrix,
-        GoogleTms,
-      );
-      const lowerRightLocation = locationTransform(
-        { lat: lowerRight.lat, lon: lowerRight.lng, zoom },
-        Config.map.tileMatrix,
-        GoogleTms,
-      );
-      bounds = [
-        [upperLeftLocation.lon, upperLeftLocation.lat],
-        [lowerRightLocation.lon, lowerRightLocation.lat],
-      ];
-    }
+    // Transform bounds to current tileMatrix
+    const lngLatBounds: maplibregl.LngLatBounds = maplibre.LngLatBounds.convert(bounds);
+    const upperLeft = lngLatBounds.getNorthEast();
+    const lowerRight = lngLatBounds.getSouthWest();
+    const zoom = this.map.getZoom();
+    const upperLeftLocation = locationTransform(
+      { lat: upperLeft.lat, lon: upperLeft.lng, zoom },
+      Config.map.tileMatrix,
+      GoogleTms,
+    );
+    const lowerRightLocation = locationTransform(
+      { lat: lowerRight.lat, lon: lowerRight.lng, zoom },
+      Config.map.tileMatrix,
+      GoogleTms,
+    );
+    bounds = [
+      [upperLeftLocation.lon, upperLeftLocation.lat],
+      [lowerRightLocation.lon, lowerRightLocation.lat],
+    ];
+
     this.map.fitBounds(bounds);
   };
 


### PR DESCRIPTION
### Motivation

The zoom to extend feature is broken after upgrade the maplibre to latest release. It always zoom back to the whole world when switching layer, seems the caused by the anti Meridian. And this only happens to the Web Mercator

### Modifications
Maplibre got a fix of [adjustAntiMeridian](https://github.com/maplibre/maplibre-gl-js/blob/87486a5ef2085e600e8fa4e31252629dd8488dcd/src/geo/lng_lat_bounds.ts#L342) between v4.5 to v4.71.
I believe that causes some conflicts with the pre-adjust in our system, and this is fixed after we do a `maplibre.LngLatBounds.convert` for Web Mercator as well. 

### Verification
Local tested, all zoom to layer working fine for Web Mercator and NZTM now.
