### PR TITLE
feat(landing): insert the 'topographic' category and layers between the 'event' and 'bathymetry' categories. BM-1119

### DIFF
--- a/packages/landing/src/components/layer.switcher.dropdown.tsx
+++ b/packages/landing/src/components/layer.switcher.dropdown.tsx
@@ -16,6 +16,7 @@ const Categories = [
   'Rural Aerial Photos',
   'Scanned Aerial Imagery',
   'Event',
+  'Topographic',
   'Bathymetry',
   'Elevation',
 ];


### PR DESCRIPTION
### Motivation

We want to locate the topo-raster individual layers category just above bathmetry

### Modifications

Add Topographic between Event and Bathymetry

### Verification

![image](https://github.com/user-attachments/assets/ebe63785-8554-4d08-b786-892a99f86bf3)