### PR TITLE
fix(tiler-sharp): when resizing preserve input data type

### DIFF
--- a/packages/tiler-sharp/src/pipeline/__tests__/pipeline.resize.test.ts
+++ b/packages/tiler-sharp/src/pipeline/__tests__/pipeline.resize.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from 'node:test';
 
 import { CompositionTiff } from '@basemaps/tiler';
 
-import { resizeBilinear } from '../pipeline.resize.js';
+import { applyCrop, resizeBilinear } from '../pipeline.resize.js';
 
 describe('resize-bilinear', () => {
   it('should round numbers when working with uint arrays', () => {
@@ -22,5 +22,28 @@ describe('resize-bilinear', () => {
 
     // All values should be rounded to 1 and not truncated down to 0
     assert.ok(ret.pixels.every((f) => f === 1));
+  });
+});
+
+describe('apply-crop', () => {
+  it('should apply a crop', () => {
+    const ret = applyCrop(
+      {
+        pixels: new Uint8Array([1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4]),
+        depth: 'uint8',
+        width: 4,
+        height: 4,
+        channels: 1,
+      },
+      { width: 2, height: 3, x: 0, y: 0 },
+    );
+
+    assert.ok(ret.pixels instanceof Uint8Array);
+    assert.equal(ret.width, 2);
+    assert.equal(ret.height, 3);
+    assert.equal(ret.channels, 1);
+    assert.equal(ret.depth, 'uint8');
+
+    assert.deepEqual(ret.pixels, new Uint8Array([1, 1, 2, 2, 3, 3]));
   });
 });

--- a/packages/tiler-sharp/src/pipeline/pipeline.resize.ts
+++ b/packages/tiler-sharp/src/pipeline/pipeline.resize.ts
@@ -71,14 +71,14 @@ export function cropResize(
 export function applyCrop(_tiff: Tiff, data: DecompressedInterleaved, crop: Size & Point): DecompressedInterleaved {
   // Cropping a image is just copying sub parts of a source image into a output image
   // loop line by line slicing the new image
-  const output = new Float32Array(crop.width * crop.height * data.channels);
+  const output = getOutputBuffer(data, { width: crop.width, height: crop.height });
   for (let y = 0; y < crop.height; y++) {
     const source = ((y + crop.y) * data.width + crop.x) * data.channels;
     const length = crop.width * data.channels;
-    output.set(data.pixels.subarray(source, source + length), y * crop.width);
+    output.pixels.set(data.pixels.subarray(source, source + length), y * crop.width);
   }
 
-  return { pixels: output, width: crop.width, height: crop.height, channels: data.channels, depth: 'float32' };
+  return output;
 }
 
 function resizeNearest(

--- a/packages/tiler-sharp/src/pipeline/pipeline.resize.ts
+++ b/packages/tiler-sharp/src/pipeline/pipeline.resize.ts
@@ -19,7 +19,7 @@ export function cropResize(
     if (cropVal == null) return data;
 
     // since there is no resize we can just copy input buffers into output buffers
-    return applyCrop(tiff, data, cropVal);
+    return applyCrop(data, cropVal);
   }
 
   // Currently very limited supported input parameters
@@ -68,7 +68,7 @@ export function cropResize(
   }
 }
 
-export function applyCrop(_tiff: Tiff, data: DecompressedInterleaved, crop: Size & Point): DecompressedInterleaved {
+export function applyCrop(data: DecompressedInterleaved, crop: Size & Point): DecompressedInterleaved {
   // Cropping a image is just copying sub parts of a source image into a output image
   // loop line by line slicing the new image
   const output = getOutputBuffer(data, { width: crop.width, height: crop.height });


### PR DESCRIPTION
### Motivation

When applying a crop on a 1-band `unit8` the crop should not change the datatype to `float32`.

Changing the data type to `float32` changes the default `color-ramp` to one used by elevation, which causes hillshades to be rendered green

Igor hillshade before Fix:

![13_7998_5185-color-ramp_before](https://github.com/user-attachments/assets/857caa96-5afb-4f0a-843c-3b70666f0063)

After Fix:
![13_7998_5185-color-ramp_after](https://github.com/user-attachments/assets/01f89a0f-1f5d-41c8-bc1a-0d0e9439f654)



### Modifications

Ensure the input data type is preserved when output datatype is made

### Verification

Unit tests and raw tiles rendered.
