### PR TITLE
fix: revert "build: maplibre v5.0.0 (#3387)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3345,8 +3345,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
       "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
-      "dev": true,
-      "license": "BSD-2-Clause"
+      "dev": true
     },
     "node_modules/@mapbox/vector-tile": {
       "version": "1.3.1",
@@ -3367,17 +3366,16 @@
       }
     },
     "node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "22.0.1",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-22.0.1.tgz",
-      "integrity": "sha512-V7bSw7Ui6+NhpeeuYqGoqamvKuy+3+uCvQ/t4ZJkwN8cx527CAlQQQ2kp+w5R9q+Tw6bUAH+fsq+mPEkicgT8g==",
+      "version": "20.4.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.4.0.tgz",
+      "integrity": "sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/unitbezier": "^0.0.1",
         "json-stringify-pretty-compact": "^4.0.0",
         "minimist": "^1.2.8",
-        "quickselect": "^3.0.0",
+        "quickselect": "^2.0.0",
         "rw": "^1.3.3",
         "tinyqueue": "^3.0.0"
       },
@@ -3386,6 +3384,12 @@
         "gl-style-migrate": "dist/gl-style-migrate.mjs",
         "gl-style-validate": "dist/gl-style-validate.mjs"
       }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/quickselect": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
+      "dev": true
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -5334,10 +5338,9 @@
       "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg=="
     },
     "node_modules/@types/geojson": {
-      "version": "7946.0.15",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.15.tgz",
-      "integrity": "sha512-9oSxFzDCT2Rj6DfcHF8G++jxBKS7mBqXl5xrRW+Kbvjry6Uduya2iiwqHPhVXpasAVMBYKkEPGgKhd3+/HZ6xA==",
-      "license": "MIT"
+      "version": "7946.0.14",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.14.tgz",
+      "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@types/geojson-vt": {
       "version": "3.2.5",
@@ -8749,11 +8752,10 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/earcut": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.1.tgz",
-      "integrity": "sha512-0l1/0gOjESMeQyYaK5IDiPNvFeu93Z/cO0TjZh9eZ1vyCtZnA7KMZ8rQggpsJHIbGSdrqYq9OhuveadOVHCshw==",
-      "dev": true,
-      "license": "ISC"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.0.tgz",
+      "integrity": "sha512-41Fs7Q/PLq1SDbqjsgcY7GA42T0jvaCNGXgGtsNdvg+Yv8eIu06bxv4/PoREkZ9nMDNwnUSG9OFB9+yv8eKhDg==",
+      "dev": true
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -12373,8 +12375,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
       "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -13361,11 +13362,10 @@
       }
     },
     "node_modules/maplibre-gl": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.0.0.tgz",
-      "integrity": "sha512-WG8IYFK2gfJYXvWjlqg1yavo/YO/JlNkblAJMt19sjIafP5oJzTgXFiOLUIYkjtrv5pKiAWuSYsx4CD3ithJqw==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.7.1.tgz",
+      "integrity": "sha512-lgL7XpIwsgICiL82ITplfS7IGwrB1OJIw/pCvprDp2dhmSSEBgmPzYRvwYYYvJGJD7fxUv1Tvpih4nZ6VrLuaA==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -13374,14 +13374,14 @@
         "@mapbox/unitbezier": "^0.0.1",
         "@mapbox/vector-tile": "^1.3.1",
         "@mapbox/whoots-js": "^3.1.0",
-        "@maplibre/maplibre-gl-style-spec": "^22.0.1",
-        "@types/geojson": "^7946.0.15",
+        "@maplibre/maplibre-gl-style-spec": "^20.3.1",
+        "@types/geojson": "^7946.0.14",
         "@types/geojson-vt": "3.2.5",
         "@types/mapbox__point-geometry": "^0.1.4",
         "@types/mapbox__vector-tile": "^1.3.4",
         "@types/pbf": "^3.0.5",
         "@types/supercluster": "^7.1.3",
-        "earcut": "^3.0.1",
+        "earcut": "^3.0.0",
         "geojson-vt": "^4.0.2",
         "gl-matrix": "^3.4.3",
         "global-prefix": "^4.0.0",
@@ -16906,8 +16906,7 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "dev": true
     },
     "node_modules/rxjs": {
       "version": "7.8.1",
@@ -18206,8 +18205,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/tippy.js": {
       "version": "6.3.7",
@@ -19686,7 +19684,7 @@
         "@types/proj4": "^2.5.2",
         "@types/react-dom": "^18.0.6",
         "@types/react-modal": "^3.16.3",
-        "maplibre-gl": "^5.0.0",
+        "maplibre-gl": "^4.5.0",
         "mime-types": "^2.1.35",
         "proj4": "^2.8.0",
         "react": "^18.2.0",

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -38,7 +38,7 @@
     "@types/proj4": "^2.5.2",
     "@types/react-dom": "^18.0.6",
     "@types/react-modal": "^3.16.3",
-    "maplibre-gl": "^5.0.0",
+    "maplibre-gl": "^4.5.0",
     "mime-types": "^2.1.35",
     "proj4": "^2.8.0",
     "react": "^18.2.0",


### PR DESCRIPTION
This reverts commit de4fbf501701801a7eaffbca70f426424fc970d1.

### Motivation

We are seeing some minor shifts in panning/zooming behaviour in 3d mode that we want to explore more before upading the production service to maplibre5

### Modifications

Reverts maplibre 5.0 upgrade.

### Verification

<!-- TODO: Say how you tested your changes. -->
