### PR TITLE
release: v7.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.14.0](https://github.com/linz/basemaps/compare/v7.13.0...v7.14.0) (2025-01-26)
+
+
+### Bug Fixes
+
+* **infra:** correct dist path location ([#3390](https://github.com/linz/basemaps/issues/3390)) ([46f8fb8](https://github.com/linz/basemaps/commit/46f8fb8ede7163172dd9cf29ad8c779bcd327d2f))
+* revert "build: maplibre v5.0.0 ([#3387](https://github.com/linz/basemaps/issues/3387))" ([#3394](https://github.com/linz/basemaps/issues/3394)) ([d441be2](https://github.com/linz/basemaps/commit/d441be2b75f507fab53df62422bed79af3eb0df3))
+* **tiler-sharp:** when resampling uint round numbers rather than truncate ([#3392](https://github.com/linz/basemaps/issues/3392)) ([d02e56f](https://github.com/linz/basemaps/commit/d02e56febebc6c729fd3213390bdc5bbb66f419f))
+
+
+### Features
+
+* **cogify:** add background color support for overriding transparent pixels BM-1146 ([#3379](https://github.com/linz/basemaps/issues/3379)) ([b8bedc3](https://github.com/linz/basemaps/commit/b8bedc343719d445f4ca211eda03997bf51f78cb))
+* improved cloudwatch analytics rollup BM-1092 ([#3381](https://github.com/linz/basemaps/issues/3381)) ([de2f295](https://github.com/linz/basemaps/commit/de2f2958c337864115d44e320f1fd3cce17bd8d2))
+* **tiler-sharp:** support uint32 and uint8 source datasets for color-ramp ([#3391](https://github.com/linz/basemaps/issues/3391)) ([f316042](https://github.com/linz/basemaps/commit/f316042853888b8555dab3ddb1df14c32a5df0b1))
+
+
+
+
+
 # [7.13.0](https://github.com/linz/basemaps/compare/v7.12.0...v7.13.0) (2025-01-06)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
       "conventionalCommits": true
     }
   },
-  "version": "7.13.0"
+  "version": "7.14.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19378,13 +19378,13 @@
     },
     "packages/_infra": {
       "name": "@basemaps/infra",
-      "version": "7.13.0",
+      "version": "7.14.0",
       "license": "MIT",
       "devDependencies": {
         "@aws-sdk/client-acm": "^3.470.0",
         "@aws-sdk/client-cloudformation": "^3.470.0",
-        "@basemaps/lambda-tiler": "^7.13.0",
-        "@basemaps/shared": "^7.12.0",
+        "@basemaps/lambda-tiler": "^7.14.0",
+        "@basemaps/shared": "^7.14.0",
         "@linzjs/cdk-tags": "^1.7.0",
         "aws-cdk": "2.162.x",
         "aws-cdk-lib": "2.162.x",
@@ -19408,12 +19408,12 @@
     },
     "packages/bathymetry": {
       "name": "@basemaps/bathymetry",
-      "version": "7.13.0",
+      "version": "7.14.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/cli": "^7.13.0",
+        "@basemaps/cli": "^7.14.0",
         "@basemaps/geo": "^7.12.0",
-        "@basemaps/shared": "^7.12.0",
+        "@basemaps/shared": "^7.14.0",
         "@rushstack/ts-command-line": "^4.3.13",
         "ulid": "^2.3.0"
       },
@@ -19436,16 +19436,16 @@
     },
     "packages/cli": {
       "name": "@basemaps/cli",
-      "version": "7.13.0",
+      "version": "7.14.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^7.12.0",
-        "@basemaps/config-loader": "^7.12.0",
+        "@basemaps/config": "^7.14.0",
+        "@basemaps/config-loader": "^7.14.0",
         "@basemaps/geo": "^7.12.0",
-        "@basemaps/server": "^7.13.0",
-        "@basemaps/shared": "^7.12.0",
+        "@basemaps/server": "^7.14.0",
+        "@basemaps/shared": "^7.14.0",
         "@basemaps/tiler": "^7.12.0",
-        "@basemaps/tiler-sharp": "^7.12.0",
+        "@basemaps/tiler-sharp": "^7.14.0",
         "@chunkd/source-memory": "^11.0.2",
         "@cotar/builder": "^6.0.1",
         "@cotar/tar": "^6.0.1",
@@ -19499,17 +19499,17 @@
     },
     "packages/cogify": {
       "name": "@basemaps/cogify",
-      "version": "7.13.0",
+      "version": "7.14.0",
       "license": "MIT",
       "bin": {
         "cogify": "build/bin.js"
       },
       "devDependencies": {
-        "@basemaps/cli": "^7.13.0",
-        "@basemaps/config": "^7.12.0",
-        "@basemaps/config-loader": "^7.12.0",
+        "@basemaps/cli": "^7.14.0",
+        "@basemaps/config": "^7.14.0",
+        "@basemaps/config-loader": "^7.14.0",
         "@basemaps/geo": "^7.12.0",
-        "@basemaps/shared": "^7.12.0",
+        "@basemaps/shared": "^7.14.0",
         "cmd-ts": "^0.12.1",
         "p-limit": "^4.0.0",
         "stac-ts": "^1.0.0"
@@ -19520,7 +19520,7 @@
     },
     "packages/config": {
       "name": "@basemaps/config",
-      "version": "7.12.0",
+      "version": "7.14.0",
       "license": "MIT",
       "dependencies": {
         "@basemaps/geo": "^7.12.0",
@@ -19533,12 +19533,12 @@
     },
     "packages/config-loader": {
       "name": "@basemaps/config-loader",
-      "version": "7.12.0",
+      "version": "7.14.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^7.12.0",
+        "@basemaps/config": "^7.14.0",
         "@basemaps/geo": "^7.12.0",
-        "@basemaps/shared": "^7.12.0"
+        "@basemaps/shared": "^7.14.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -19569,12 +19569,12 @@
     },
     "packages/lambda-analytic-cloudfront": {
       "name": "@basemaps/lambda-analytic-cloudfront",
-      "version": "7.11.0",
+      "version": "7.14.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^7.11.0",
+        "@basemaps/config": "^7.14.0",
         "@basemaps/geo": "^7.11.0",
-        "@basemaps/shared": "^7.11.0",
+        "@basemaps/shared": "^7.14.0",
         "@elastic/elasticsearch": "^8.16.2",
         "@linzjs/lambda": "^4.0.0",
         "ua-parser-js": "^1.0.39"
@@ -19588,12 +19588,12 @@
     },
     "packages/lambda-analytics": {
       "name": "@basemaps/lambda-analytics",
-      "version": "7.12.0",
+      "version": "7.14.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^7.12.0",
+        "@basemaps/config": "^7.14.0",
         "@basemaps/geo": "^7.12.0",
-        "@basemaps/shared": "^7.12.0",
+        "@basemaps/shared": "^7.14.0",
         "ua-parser-js": "^1.0.2"
       },
       "devDependencies": {
@@ -19605,15 +19605,15 @@
     },
     "packages/lambda-tiler": {
       "name": "@basemaps/lambda-tiler",
-      "version": "7.13.0",
+      "version": "7.14.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^7.12.0",
-        "@basemaps/config-loader": "^7.12.0",
+        "@basemaps/config": "^7.14.0",
+        "@basemaps/config-loader": "^7.14.0",
         "@basemaps/geo": "^7.12.0",
-        "@basemaps/shared": "^7.12.0",
+        "@basemaps/shared": "^7.14.0",
         "@basemaps/tiler": "^7.12.0",
-        "@basemaps/tiler-sharp": "^7.12.0",
+        "@basemaps/tiler-sharp": "^7.14.0",
         "@linzjs/geojson": "^7.10.0",
         "@linzjs/lambda": "^4.0.0",
         "@mapbox/vector-tile": "^2.0.3",
@@ -19671,14 +19671,14 @@
     },
     "packages/landing": {
       "name": "@basemaps/landing",
-      "version": "7.13.0",
+      "version": "7.14.0",
       "license": "MIT",
       "devDependencies": {
         "@basemaps/attribution": "^7.12.0",
-        "@basemaps/config": "^7.12.0",
+        "@basemaps/config": "^7.14.0",
         "@basemaps/geo": "^7.12.0",
-        "@basemaps/infra": "^7.13.0",
-        "@basemaps/shared": "^7.12.0",
+        "@basemaps/infra": "^7.14.0",
+        "@basemaps/shared": "^7.14.0",
         "@linzjs/lui": "^21.46.0",
         "@servie/events": "^3.0.0",
         "@types/proj4": "^2.5.2",
@@ -19744,7 +19744,7 @@
     },
     "packages/server": {
       "name": "@basemaps/server",
-      "version": "7.13.0",
+      "version": "7.14.0",
       "license": "MIT",
       "dependencies": {
         "lerc": "^4.0.4",
@@ -19754,12 +19754,12 @@
         "basemaps-server": "bin/basemaps-server.cjs"
       },
       "devDependencies": {
-        "@basemaps/config": "^7.12.0",
-        "@basemaps/config-loader": "^7.12.0",
+        "@basemaps/config": "^7.14.0",
+        "@basemaps/config-loader": "^7.14.0",
         "@basemaps/geo": "^7.12.0",
-        "@basemaps/lambda-tiler": "^7.13.0",
+        "@basemaps/lambda-tiler": "^7.14.0",
         "@basemaps/landing": "^6.39.0",
-        "@basemaps/shared": "^7.12.0",
+        "@basemaps/shared": "^7.14.0",
         "@fastify/formbody": "^7.0.1",
         "@fastify/static": "^6.5.0",
         "cmd-ts": "^0.12.1",
@@ -19784,13 +19784,13 @@
     },
     "packages/shared": {
       "name": "@basemaps/shared",
-      "version": "7.12.0",
+      "version": "7.14.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.470.0",
         "@aws-sdk/client-s3": "^3.472.0",
         "@aws-sdk/util-dynamodb": "^3.470.0",
-        "@basemaps/config": "^7.12.0",
+        "@basemaps/config": "^7.14.0",
         "@basemaps/geo": "^7.12.0",
         "@chunkd/fs": "^11.2.0",
         "@chunkd/fs-aws": "^11.3.0",
@@ -19868,10 +19868,10 @@
     },
     "packages/tiler-sharp": {
       "name": "@basemaps/tiler-sharp",
-      "version": "7.12.0",
+      "version": "7.14.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^7.12.0",
+        "@basemaps/config": "^7.14.0",
         "@basemaps/geo": "^7.12.0",
         "@basemaps/tiler": "^7.12.0",
         "@linzjs/metrics": "^7.5.0",

--- a/packages/_infra/CHANGELOG.md
+++ b/packages/_infra/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.14.0](https://github.com/linz/basemaps/compare/v7.13.0...v7.14.0) (2025-01-26)
+
+
+### Bug Fixes
+
+* **infra:** correct dist path location ([#3390](https://github.com/linz/basemaps/issues/3390)) ([46f8fb8](https://github.com/linz/basemaps/commit/46f8fb8ede7163172dd9cf29ad8c779bcd327d2f))
+
+
+### Features
+
+* improved cloudwatch analytics rollup BM-1092 ([#3381](https://github.com/linz/basemaps/issues/3381)) ([de2f295](https://github.com/linz/basemaps/commit/de2f2958c337864115d44e320f1fd3cce17bd8d2))
+
+
+
+
+
 # [7.13.0](https://github.com/linz/basemaps/compare/v7.12.0...v7.13.0) (2025-01-06)
 
 **Note:** Version bump only for package @basemaps/infra

--- a/packages/_infra/package.json
+++ b/packages/_infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/infra",
-  "version": "7.13.0",
+  "version": "7.14.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -26,8 +26,8 @@
   "devDependencies": {
     "@aws-sdk/client-acm": "^3.470.0",
     "@aws-sdk/client-cloudformation": "^3.470.0",
-    "@basemaps/lambda-tiler": "^7.13.0",
-    "@basemaps/shared": "^7.12.0",
+    "@basemaps/lambda-tiler": "^7.14.0",
+    "@basemaps/shared": "^7.14.0",
     "@linzjs/cdk-tags": "^1.7.0",
     "aws-cdk": "2.162.x",
     "aws-cdk-lib": "2.162.x",

--- a/packages/bathymetry/CHANGELOG.md
+++ b/packages/bathymetry/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.14.0](https://github.com/linz/basemaps/compare/v7.13.0...v7.14.0) (2025-01-26)
+
+**Note:** Version bump only for package @basemaps/bathymetry
+
+
+
+
+
 # [7.13.0](https://github.com/linz/basemaps/compare/v7.12.0...v7.13.0) (2025-01-06)
 
 **Note:** Version bump only for package @basemaps/bathymetry

--- a/packages/bathymetry/package.json
+++ b/packages/bathymetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/bathymetry",
-  "version": "7.13.0",
+  "version": "7.14.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -28,9 +28,9 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/cli": "^7.13.0",
+    "@basemaps/cli": "^7.14.0",
     "@basemaps/geo": "^7.12.0",
-    "@basemaps/shared": "^7.12.0",
+    "@basemaps/shared": "^7.14.0",
     "@rushstack/ts-command-line": "^4.3.13",
     "ulid": "^2.3.0"
   },

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.14.0](https://github.com/linz/basemaps/compare/v7.13.0...v7.14.0) (2025-01-26)
+
+**Note:** Version bump only for package @basemaps/cli
+
+
+
+
+
 # [7.13.0](https://github.com/linz/basemaps/compare/v7.12.0...v7.13.0) (2025-01-06)
 
 **Note:** Version bump only for package @basemaps/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli",
-  "version": "7.13.0",
+  "version": "7.14.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -40,13 +40,13 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
-    "@basemaps/config": "^7.12.0",
-    "@basemaps/config-loader": "^7.12.0",
+    "@basemaps/config": "^7.14.0",
+    "@basemaps/config-loader": "^7.14.0",
     "@basemaps/geo": "^7.12.0",
-    "@basemaps/server": "^7.13.0",
-    "@basemaps/shared": "^7.12.0",
+    "@basemaps/server": "^7.14.0",
+    "@basemaps/shared": "^7.14.0",
     "@basemaps/tiler": "^7.12.0",
-    "@basemaps/tiler-sharp": "^7.12.0",
+    "@basemaps/tiler-sharp": "^7.14.0",
     "@chunkd/source-memory": "^11.0.2",
     "@cotar/builder": "^6.0.1",
     "@cotar/tar": "^6.0.1",

--- a/packages/cogify/CHANGELOG.md
+++ b/packages/cogify/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.14.0](https://github.com/linz/basemaps/compare/v7.13.0...v7.14.0) (2025-01-26)
+
+
+### Features
+
+* **cogify:** add background color support for overriding transparent pixels BM-1146 ([#3379](https://github.com/linz/basemaps/issues/3379)) ([b8bedc3](https://github.com/linz/basemaps/commit/b8bedc343719d445f4ca211eda03997bf51f78cb))
+
+
+
+
+
 # [7.13.0](https://github.com/linz/basemaps/compare/v7.12.0...v7.13.0) (2025-01-06)
 
 **Note:** Version bump only for package @basemaps/cogify

--- a/packages/cogify/package.json
+++ b/packages/cogify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cogify",
-  "version": "7.13.0",
+  "version": "7.14.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -40,11 +40,11 @@
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "devDependencies": {
-    "@basemaps/cli": "^7.13.0",
-    "@basemaps/config": "^7.12.0",
-    "@basemaps/config-loader": "^7.12.0",
+    "@basemaps/cli": "^7.14.0",
+    "@basemaps/config": "^7.14.0",
+    "@basemaps/config-loader": "^7.14.0",
     "@basemaps/geo": "^7.12.0",
-    "@basemaps/shared": "^7.12.0",
+    "@basemaps/shared": "^7.14.0",
     "cmd-ts": "^0.12.1",
     "p-limit": "^4.0.0",
     "stac-ts": "^1.0.0"

--- a/packages/config-loader/CHANGELOG.md
+++ b/packages/config-loader/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.14.0](https://github.com/linz/basemaps/compare/v7.13.0...v7.14.0) (2025-01-26)
+
+**Note:** Version bump only for package @basemaps/config-loader
+
+
+
+
+
 # [7.12.0](https://github.com/linz/basemaps/compare/v7.11.1...v7.12.0) (2024-11-14)
 
 

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/config-loader",
-  "version": "7.12.0",
+  "version": "7.14.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -28,8 +28,8 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/config": "^7.12.0",
+    "@basemaps/config": "^7.14.0",
     "@basemaps/geo": "^7.12.0",
-    "@basemaps/shared": "^7.12.0"
+    "@basemaps/shared": "^7.14.0"
   }
 }

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.14.0](https://github.com/linz/basemaps/compare/v7.13.0...v7.14.0) (2025-01-26)
+
+
+### Features
+
+* **cogify:** add background color support for overriding transparent pixels BM-1146 ([#3379](https://github.com/linz/basemaps/issues/3379)) ([b8bedc3](https://github.com/linz/basemaps/commit/b8bedc343719d445f4ca211eda03997bf51f78cb))
+
+
+
+
+
 # [7.12.0](https://github.com/linz/basemaps/compare/v7.11.1...v7.12.0) (2024-11-14)
 
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/config",
-  "version": "7.12.0",
+  "version": "7.14.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",

--- a/packages/lambda-analytic-cloudfront/CHANGELOG.md
+++ b/packages/lambda-analytic-cloudfront/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+# [7.14.0](https://github.com/linz/basemaps/compare/v7.13.0...v7.14.0) (2025-01-26)
+
+
+### Features
+
+* improved cloudwatch analytics rollup BM-1092 ([#3381](https://github.com/linz/basemaps/issues/3381)) ([de2f295](https://github.com/linz/basemaps/commit/de2f2958c337864115d44e320f1fd3cce17bd8d2))

--- a/packages/lambda-analytic-cloudfront/package.json
+++ b/packages/lambda-analytic-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-analytic-cloudfront",
-  "version": "7.11.0",
+  "version": "7.14.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -18,9 +18,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@basemaps/config": "^7.11.0",
+    "@basemaps/config": "^7.14.0",
     "@basemaps/geo": "^7.11.0",
-    "@basemaps/shared": "^7.11.0",
+    "@basemaps/shared": "^7.14.0",
     "@elastic/elasticsearch": "^8.16.2",
     "@linzjs/lambda": "^4.0.0",
     "ua-parser-js": "^1.0.39"

--- a/packages/lambda-analytics/CHANGELOG.md
+++ b/packages/lambda-analytics/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.14.0](https://github.com/linz/basemaps/compare/v7.13.0...v7.14.0) (2025-01-26)
+
+**Note:** Version bump only for package @basemaps/lambda-analytics
+
+
+
+
+
 # [7.12.0](https://github.com/linz/basemaps/compare/v7.11.1...v7.12.0) (2024-11-14)
 
 **Note:** Version bump only for package @basemaps/lambda-analytics

--- a/packages/lambda-analytics/package.json
+++ b/packages/lambda-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-analytics",
-  "version": "7.12.0",
+  "version": "7.14.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -18,9 +18,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@basemaps/config": "^7.12.0",
+    "@basemaps/config": "^7.14.0",
     "@basemaps/geo": "^7.12.0",
-    "@basemaps/shared": "^7.12.0",
+    "@basemaps/shared": "^7.14.0",
     "ua-parser-js": "^1.0.2"
   },
   "scripts": {

--- a/packages/lambda-tiler/CHANGELOG.md
+++ b/packages/lambda-tiler/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.14.0](https://github.com/linz/basemaps/compare/v7.13.0...v7.14.0) (2025-01-26)
+
+**Note:** Version bump only for package @basemaps/lambda-tiler
+
+
+
+
+
 # [7.13.0](https://github.com/linz/basemaps/compare/v7.12.0...v7.13.0) (2025-01-06)
 
 

--- a/packages/lambda-tiler/package.json
+++ b/packages/lambda-tiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-tiler",
-  "version": "7.13.0",
+  "version": "7.14.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -22,12 +22,12 @@
   "types": "./build/index.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@basemaps/config": "^7.12.0",
-    "@basemaps/config-loader": "^7.12.0",
+    "@basemaps/config": "^7.14.0",
+    "@basemaps/config-loader": "^7.14.0",
     "@basemaps/geo": "^7.12.0",
-    "@basemaps/shared": "^7.12.0",
+    "@basemaps/shared": "^7.14.0",
     "@basemaps/tiler": "^7.12.0",
-    "@basemaps/tiler-sharp": "^7.12.0",
+    "@basemaps/tiler-sharp": "^7.14.0",
     "@linzjs/geojson": "^7.10.0",
     "@linzjs/lambda": "^4.0.0",
     "@mapbox/vector-tile": "^2.0.3",

--- a/packages/landing/CHANGELOG.md
+++ b/packages/landing/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.14.0](https://github.com/linz/basemaps/compare/v7.13.0...v7.14.0) (2025-01-26)
+
+
+### Bug Fixes
+
+* revert "build: maplibre v5.0.0 ([#3387](https://github.com/linz/basemaps/issues/3387))" ([#3394](https://github.com/linz/basemaps/issues/3394)) ([d441be2](https://github.com/linz/basemaps/commit/d441be2b75f507fab53df62422bed79af3eb0df3))
+
+
+
+
+
 # [7.13.0](https://github.com/linz/basemaps/compare/v7.12.0...v7.13.0) (2025-01-06)
 
 

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/landing",
-  "version": "7.13.0",
+  "version": "7.14.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -29,10 +29,10 @@
   ],
   "devDependencies": {
     "@basemaps/attribution": "^7.12.0",
-    "@basemaps/config": "^7.12.0",
+    "@basemaps/config": "^7.14.0",
     "@basemaps/geo": "^7.12.0",
-    "@basemaps/infra": "^7.13.0",
-    "@basemaps/shared": "^7.12.0",
+    "@basemaps/infra": "^7.14.0",
+    "@basemaps/shared": "^7.14.0",
     "@linzjs/lui": "^21.46.0",
     "@servie/events": "^3.0.0",
     "@types/proj4": "^2.5.2",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.14.0](https://github.com/linz/basemaps/compare/v7.13.0...v7.14.0) (2025-01-26)
+
+**Note:** Version bump only for package @basemaps/server
+
+
+
+
+
 # [7.13.0](https://github.com/linz/basemaps/compare/v7.12.0...v7.13.0) (2025-01-06)
 
 **Note:** Version bump only for package @basemaps/server

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/server",
-  "version": "7.13.0",
+  "version": "7.14.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -52,12 +52,12 @@
     "sharp": "^0.33.0"
   },
   "devDependencies": {
-    "@basemaps/config": "^7.12.0",
-    "@basemaps/config-loader": "^7.12.0",
+    "@basemaps/config": "^7.14.0",
+    "@basemaps/config-loader": "^7.14.0",
     "@basemaps/geo": "^7.12.0",
-    "@basemaps/lambda-tiler": "^7.13.0",
+    "@basemaps/lambda-tiler": "^7.14.0",
     "@basemaps/landing": "^6.39.0",
-    "@basemaps/shared": "^7.12.0",
+    "@basemaps/shared": "^7.14.0",
     "@fastify/formbody": "^7.0.1",
     "@fastify/static": "^6.5.0",
     "cmd-ts": "^0.12.1",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.14.0](https://github.com/linz/basemaps/compare/v7.13.0...v7.14.0) (2025-01-26)
+
+
+### Features
+
+* improved cloudwatch analytics rollup BM-1092 ([#3381](https://github.com/linz/basemaps/issues/3381)) ([de2f295](https://github.com/linz/basemaps/commit/de2f2958c337864115d44e320f1fd3cce17bd8d2))
+
+
+
+
+
 # [7.12.0](https://github.com/linz/basemaps/compare/v7.11.1...v7.12.0) (2024-11-14)
 
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/shared",
-  "version": "7.12.0",
+  "version": "7.14.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -26,7 +26,7 @@
     "@aws-sdk/client-dynamodb": "^3.470.0",
     "@aws-sdk/client-s3": "^3.472.0",
     "@aws-sdk/util-dynamodb": "^3.470.0",
-    "@basemaps/config": "^7.12.0",
+    "@basemaps/config": "^7.14.0",
     "@basemaps/geo": "^7.12.0",
     "@chunkd/fs": "^11.2.0",
     "@chunkd/fs-aws": "^11.3.0",

--- a/packages/tiler-sharp/CHANGELOG.md
+++ b/packages/tiler-sharp/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.14.0](https://github.com/linz/basemaps/compare/v7.13.0...v7.14.0) (2025-01-26)
+
+
+### Bug Fixes
+
+* **tiler-sharp:** when resampling uint round numbers rather than truncate ([#3392](https://github.com/linz/basemaps/issues/3392)) ([d02e56f](https://github.com/linz/basemaps/commit/d02e56febebc6c729fd3213390bdc5bbb66f419f))
+
+
+### Features
+
+* **tiler-sharp:** support uint32 and uint8 source datasets for color-ramp ([#3391](https://github.com/linz/basemaps/issues/3391)) ([f316042](https://github.com/linz/basemaps/commit/f316042853888b8555dab3ddb1df14c32a5df0b1))
+
+
+
+
+
 # [7.12.0](https://github.com/linz/basemaps/compare/v7.11.1...v7.12.0) (2024-11-14)
 
 **Note:** Version bump only for package @basemaps/tiler-sharp

--- a/packages/tiler-sharp/package.json
+++ b/packages/tiler-sharp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/tiler-sharp",
-  "version": "7.12.0",
+  "version": "7.14.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -22,7 +22,7 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@basemaps/config": "^7.12.0",
+    "@basemaps/config": "^7.14.0",
     "@basemaps/geo": "^7.12.0",
     "@basemaps/tiler": "^7.12.0",
     "@linzjs/metrics": "^7.5.0",


### PR DESCRIPTION
# [7.14.0](https://github.com/linz/basemaps/compare/v7.13.0...v7.14.0) (2025-01-26)


### Bug Fixes

* **infra:** correct dist path location ([#3390](https://github.com/linz/basemaps/issues/3390)) ([46f8fb8](https://github.com/linz/basemaps/commit/46f8fb8ede7163172dd9cf29ad8c779bcd327d2f))
* revert "build: maplibre v5.0.0 ([#3387](https://github.com/linz/basemaps/issues/3387))" ([#3394](https://github.com/linz/basemaps/issues/3394)) ([d441be2](https://github.com/linz/basemaps/commit/d441be2b75f507fab53df62422bed79af3eb0df3))
* **tiler-sharp:** when resampling uint round numbers rather than truncate ([#3392](https://github.com/linz/basemaps/issues/3392)) ([d02e56f](https://github.com/linz/basemaps/commit/d02e56febebc6c729fd3213390bdc5bbb66f419f))


### Features

* **cogify:** add background color support for overriding transparent pixels BM-1146 ([#3379](https://github.com/linz/basemaps/issues/3379)) ([b8bedc3](https://github.com/linz/basemaps/commit/b8bedc343719d445f4ca211eda03997bf51f78cb))
* improved cloudwatch analytics rollup BM-1092 ([#3381](https://github.com/linz/basemaps/issues/3381)) ([de2f295](https://github.com/linz/basemaps/commit/de2f2958c337864115d44e320f1fd3cce17bd8d2))
* **tiler-sharp:** support uint32 and uint8 source datasets for color-ramp ([#3391](https://github.com/linz/basemaps/issues/3391)) ([f316042](https://github.com/linz/basemaps/commit/f316042853888b8555dab3ddb1df14c32a5df0b1))