### PR TITLE
fix(tiler-sharp): when resampling uint round numbers rather than truncate

### DIFF
--- a/packages/tiler-sharp/src/pipeline/__tests__/pipeline.resize.test.ts
+++ b/packages/tiler-sharp/src/pipeline/__tests__/pipeline.resize.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { CompositionTiff } from '@basemaps/tiler';
+
+import { resizeBilinear } from '../pipeline.resize.js';
+
+describe('resize-bilinear', () => {
+  it('should round numbers when working with uint arrays', () => {
+    const ret = resizeBilinear(
+      {
+        pixels: new Uint8Array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]),
+        depth: 'uint8',
+        width: 4,
+        height: 4,
+        channels: 1,
+      },
+      { source: { width: 4, height: 4 } } as unknown as CompositionTiff,
+      { x: 0, y: 0, width: 1, height: 1 },
+      { width: 256, height: 256, scale: 123.123123123 },
+    );
+
+    // All values should be rounded to 1 and not truncated down to 0
+    assert.ok(ret.pixels.every((f) => f === 1));
+  });
+});


### PR DESCRIPTION
### Motivation

When resampling `uint` it can end up resampling slightly high or low eg resampling `1` can result in `1.00..01` or `0.99999..`

When setting a number on a Uint8Array floating point numbers are truncated, so `0.9999` will be rounded down to `0` rather than up to `1`.

### Modifications

When resampling `uint` round numbers before assigning them.

### Verification

Added unit test to validate rounding
