### PR TITLE
fix(infra): correct dist path location

### DIFF
--- a/packages/_infra/src/analytics/edge.analytics.ts
+++ b/packages/_infra/src/analytics/edge.analytics.ts
@@ -10,7 +10,7 @@ import { Construct } from 'constructs';
 import { getConfig } from '../config.js';
 
 const CodePath = '../lambda-analytics/dist';
-const CodePathV2 = '../lambda-analytics-cloudfront/dist';
+const CodePathV2 = '../lambda-analytic-cloudfront/dist';
 
 export interface EdgeAnalyticsProps extends StackProps {
   distributionId: string;


### PR DESCRIPTION
### Motivation

A path was typoed causing the cdk deployment to fail

### Modifications

corrected typo in path

### Verification

ran a `cdk synth` locally to validate path
