### PR TITLE
release: v7.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [7.15.1](https://github.com/linz/basemaps/compare/v7.15.0...v7.15.1) (2025-03-24)
+
+
+### Bug Fixes
+
+* **landing:** update the set of labels disabled layers BM-1230 ([#3412](https://github.com/linz/basemaps/issues/3412)) ([b279694](https://github.com/linz/basemaps/commit/b2796944620071125b44d1ec0395853a8aca2dcd))
+
+
+
+
+
 # [7.15.0](https://github.com/linz/basemaps/compare/v7.14.0...v7.15.0) (2025-03-17)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
       "conventionalCommits": true
     }
   },
-  "version": "7.15.0"
+  "version": "7.15.1"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19671,7 +19671,7 @@
     },
     "packages/landing": {
       "name": "@basemaps/landing",
-      "version": "7.15.0",
+      "version": "7.15.1",
       "license": "MIT",
       "devDependencies": {
         "@basemaps/attribution": "^7.15.0",

--- a/packages/landing/CHANGELOG.md
+++ b/packages/landing/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [7.15.1](https://github.com/linz/basemaps/compare/v7.15.0...v7.15.1) (2025-03-24)
+
+
+### Bug Fixes
+
+* **landing:** update the set of labels disabled layers BM-1230 ([#3412](https://github.com/linz/basemaps/issues/3412)) ([b279694](https://github.com/linz/basemaps/commit/b2796944620071125b44d1ec0395853a8aca2dcd))
+
+
+
+
+
 # [7.15.0](https://github.com/linz/basemaps/compare/v7.14.0...v7.15.0) (2025-03-17)
 
 **Note:** Version bump only for package @basemaps/landing

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/landing",
-  "version": "7.15.0",
+  "version": "7.15.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",


### PR DESCRIPTION
## [7.15.1](https://github.com/linz/basemaps/compare/v7.15.0...v7.15.1) (2025-03-24)

### Bug Fixes

* **landing:** update the set of labels disabled layers BM-1230 ([#3412](https://github.com/linz/basemaps/issues/3412)) ([b279694](https://github.com/linz/basemaps/commit/b2796944620071125b44d1ec0395853a8aca2dcd))