### PR TITLE
fix(landing): update the set of labels disabled layers BM-1230

### DIFF
--- a/packages/landing/src/__tests__/map.config.test.ts
+++ b/packages/landing/src/__tests__/map.config.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import { GoogleTms, Nztm2000QuadTms, Nztm2000Tms } from '@basemaps/geo';
 
+import { LabelsDisabledLayers } from '../components/map.label.js';
 import { Config } from '../config.js';
 import { MapConfig } from '../config.map.js';
 import { MapOptionType, WindowUrl } from '../url.js';
@@ -173,6 +174,31 @@ describe('WindowUrl', () => {
 
     mc.updateFromUrl('i=01EDA2YFXH2JN264VG1HKBT625');
     assert.equal(mc.layerId, '01EDA2YFXH2JN264VG1HKBT625');
+  });
+
+  it('should preserve the labels param', () => {
+    const url = WindowUrl.toTileUrl({
+      urlType: MapOptionType.Style,
+      tileMatrix: GoogleTms,
+      layerId: 'aerial',
+      style: 'aerial',
+      labels: true,
+    });
+    assert.equal(url.includes('labels=true'), true);
+  });
+
+  it('should discard the labels param', () => {
+    for (const style of LabelsDisabledLayers.values()) {
+      const url = WindowUrl.toTileUrl({
+        urlType: MapOptionType.Style,
+        tileMatrix: GoogleTms,
+        layerId: 'topographic',
+        style,
+        labels: true,
+      });
+
+      assert.equal(url.includes('labels=true'), false);
+    }
   });
 
   it('should enable labels by default', () => {

--- a/packages/landing/src/components/map.label.tsx
+++ b/packages/landing/src/components/map.label.tsx
@@ -2,7 +2,15 @@ import { IControl } from 'maplibre-gl';
 
 import { Config, GaEvent, gaEvent } from '../config.js';
 
-export const LabelsDisabledLayers = new Set(['topographic', 'topolite', 'topo-raster']);
+export const LabelsDisabledLayers = new Set([
+  'labels',
+  'labels-v2',
+  'topographic',
+  'topographic-v2',
+  'topolite',
+  'topolite-v2',
+  'topo-raster',
+]);
 
 export class MapLabelControl implements IControl {
   map?: maplibregl.Map;


### PR DESCRIPTION
### Motivation

We have now published the Shortbread vector map stylesheets into Basemaps. However, attempting to view any of them, with the labels enabled, results in a `400 Bad Request` response.

#### Example

Attempting to view the `topographic-v2` layer results in a blank map as fetching the style fails:

| https://basemaps.linz.govt.nz/?style=topographic-v2&i=topographic&labels=true |
| - |
| ![][img_before] |


The blank map is caused by the stylesheet request preserving the `labels` parameter instead of trimming it off:
```
https://basemaps.linz.govt.nz/v1/styles/topographic-v2.json?api={api_key}&labels=true
```

The request then returns the following `400` status response:
```
{"id":"01JQ30CEPF9CDXBFMN9229S0WV","status":400,"message":"Cannot merge styles with duplicate layerIds: Parcels-Ln","correlationId":"01JQ30CEPG8AKWBZK5VXHH2TZ3"}
```

### Modifications

- Updated the set of layers for which to disable labels.
- Added tests to verify that the landing package trims off the `labels` param for such layers.

### Verification

I have verified locally that the Shortbread vector map layers show on the map regardless of whether the `labels` parameter is present in the URL, similar to the `topographic` layer.

#### Example

Viewing the `topographic-v2` layer (locally) now shows the map as expected:

| http://localhost:5000/?style=topographic-v2&i=topographic&labels=true |
| - |
| ![][img_after] |

The stylesheet request now trims off the `labels` parameter instead of preserving it:
```
https://basemaps.linz.govt.nz/v1/styles/topographic-v2.json?api={api_key}
```
The request now returns the following `200` status response (snippet):
```
{ "id": "st_topographic-v2", "version": 8, ... }
```

<!-- TODO: Say how you tested your changes. -->

[img_before]: https://github.com/user-attachments/assets/9d75c80a-c8c2-4c27-ab51-b4bf09a6cc5d
[img_after]: https://github.com/user-attachments/assets/10fb7211-3b3c-4ee8-870d-d9084e2b4ff7


