### PR TITLE
refactor: add missing project reference

### DIFF
--- a/packages/lambda-analytic-cloudfront/src/__test__/analytics.test.ts
+++ b/packages/lambda-analytic-cloudfront/src/__test__/analytics.test.ts
@@ -43,6 +43,8 @@ describe('analytic lambda', () => {
   function setupEnv(t: TestContext): void {
     t.mock.method(Env, 'get', (key: string): string => {
       switch (key) {
+        case Env.Analytics.ElasticIndexName:
+          return 'basemaps-history';
         case Env.Analytics.CacheBucket:
           return 'mem://cache/';
         case Env.Analytics.CloudFrontSourceBucket:
@@ -68,8 +70,7 @@ describe('analytic lambda', () => {
     } as unknown as Client;
 
     const YesterDay = getYesterday();
-    const shortDate = YesterDay.toISOString().slice(0, 13).replace('T', '-');
-
+    const shortDate = YesterDay.toISOString().slice(0, 10) + '-23';
     await fsa.write(new URL(`mem://source/cfid.${shortDate}/data.txt.gz`), gzipSync(LogData));
 
     await main(new FakeLambdaRequest());
@@ -114,8 +115,7 @@ describe('analytic lambda', () => {
     } as unknown as Client;
 
     const YesterDay = getYesterday();
-    const shortDate = YesterDay.toISOString().slice(0, 13).replace('T', '-');
-
+    const shortDate = YesterDay.toISOString().slice(0, 10) + '-23';
     await fsa.write(new URL(`mem://source/cfid.${shortDate}/data.txt.gz`), gzipSync(LogData));
 
     const ret = await main(new FakeLambdaRequest()).catch((e: Error) => e);

--- a/packages/lambda-analytic-cloudfront/src/date.ts
+++ b/packages/lambda-analytic-cloudfront/src/date.ts
@@ -1,6 +1,7 @@
 export function getYesterday(): Date {
   // Process up to about a day ago
   const maxDate = new Date();
+  maxDate.setUTCHours(0);
   maxDate.setUTCMinutes(0);
   maxDate.setUTCSeconds(0);
   maxDate.setUTCMilliseconds(0);

--- a/packages/lambda-analytic-cloudfront/src/useragent/agents/gis.ts
+++ b/packages/lambda-analytic-cloudfront/src/useragent/agents/gis.ts
@@ -4,6 +4,7 @@ import { isValidOs, UserAgentOs, UserAgentParser } from '../parser.types.js';
 function guessQgisOs(ua: string): UserAgentOs | undefined {
   if (ua.includes('/windows')) return 'windows';
   if (ua.includes('/mac')) return 'macos';
+  return;
 }
 
 const ArcGis: Record<string, UserAgentParser> = {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
     { "path": "./packages/shared/tsconfig.json" },
     { "path": "./packages/lambda-tiler/tsconfig.json" },
     { "path": "./packages/lambda-analytics/tsconfig.json" },
+    { "path": "./packages/lambda-analytic-cloudfront/tsconfig.json" },
     { "path": "./packages/attribution/tsconfig.json" },
     { "path": "./packages/landing/tsconfig.json" },
     { "path": "./packages/server/tsconfig.json" },


### PR DESCRIPTION
### Motivation

`lambda-analytic-cloudfront` was missing from the project reference and was not being built

### Modifications

Add `lambda-analytic-cloudfront` to the project references so it builds

### Verification

<!-- TODO: Say how you tested your changes. -->
