### PR TITLE
fix(lambda-tiler): automatically choose pipelines

### DIFF
--- a/packages/lambda-tiler/src/__tests__/config.data.ts
+++ b/packages/lambda-tiler/src/__tests__/config.data.ts
@@ -63,6 +63,24 @@ export const TileSetElevation: ConfigTileSetRaster = {
   ],
   outputs: [DefaultTerrainRgbOutput, DefaultColorRampOutput],
 };
+export const TileSetHillshadeElevation: ConfigTileSetRaster = {
+  id: 'ts_hillshade',
+  name: 'hillshade',
+  type: TileSetType.Raster,
+  description: 'hillshade__description',
+  title: 'hillshade Imagery',
+  category: 'hillshade',
+  layers: [
+    {
+      // TODO: create one band imagery to reference
+      2193: 'im_01FYWKAJ86W9P7RWM1VB62KD0H',
+      3857: 'im_01FYWKATAEK2ZTJQ2PX44Y0XNT',
+      title: 'New Zealand 8m Hillshade DEM (2012)',
+      name: 'new-zealand_hillshade_2012_dem_8m',
+    },
+  ],
+  outputs: [DefaultColorRampOutput],
+};
 
 export const Imagery2193: ConfigImagery = {
   id: 'im_01FYWKAJ86W9P7RWM1VB62KD0H',

--- a/packages/lambda-tiler/src/routes/__tests__/xyz.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/xyz.test.ts
@@ -135,7 +135,10 @@ describe('/v1/tiles', () => {
 
     const elevation = FakeData.tileSetRaster('elevation');
 
-    elevation.outputs = [{ title: 'Terrain RGB', name: 'terrain-rgb' }];
+    elevation.outputs = [
+      { title: 'Terrain RGB', name: 'terrain-rgb' },
+      { title: 'Color Ramp', name: 'color-ramp' },
+    ];
     config.put(elevation);
 
     const request = mockRequest('/v1/tiles/elevation/3857/11/2022/1283.webp', 'get', Api.header);
@@ -143,6 +146,21 @@ describe('/v1/tiles', () => {
     const res = await handler.router.handle(request);
 
     assert.equal(res.status, 404, res.statusDescription);
+  });
+
+  it('should default to the pipeline if only one pipeline is defined', async (t) => {
+    t.mock.method(ConfigLoader, 'getDefaultConfig', () => Promise.resolve(config));
+
+    const elevation = FakeData.tileSetRaster('elevation');
+
+    elevation.outputs = [{ title: 'Terrain RGB', name: 'terrain-rgb' }];
+    config.put(elevation);
+
+    const request = mockRequest('/v1/tiles/elevation/3857/11/2022/1283.webp', 'get', Api.header);
+
+    const res = await handler.router.handle(request);
+
+    assert.equal(res.status, 200, res.statusDescription);
   });
 
   it('should generate a terrain-rgb 11/2022/1283 in webp', async (t) => {

--- a/packages/lambda-tiler/src/util/validate.ts
+++ b/packages/lambda-tiler/src/util/validate.ts
@@ -125,6 +125,11 @@ export const Validate = {
    * Defaults to standard image format output if no outputs are defined on the tileset
    */
   pipeline(tileSet: ConfigTileSetRaster, tileType: string, pipeline?: string | null): ConfigTileSetRasterOutput | null {
+    // If there is only one pipeline force the use of it
+    if (tileSet.outputs?.length === 1 && pipeline == null) {
+      pipeline = tileSet.outputs[0].name;
+    }
+
     if (pipeline != null && pipeline !== 'rgba') {
       if (tileSet.outputs == null) throw new LambdaHttpResponse(404, 'TileSet has no pipelines');
       const output = tileSet.outputs.find((f) => f.name === pipeline);

--- a/packages/lambda-tiler/src/util/validate.ts
+++ b/packages/lambda-tiler/src/util/validate.ts
@@ -126,9 +126,7 @@ export const Validate = {
    */
   pipeline(tileSet: ConfigTileSetRaster, tileType: string, pipeline?: string | null): ConfigTileSetRasterOutput | null {
     // If there is only one pipeline force the use of it
-    if (tileSet.outputs?.length === 1 && pipeline == null) {
-      pipeline = tileSet.outputs[0].name;
-    }
+    if (tileSet.outputs?.length === 1 && pipeline == null) pipeline = tileSet.outputs[0].name;
 
     if (pipeline != null && pipeline !== 'rgba') {
       if (tileSet.outputs == null) throw new LambdaHttpResponse(404, 'TileSet has no pipelines');
@@ -141,7 +139,8 @@ export const Validate = {
       }
       return output;
     }
-    // If the tileset has pipelines defined the user MUST specify which one
+
+    // If the tileset has multiple pipelines defined the user MUST specify which one
     if (tileSet.outputs) {
       throw new LambdaHttpResponse(404, 'TileSet needs pipeline: ' + tileSet.outputs.map((f) => f.name).join(', '));
     }


### PR DESCRIPTION
### Motivation

If a tileset has only one output pipeline eg `color-ramp`, The user should not be required to add `?pipeline=color-ramp` when fetching a tile from the xyz api, it should default to the only pipeline in the tileset.

The basemap's UI does not currently allow the user to select the pipeline

### Modifications

Qhen there is only one pipeline automatically select it for the renderer

### Verification

Tested locally against Hillshade Igor and unit tests
