### PR TITLE
build: fix text escaping for multiline with "`" commit messages

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -66,7 +66,7 @@ jobs:
               tags.push('latest');
 
               // If on a release commit add `v7`, `v7.1` and `v7.1`
-              if (`${{ toJson(github.event.head_commit.message) }}`.startsWith('release:')) {
+              if (${{ toJson(github.event.head_commit.message) }}.startsWith('release:')) {
                 tags.push('${{ steps.version.outputs.version_major }}');
                 tags.push('${{ steps.version.outputs.version_major_minor }}');
               }


### PR DESCRIPTION
### Motivation

There is a bug causing container builds to fail if the commit message contains a backtick "\`"

When github replaces the commit message it directly inserts it into the script without any escaping

```javascript
const x = ${{ github....commit_message }}

// directly replaced no quotes included, and includes \n as line breaks
const x = build: fix text.
body text here
some `comments` in the body
```

using `toJson()`

```typescript 
const x  = ${{ toJson(...commit_message) }}

// all escaped and includes a starting "
const x = "build: fix text.\nbody text here\nsome `comments` in the body"
```

using `toJson` and backticks
```typescript 
const x  = `${{ toJson(...commit_message) }}`

// Broken string
const x = `"build: fix text.\nbody text here\nsome `comments` in the body"`
//        ^                                        ^
```



### Modifications

Removing "\`" as `toJson()` will handle the string escaping.


### Verification

Building containers as part of pull request.
