### PR TITLE
perf(tiler-sharp): split greyscale  color ramps into specalized function

### DIFF
--- a/packages/tiler-sharp/src/pipeline/__tests__/pipeline.color.ramp.test.ts
+++ b/packages/tiler-sharp/src/pipeline/__tests__/pipeline.color.ramp.test.ts
@@ -4,6 +4,8 @@ import { describe, it } from 'node:test';
 import { Tiff } from '@basemaps/shared';
 import { CompositionTiff } from '@basemaps/tiler';
 
+import { ColorRamp } from '../colorize/color.ramp.js';
+import { GreyScale } from '../colorize/grey.scale.js';
 import { DecompressedInterleaved } from '../decompressor.js';
 import { PipelineColorRamp } from '../pipeline.color.ramp.js';
 
@@ -44,6 +46,34 @@ describe('pipeline.color-ramp', () => {
     assert.equal(String(output.pixels.slice(0, 4)), '0,0,0,255');
     assert.equal(String(output.pixels.slice(4, 8)), '128,128,128,255');
     assert.equal(String(output.pixels.slice(8, 12)), '255,255,255,255');
+  });
+
+  it('should create the same uint8 from greyscale:uint8 or color-ramp', () => {
+    const greyRamp = new GreyScale(0, 255);
+    const greyOut = new Uint8ClampedArray(4);
+    const colorRamp = new ColorRamp(`0 0 0 0 255\n255 255 255 255 255`);
+    const colorOut = new Uint8ClampedArray(4);
+
+    for (let i = 0; i < 255; i++) {
+      greyRamp.set(i, greyOut, 0);
+      colorRamp.set(i, colorOut, 0);
+      assert.deepEqual(greyOut, colorOut);
+    }
+  });
+
+  it('should create the same uint8 from greyscale:uint32 or color-ramp', () => {
+    const intMax = 2 ** 32 - 1;
+    const greyRamp = new GreyScale(0, intMax);
+    const greyOut = new Uint8ClampedArray(4);
+    const colorRamp = new ColorRamp(`0 0 0 0 255\n${intMax} 255 255 255 255`);
+    const colorOut = new Uint8ClampedArray(4);
+
+    const intStep = intMax / 1_000;
+    for (let i = 0; i < intMax; i += intStep) {
+      greyRamp.set(i, greyOut, 0);
+      colorRamp.set(i, colorOut, 0);
+      assert.deepEqual(greyOut, colorOut);
+    }
   });
 
   it('should color-ramp a uint32', async () => {

--- a/packages/tiler-sharp/src/pipeline/colorize/color.ramp.ts
+++ b/packages/tiler-sharp/src/pipeline/colorize/color.ramp.ts
@@ -1,0 +1,72 @@
+import { Colorizer } from './colorize.js';
+
+export class ColorRamp implements Colorizer {
+  min: number;
+  max: number;
+  ramps: { v: number; color: [number, number, number, number] }[] = [];
+  constructor(ramp: string) {
+    const ramps = ramp.trim().split('\n');
+
+    for (const ramp of ramps) {
+      const parts = ramp.trim().split(' ');
+      const numbers = parts.map(Number);
+      this.ramps.push({ v: numbers[0], color: numbers.slice(1) as [number, number, number, number] });
+    }
+
+    this.min = this.ramps[0].v;
+    this.max = this.ramps[this.ramps.length - 1].v;
+  }
+
+  set(val: number, data: Uint8ClampedArray, targetOffset: number): void {
+    // Value too small use the min color
+    if (val <= this.min) {
+      const color = this.ramps[0].color;
+      data[targetOffset] = color[0];
+      data[targetOffset + 1] = color[1];
+      data[targetOffset + 2] = color[2];
+      data[targetOffset + 3] = color[3];
+      return;
+      // Value too large use max color
+    } else if (val >= this.max) {
+      const color = this.ramps[this.ramps.length - 1].color;
+      data[targetOffset] = color[0];
+      data[targetOffset + 1] = color[1];
+      data[targetOffset + 2] = color[2];
+      data[targetOffset + 3] = color[3];
+      return;
+    }
+
+    for (let i = 0; i < this.ramps.length - 1; i++) {
+      const ramp = this.ramps[i];
+      if (val < ramp.v) continue;
+      if (ramp.v === val) {
+        const color = ramp.color;
+        data[targetOffset] = color[0];
+        data[targetOffset + 1] = color[1];
+        data[targetOffset + 2] = color[2];
+        data[targetOffset + 3] = color[3];
+        return;
+      }
+
+      const rampNext = this.ramps[i + 1];
+      if (val >= rampNext.v) continue;
+
+      const range = rampNext.v - ramp.v;
+      const offset = val - ramp.v;
+      const scale = offset / range;
+
+      const r = Math.round((rampNext.color[0] - ramp.color[0]) * scale + ramp.color[0]);
+      const g = Math.round((rampNext.color[1] - ramp.color[1]) * scale + ramp.color[1]);
+      const b = Math.round((rampNext.color[2] - ramp.color[2]) * scale + ramp.color[2]);
+      const a = Math.round((rampNext.color[3] - ramp.color[3]) * scale + ramp.color[3]);
+      data[targetOffset] = r;
+      data[targetOffset + 1] = g;
+      data[targetOffset + 2] = b;
+      data[targetOffset + 3] = a;
+      return;
+    }
+
+    // Because min/max bounds are checked first all values should fall within min-max
+    throw new Error('Ramp value assertion failure');
+  }
+}

--- a/packages/tiler-sharp/src/pipeline/colorize/colorize.ts
+++ b/packages/tiler-sharp/src/pipeline/colorize/colorize.ts
@@ -1,0 +1,10 @@
+export interface Colorizer {
+  /**
+   * create a RGBA color for a given value, then set the RGBA at the target offset
+   *
+   * @param val Data value
+   * @param data pixel data to set the color in
+   * @param targetOffset Offset to set the color at
+   */
+  set(val: number, data: Uint8ClampedArray, targetOffset: number): void;
+}

--- a/packages/tiler-sharp/src/pipeline/colorize/grey.scale.ts
+++ b/packages/tiler-sharp/src/pipeline/colorize/grey.scale.ts
@@ -1,0 +1,23 @@
+import { Colorizer } from './colorize.js';
+
+/**
+ * Convert a number between min and max into a RGBA between 0 and 255
+ */
+export class GreyScale implements Colorizer {
+  min: number;
+  max: number;
+
+  constructor(minVal: number, maxVal: number) {
+    this.min = minVal;
+    this.max = maxVal;
+  }
+
+  set(val: number, data: Uint8ClampedArray, targetOffset: number): void {
+    const scaledValue = ((val - this.min) * 255) / (this.max - this.min);
+
+    data[targetOffset] = scaledValue;
+    data[targetOffset + 1] = scaledValue;
+    data[targetOffset + 2] = scaledValue;
+    data[targetOffset + 3] = 255;
+  }
+}


### PR DESCRIPTION
### Motivation

Currently when expanding a `uint8` color into a 4-band RGBA `uint8,uint8,uint8,uint8` the `color-ramp` is used which is not designed for a direct color mapping. 

For a 1024x1024 tile the current color ramp implementation takes approx 7ms to convert a 1-band to 4 band grey scale, using a direct band expansion drops the time taken to approx 1ms.

This pull requests creates a simple color mapper where given a input value (eg 240) it is propagated to the R,G and B bands of the output eg `240,240,240` creating a grey scale image from a one band input.


### Modifications

Create a specialised `Colorizer` for one band inputs that is significantly (5x) faster than  using a color ramp directly

### Verification

Unit tests to validate inputs and outputs are the same between implementations
