### PR TITLE
fix(lambda-analytic-cloudfront): process logs upto one hour ago

### DIFF
--- a/packages/lambda-analytic-cloudfront/src/__test__/analytics.test.ts
+++ b/packages/lambda-analytic-cloudfront/src/__test__/analytics.test.ts
@@ -7,7 +7,7 @@ import { Client } from '@elastic/elasticsearch';
 import { LambdaRequest } from '@linzjs/lambda';
 import { Context } from 'aws-lambda';
 
-import { getOneHourAgo, getYesterday } from '../date.js';
+import { getOneHourAgo } from '../date.js';
 import { Elastic } from '../elastic.js';
 import { main } from '../handler.js';
 import { LogStats } from '../log.stats.js';

--- a/packages/lambda-analytic-cloudfront/src/__test__/analytics.test.ts
+++ b/packages/lambda-analytic-cloudfront/src/__test__/analytics.test.ts
@@ -7,7 +7,7 @@ import { Client } from '@elastic/elasticsearch';
 import { LambdaRequest } from '@linzjs/lambda';
 import { Context } from 'aws-lambda';
 
-import { getYesterday } from '../date.js';
+import { getOneHourAgo, getYesterday } from '../date.js';
 import { Elastic } from '../elastic.js';
 import { main } from '../handler.js';
 import { LogStats } from '../log.stats.js';
@@ -69,8 +69,8 @@ describe('analytic lambda', () => {
       },
     } as unknown as Client;
 
-    const YesterDay = getYesterday();
-    const shortDate = YesterDay.toISOString().slice(0, 10) + '-23';
+    const oneHourAgo = getOneHourAgo();
+    const shortDate = oneHourAgo.toISOString().slice(0, 13).replace('T', '-');
     await fsa.write(new URL(`mem://source/cfid.${shortDate}/data.txt.gz`), gzipSync(LogData));
 
     await main(new FakeLambdaRequest());
@@ -114,8 +114,8 @@ describe('analytic lambda', () => {
       },
     } as unknown as Client;
 
-    const YesterDay = getYesterday();
-    const shortDate = YesterDay.toISOString().slice(0, 10) + '-23';
+    const oneHourAgo = getOneHourAgo();
+    const shortDate = oneHourAgo.toISOString().slice(0, 13).replace('T', '-');
     await fsa.write(new URL(`mem://source/cfid.${shortDate}/data.txt.gz`), gzipSync(LogData));
 
     const ret = await main(new FakeLambdaRequest()).catch((e: Error) => e);

--- a/packages/lambda-analytic-cloudfront/src/date.ts
+++ b/packages/lambda-analytic-cloudfront/src/date.ts
@@ -1,11 +1,17 @@
-export function getYesterday(): Date {
-  // Process up to about a day ago
+/**
+ * Create a UTC time date that is rounded down to one hour ago
+ *
+ * @example
+ * 2025-03-17T03:19:33.599Z -> 2025-03-17T02:00:00.000Z
+ *
+ * @returns
+ */
+export function getOneHourAgo(): Date {
   const maxDate = new Date();
-  maxDate.setUTCHours(0);
   maxDate.setUTCMinutes(0);
   maxDate.setUTCSeconds(0);
   maxDate.setUTCMilliseconds(0);
-  maxDate.setUTCDate(maxDate.getUTCDate() - 1);
+  maxDate.setUTCHours(maxDate.getUTCHours() - 1);
   return maxDate;
 }
 
@@ -17,18 +23,6 @@ export function* byDay(startDate: Date, endDate: Date): Generator<string> {
   while (true) {
     yield currentDate.toISOString().slice(0, 10);
     currentDate.setUTCDate(currentDate.getUTCDate() - 1);
-    if (currentDate.getTime() < endDate.getTime()) break;
-  }
-}
-
-export function* byMonth(startDate: Date, endDate: Date): Generator<string> {
-  const currentDate = new Date(startDate);
-  currentDate.setUTCMinutes(0);
-  currentDate.setUTCSeconds(0);
-  currentDate.setUTCMilliseconds(0);
-  while (true) {
-    yield currentDate.toISOString().slice(0, 7);
-    currentDate.setUTCMonth(currentDate.getUTCMonth() - 1);
     if (currentDate.getTime() < endDate.getTime()) break;
   }
 }

--- a/packages/lambda-analytic-cloudfront/src/handler.ts
+++ b/packages/lambda-analytic-cloudfront/src/handler.ts
@@ -6,7 +6,7 @@ import { LambdaRequest } from '@linzjs/lambda';
 import pLimit from 'p-limit';
 import { basename } from 'path';
 
-import { byDay, getOneHourAgo, getYesterday } from './date.js';
+import { byDay, getOneHourAgo } from './date.js';
 import { Elastic } from './elastic.js';
 import { FileProcess, toFullDate } from './log.reader.js';
 import { LogStats } from './log.stats.js';

--- a/packages/lambda-analytic-cloudfront/src/handler.ts
+++ b/packages/lambda-analytic-cloudfront/src/handler.ts
@@ -6,7 +6,7 @@ import { LambdaRequest } from '@linzjs/lambda';
 import pLimit from 'p-limit';
 import { basename } from 'path';
 
-import { byDay, getYesterday } from './date.js';
+import { byDay, getOneHourAgo, getYesterday } from './date.js';
 import { Elastic } from './elastic.js';
 import { FileProcess, toFullDate } from './log.reader.js';
 import { LogStats } from './log.stats.js';
@@ -51,20 +51,22 @@ export async function main(req: LambdaRequest): Promise<void> {
   const fileQ = pLimit(5);
 
   let processedCount = 0;
-  for (const prefixByDay of byDay(getYesterday(), OldestDate)) {
+  for (const prefixByDay of byDay(getOneHourAgo(), OldestDate)) {
     if (processedCount > MaxToProcess) break;
     const todo = [];
 
     for (let hour = 23; hour >= 0; hour--) {
-      processedCount++;
-      if (processedCount > MaxToProcess) break;
       const hourOfDay = String(hour).padStart(2, '0');
       const prefix = `${prefixByDay}-${hourOfDay}`;
 
       const targetDate = new Date(toFullDate(prefixByDay + 'T' + hourOfDay));
       const dateDiff = Date.now() - targetDate.getTime();
+
       // Do not process anything within a hour of the current time as some logs take a while to propagate into the bucket
       if (dateDiff < 60 * 60 * 1000) continue;
+
+      processedCount++;
+      if (processedCount > MaxToProcess) break;
 
       // Create a folder structure of /YYYY/MM/
       const cacheFolderParts = prefix.slice(0, 7).replace('-', '/');


### PR DESCRIPTION
### Motivation

Log processing is done in batches and is restricted to at most one hour behind, there is a bug in the existing logic where logs processing can be delayed by upto a day.

This is caused by the looping logic where it subtracts one day then loops over the 24 hours of that day, so if the time is close to the day start (eg 1am utc) the logs are processed upto midnight of the day before, if the current time is close to the end of the day (eg 11pm utc) the logs will be processed up to midnight the day before.

### Modifications

Move the processing logic to start looping from one hour ago, 
Exclude any timestamps that are in the future.

### Verification

Unit tests
