### PR TITLE
[WIP] feat(cogify): support band expansion of greyscale imagery

### DIFF
--- a/packages/cogify/src/cogify/cli/cli.cog.ts
+++ b/packages/cogify/src/cogify/cli/cli.cog.ts
@@ -340,7 +340,6 @@ async function createCog(ctx: CogCreationContext): Promise<URL> {
   // 4 band RGBA output we need to ensure there is alpha and band expansion
   if (ctx.options.preset === 'webp' && ctx.options.sourceBands?.join(',') === 'uint8') {
     vrtOpts.addAlpha = true;
-    vrtOpts.expandBands = true;
   }
 
   // Create the vrt of all the source files

--- a/packages/cogify/src/cogify/covering/tile.cover.ts
+++ b/packages/cogify/src/cogify/covering/tile.cover.ts
@@ -163,6 +163,7 @@ export async function createTileCover(ctx: TileCoverContext): Promise<TileCoverR
           ...Presets[ctx.preset].options,
           tile,
           tileMatrix: ctx.tileMatrix.identifier,
+          sourceBands: ctx.imagery.bands,
           sourceEpsg: ctx.imagery.projection,
           zoomLevel: targetBaseZoom,
         },

--- a/packages/cogify/src/cogify/stac.ts
+++ b/packages/cogify/src/cogify/stac.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 
-import { Rgba } from '@basemaps/config';
+import { ImageryBandType, Rgba } from '@basemaps/config';
 import { EpsgCode, Tile } from '@basemaps/geo';
 import { StacCollection, StacItem, StacLink } from 'stac-ts';
 
@@ -16,6 +16,17 @@ export interface CogifyCreationOptions {
 
   /** Projection of source imagery */
   sourceEpsg: number;
+
+  /** Band information of the source imagery
+   *
+   * @example
+   * ```
+   * ["uint8"] // one band uint8 eg grey scale
+   * ["float32"] // one band float32 eg elevation data
+   * ["uint8","uint8","uint8"] // three band uint8 eg RGB
+   * ```
+   */
+  sourceBands?: ImageryBandType[];
 
   /**
    * Compression to use for the cog

--- a/packages/config/src/color.ts
+++ b/packages/config/src/color.ts
@@ -5,9 +5,7 @@
 export function parseHex(str: string): number {
   if (str === '') return 0;
   const val = parseInt(str, 16);
-  if (isNaN(val)) {
-    throw new Error('Invalid hex byte: ' + str);
-  }
+  if (isNaN(val)) throw new Error('Invalid hex byte: ' + str);
   return val;
 }
 
@@ -31,9 +29,9 @@ export function parseRgba(str: string): Rgba {
     throw new Error('Invalid hex color: ' + str);
   }
   return {
-    r: parseHex(str.substr(0, 2)),
-    g: parseHex(str.substr(2, 2)),
-    b: parseHex(str.substr(4, 2)),
-    alpha: parseHex(str.substr(6, 2)),
+    r: parseHex(str.slice(0, 2)),
+    g: parseHex(str.slice(2, 2)),
+    b: parseHex(str.slice(4, 2)),
+    alpha: parseHex(str.slice(6, 2)),
   };
 }


### PR DESCRIPTION
### Motivation

LINZ is now publishing one band grey scale `[uint8]` lerc datasets such as 

```
s3://nz-elevation/new-zealand/new-zealand/dem-hillshade/2193/ 
s3://nz-elevation/new-zealand/new-zealand/dem-hillshade-igor/2193/
```

Basemaps prefers grey scale imagery to be stored as webp, webp requires 3 or 4 bands of source imagery.

### Modifications

if the `webp` preset is used on imagery that is one band `uint8` expand the source imagery into 3 bands of the same `uint8` 

if a source pixel's value is `240` then it will be converted into RGB: `240,240,240` 

### Verification

Imported the dem-hillshade locally