### PR TITLE
feat(lambda-tiler): load config from s3

### DIFF
--- a/packages/lambda-tiler/src/routes/__tests__/fonts.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/fonts.test.ts
@@ -84,15 +84,16 @@ describe('/v1/fonts', () => {
     assert.equal(res.status, 404);
   });
 
-  it('should get the correct utf8 font with default assets', async (t) => {
+  it('should get the correct utf8 font with default assets', async () => {
     config.assets = undefined;
-    await fsa.write(new URL('memory://config.json'), JSON.stringify(config.toJson()));
+    const configJson = config.toJson();
+    await fsa.write(new URL(`memory://config-${configJson.hash}.json`), JSON.stringify(configJson));
 
     config.objects.set('cb_latest', {
       id: 'cb_latest',
       name: 'latest',
-      path: 'memory://config.json',
-      hash: 'hash',
+      path: `memory://config-${configJson.hash}.json`,
+      hash: configJson.hash,
       assets: 'memory://new-location/',
     } as BaseConfig);
 

--- a/packages/lambda-tiler/src/util/config.loader.ts
+++ b/packages/lambda-tiler/src/util/config.loader.ts
@@ -22,8 +22,9 @@ export class ConfigLoader {
     const config = getDefaultConfig();
 
     // Look up the latest config bundle out of dynamodb, then load the config from the provided path
-    const cb = await config.ConfigBundle.get(config.ConfigBundle.id('latest'));
-    if (cb == null) throw new LambdaHttpResponse(500, 'Unable to find latest configuration');
+    const cb = await config.ConfigBundle.get('cb_latest');
+    if (cb == null) return config;
+
     req?.timer.start('config:load');
 
     return CachedConfig.get(fsa.toUrl(cb.path)).then((cfg) => {


### PR DESCRIPTION
### Motivation

We currently store all of the configuration in both dynamodb and s3, inside dynamodb each config object is stored as by the config id eg `ts_aerial` in s3 all the configuration is stored a single bundle JSON file.

In DynamoDB each tileset and imagery is stored individually this can lead to a huge number of requests on dynamo as lambda functions are spun up, for instance loading the standard `ts_aerial` tile set will then load 400 imagery records for each of the individual layers inside the configuration.

This query load as lambdas are spun up can trigger throttling issues with dynamodb, the lambdas will attempt to retry the queries sometimes taking multiple seconds to load the required layers or in the worse case the lambda will hit the retry limit without successfully retrieving the layers which will trigger HTTP 500 response.

### Modifications

Lookup the current configuration id from dynamodb using the latest config bundle record `cb_latest` then load the bundled config from s3.

the `cb_latest` record will be queried on every request to validate that the latest bundle is still being used.

### Verification

Unit tests, but need to verify performance of loading directly from s3 inside of a hot lamba this needs to be deployed and then performance compared.