### PR TITLE
feat(tiler-sharp): support uint32 and uint8 source datasets for color-ramp

### DIFF
--- a/packages/lambda-tiler/src/cli/render.tile.ts
+++ b/packages/lambda-tiler/src/cli/render.tile.ts
@@ -9,8 +9,8 @@ import { extname } from 'path';
 import { TileXyzRaster } from '../routes/tile.xyz.raster.js';
 
 // Render configuration
-const source = fsa.toUrl(`/home/blacha/data/elevation/christchurch_2020-2021/`);
-const tile = fromPath('/14/7898/8615.webp');
+const source = fsa.toUrl(`/home/blacha/data/nz-elevation/hillshade`);
+const tile = fromPath('/9/250/256.png');
 const pipeline: string | null = 'color-ramp';
 let tileMatrix: TileMatrixSet | null = null;
 

--- a/packages/lambda-tiler/src/cli/render.tile.ts
+++ b/packages/lambda-tiler/src/cli/render.tile.ts
@@ -9,8 +9,8 @@ import { extname } from 'path';
 import { TileXyzRaster } from '../routes/tile.xyz.raster.js';
 
 // Render configuration
-const source = fsa.toUrl(`/home/blacha/data/nz-elevation/hillshade`);
-const tile = fromPath('/9/250/256.png');
+const source = fsa.toUrl(`/home/blacha/data/elevation/christchurch_2020-2021/`);
+const tile = fromPath('/14/7898/8615.webp');
 const pipeline: string | null = 'color-ramp';
 let tileMatrix: TileMatrixSet | null = null;
 

--- a/packages/tiler-sharp/src/pipeline/__tests__/pipeline.color.ramp.test.ts
+++ b/packages/tiler-sharp/src/pipeline/__tests__/pipeline.color.ramp.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { Tiff } from '@basemaps/shared';
+import { CompositionTiff } from '@basemaps/tiler';
+
+import { DecompressedInterleaved } from '../decompressor.js';
+import { PipelineColorRamp } from '../pipeline.color.ramp.js';
+
+const FakeTiff = { images: [{ noData: -9999, resolution: [0.1, -0.1] }] } as unknown as Tiff;
+const FakeComp = { asset: FakeTiff, source: { x: 0, y: 0, imageId: 0 } } as CompositionTiff;
+
+describe('pipeline.color-ramp', () => {
+  it('should color-ramp a float32 DEM with default ramp', async () => {
+    const bytes: DecompressedInterleaved = {
+      pixels: new Float32Array([-9999, 0, 100]),
+      depth: 'float32',
+      channels: 1,
+      width: 3,
+      height: 1,
+    };
+
+    const output = await PipelineColorRamp.process(FakeComp, bytes);
+
+    assert.equal(output.channels, 4);
+
+    assert.equal(String(output.pixels.slice(0, 4)), '0,0,0,0');
+    assert.equal(String(output.pixels.slice(4, 8)), '167,205,228,255');
+  });
+
+  it('should color-ramp a uint8', async () => {
+    const bytes: DecompressedInterleaved = {
+      pixels: new Uint8Array([0, 128, 255]),
+      depth: 'uint8',
+      channels: 1,
+      width: 3,
+      height: 1,
+    };
+
+    const output = await PipelineColorRamp.process(FakeComp, bytes);
+
+    assert.equal(output.channels, 4);
+
+    assert.equal(String(output.pixels.slice(0, 4)), '0,0,0,255');
+    assert.equal(String(output.pixels.slice(4, 8)), '128,128,128,255');
+    assert.equal(String(output.pixels.slice(8, 12)), '255,255,255,255');
+  });
+
+  it('should color-ramp a uint32', async () => {
+    const bytes: DecompressedInterleaved = {
+      pixels: new Uint32Array([0, 2 ** 31, 2 ** 32 - 1]),
+      depth: 'uint32',
+      channels: 1,
+      width: 3,
+      height: 1,
+    };
+
+    const output = await PipelineColorRamp.process(FakeComp, bytes);
+
+    assert.equal(output.channels, 4);
+
+    assert.equal(String(output.pixels.slice(0, 4)), '0,0,0,255');
+    assert.equal(String(output.pixels.slice(4, 8)), '128,128,128,255');
+    assert.equal(String(output.pixels.slice(8, 12)), '255,255,255,255');
+  });
+});

