### PR TITLE
build: upgrade visual snapshot to support new artifacts api

### DIFF
--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -43,7 +43,7 @@ jobs:
           docker run --rm --network="host" -v $PWD:$PWD ghcr.io/linz/basemaps-screenshot/cli:v1 --url http://localhost:5000 --output $PWD/.artifacts/visual-snapshots
 
       - name: Save snapshots
-        uses: getsentry/action-visual-snapshot@v2
+        uses: blacha/action-visual-snapshot@v2-next
         with:
           save-only: true
           snapshot-path: .artifacts/visual-snapshots
@@ -68,7 +68,7 @@ jobs:
 
       - name: Diff snapshots
         id: visual-snapshots-diff
-        uses: blacha/action-visual-snapshot@v2
+        uses: blacha/action-visual-snapshot@v2-next
         with:
           storage-prefix: 's3://linz-basemaps-screenshot'
           storage-url: 'https://d25mfjh9syaxsr.cloudfront.net'


### PR DESCRIPTION
### Motivation

`getsentry/action-visual-snapshot` has been deprecated and archived, it is no longer supported, github has recently removed support for the artifacts API it was using to store the images, causing all of these actions to fail.

### Modifications

Fork the github action and update it to support the newer github actions artifacts API.

this is a temporary fix with the intention to replace this github action with another more supported action in the near term.

### Verification

Checking to see if the build succeeds after this is merged.


ref: https://github.com/linz/basemaps-config/pull/1039