### PR TITLE
refactor(landing): refine the labels param parsing logic

### DIFF
--- a/packages/landing/src/__tests__/map.config.test.ts
+++ b/packages/landing/src/__tests__/map.config.test.ts
@@ -209,10 +209,20 @@ describe('WindowUrl', () => {
     assert.equal(mc.labels, true);
 
     // aerial layer, labels enabled & debug disabled
-    mc.updateFromUrl('?labels=true');
-    assert.equal(mc.layerId, 'aerial');
-    assert.equal(mc.isDebug, false);
-    assert.equal(mc.labels, true);
+    for (const params of ['?labels', '?labels=true']) {
+      mc.updateFromUrl(params);
+      assert.equal(mc.layerId, 'aerial');
+      assert.equal(mc.isDebug, false);
+      assert.equal(mc.labels, true);
+    }
+
+    // aerial layer, labels enabled & debug enabled
+    for (const params of ['?labels&debug', '?labels=true&debug']) {
+      mc.updateFromUrl(params);
+      assert.equal(mc.layerId, 'aerial');
+      assert.equal(mc.isDebug, true);
+      assert.equal(mc.labels, true);
+    }
   });
 
   it('should not enable labels by default', () => {

--- a/packages/landing/src/config.map.ts
+++ b/packages/landing/src/config.map.ts
@@ -145,10 +145,14 @@ export class MapConfig extends Emitter<MapConfigEvents> {
     this.style = style ?? null;
     this.layerId = layerId.startsWith('im_') ? layerId.slice(3) : layerId;
     this.tileMatrix = tileMatrix;
-    if (labels == null) {
-      this.labels = layerId === 'aerial' && this.isDebug === false;
+    this.labels = false;
+
+    if (typeof labels === 'string') {
+      // enable labels for any string value other than "false"
+      if (labels !== 'false') this.labels = true;
     } else {
-      this.labels = labels !== 'false';
+      // if not in debug mode, show labels for the aerial layer by default
+      if (layerId === 'aerial' && !this.isDebug) this.labels = true;
     }
 
     if (this.layerId === 'topographic' && this.style == null) this.style = 'topographic';


### PR DESCRIPTION
### Motivation

While looking through the `basemaps/landing` package, I noticed that the code for handling the `labels` URL query parameter is hard to understand. The default behavior is also unclear. This work aims to fix that.

- Refactors code from https://github.com/linz/basemaps/pull/3364

### Modifications

1. Modified the [code] responsible for parsing the `labels` URL query parameter. The code lives within the [updateFromUrl] function. A 'before' and 'after' is as follows:

   #### Before

   The current logic, although concise, is a little difficult to interpret:

   ```typescript
   if (labels == null) {
     this.labels = layerId === "aerial" && this.isDebug === false;
   } else {
     this.labels = labels !== "false";
   }
   ```

   #### After

   The updated logic, although verbose, seeks to clarify the process flow and explain each statement's context:

   ```typescript
   this.labels = false;

   if (typeof labels === "string") {
     // enable labels for any string value other than "false"
     if (labels !== "false") this.labels = true;
   } else {
     // if not in debug mode, show labels for the aerial layer by default
     if (layerId === "aerial" && !this.isDebug) this.labels = true;
   }
   ```

2. Expanded upon some of the [existing test cases][adjusted] that validate the parsing logic for the `labels` URL query parameter.

### Verification

All of the [original] and [adjusted] test cases pass, indicating that the parsing logic remains unchanged.

<!-- external links -->

[code]: https://github.com/linz/basemaps/pull/3413/files#diff-f03767e7b3c93746f0651b4ce3f2d304bdf32185d88bb0d3374d03781ed22348

[updateFromUrl]: https://github.com/linz/basemaps/blob/e874e2b678ae074f344f4ce0fef6c6460fb42495/packages/landing/src/config.map.ts#L125

[original]: https://github.com/linz/basemaps/blob/e874e2b678ae074f344f4ce0fef6c6460fb42495/packages/landing/src/__tests__/map.config.test.ts#L204
[adjusted]: https://github.com/linz/basemaps/pull/3413/files#diff-31cb3968d74549f956e1a33e2913e003c78ea11bf84c02474b1d7241eb39ead7