--- a/packages/tiler-sharp/src/pipeline/decompressor.lerc.ts
+++ b/packages/tiler-sharp/src/pipeline/decompressor.lerc.ts
@@ -9,9 +9,6 @@ export const LercDecompressor: Decompressor = {
     await Lerc.load();
     const bytes = Lerc.decode(tile);
 
-    if (bytes.pixelType !== 'F32') {
-      throw new Error(`Lerc: Invalid output pixelType:${bytes.pixelType} from:${source.source.url.href}`);
-    }
     if (bytes.depthCount !== 1) {
       throw new Error(`Lerc: Invalid output depthCount:${bytes.depthCount} from:${source.source.url.href}`);
     }
@@ -19,13 +16,34 @@ export const LercDecompressor: Decompressor = {
       throw new Error(`Lerc: Invalid output bandCount:${bytes.pixels.length} from:${source.source.url.href}`);
     }
 
-    return {
-      pixels: bytes.pixels[0] as Float32Array,
-      width: bytes.width,
-      height: bytes.height,
-      channels: 1,
-      depth: 'float32',
-    };
+    switch (bytes.pixelType) {
+      case 'F32':
+        return {
+          pixels: bytes.pixels[0] as Float32Array,
+          width: bytes.width,
+          height: bytes.height,
+          channels: 1,
+          depth: 'float32',
+        };
+      case 'U32':
+        return {
+          pixels: bytes.pixels[0] as Uint32Array,
+          width: bytes.width,
+          height: bytes.height,
+          channels: 1,
+          depth: 'uint32',
+        };
+      case 'U8':
+        return {
+          pixels: bytes.pixels[0] as Uint8Array,
+          width: bytes.width,
+          height: bytes.height,
+          channels: 1,
+          depth: 'uint8',
+        };
+    }
+
+    throw new Error(`Lerc: Invalid output pixelType:${bytes.pixelType} from:${source.source.url.href}`);
   },
 };
 

--- a/packages/tiler-sharp/src/pipeline/decompressor.ts
+++ b/packages/tiler-sharp/src/pipeline/decompressor.ts
@@ -1,6 +1,14 @@
 import { CompositionTiff } from '@basemaps/tiler';
 import { Tiff } from '@cogeotiff/core';
 
+export interface DecompressedInterleavedUint32 {
+  pixels: Uint32Array;
+  depth: 'uint32';
+  channels: number;
+  width: number;
+  height: number;
+}
+
 export interface DecompressedInterleavedFloat {
   pixels: Float32Array;
   depth: 'float32';
@@ -18,7 +26,10 @@ export interface DecompressedInterleavedUint8 {
 }
 
 // One buffer containing all bands
-export type DecompressedInterleaved = DecompressedInterleavedFloat | DecompressedInterleavedUint8;
+export type DecompressedInterleaved =
+  | DecompressedInterleavedFloat
+  | DecompressedInterleavedUint8
+  | DecompressedInterleavedUint32;
 
 export interface Decompressor {
   type: 'image/webp' | 'application/lerc';

--- a/packages/tiler-sharp/src/pipeline/pipeline.color.ramp.ts
+++ b/packages/tiler-sharp/src/pipeline/pipeline.color.ramp.ts
@@ -45,7 +45,7 @@ export class ColorRamp {
 export const Ramps: Record<DecompressedInterleaved['depth'], ColorRamp> = {
   float32: new ColorRamp(DefaultColorRamp),
   uint8: new ColorRamp(`0 0 0 0 255\n255 255 255 255 255`),
-  uint32: new ColorRamp(`0 0 0 0 255\n${2 ** 32} 255 255 255 255`),
+  uint32: new ColorRamp(`0 0 0 0 255\n${2 ** 32 - 1} 255 255 255 255`),
 };
 
 export const PipelineColorRamp: Pipeline = {

--- a/packages/tiler-sharp/src/pipeline/pipeline.color.ramp.ts
+++ b/packages/tiler-sharp/src/pipeline/pipeline.color.ramp.ts
@@ -42,7 +42,11 @@ export class ColorRamp {
   }
 }
 
-export const ramp = new ColorRamp(DefaultColorRamp);
+export const Ramps: Record<DecompressedInterleaved['depth'], ColorRamp> = {
+  float32: new ColorRamp(DefaultColorRamp),
+  uint8: new ColorRamp(`0 0 0 0 255\n255 255 255 255 255`),
+  uint32: new ColorRamp(`0 0 0 0 255\n${2 ** 32} 255 255 255 255`),
+};
 
 export const PipelineColorRamp: Pipeline = {
   type: 'color-ramp',
@@ -55,6 +59,8 @@ export const PipelineColorRamp: Pipeline = {
       width: data.width,
       height: data.height,
     };
+
+    const ramp = Ramps[data.depth];
 
     const size = data.width * data.height;
     const noData = comp.asset.images[0].noData;

--- a/packages/tiler-sharp/src/pipeline/pipeline.resize.ts
+++ b/packages/tiler-sharp/src/pipeline/pipeline.resize.ts
@@ -109,7 +109,7 @@ function resizeNearest(
   return ret;
 }
 
-function getOutputBuffer(source: DecompressedInterleaved, target: Size & { scale: number }): DecompressedInterleaved {
+function getOutputBuffer(source: DecompressedInterleaved, target: Size): DecompressedInterleaved {
   switch (source.depth) {
     case 'uint8':
       return {


### PR DESCRIPTION
### Motivation

We are getting datasets that have other datatypes than float32 that need to be expanded into 4 band RGBA so basemaps can render them.

A common type is a one band `uint8` which is generally a grey scale dataset which can be directly band expanded from `0` to `r:0, g:0, b:0, alpha: 255` and `255` to `r:255, g:255, b:255, alpha: 255`

### Modifications

Added support for `uint8` and `uint32` with the tiler piplines

TODO: it would be nicer to handle the datatypes more generically, to hopefully avoid giant switch case statements, we should in theory be able to trust that lerc gives us the correct typed array for instance.


### Verification

Added unit tests and rendered it locally 

![image](https://github.com/user-attachments/assets/f8788700-b9d3-470c-a7d7-9aabe8067f0f)
