### PR TITLE
fix(landing): support viewing CITM2000Quad

### DIFF
--- a/packages/geo/src/index.ts
+++ b/packages/geo/src/index.ts
@@ -12,6 +12,7 @@ export { AttributionCollection, AttributionItem, AttributionStac } from './stac/
 export { TileId } from './tile.js';
 export { TileJson, TileJsonV3, TileJsonVectorLayer } from './tile.json/tile.json.js';
 export { Tile, TileMatrixSet } from './tile.matrix.set.js';
+export { Citm2000Tms } from './tms/citm2000.js';
 export { GoogleTms } from './tms/google.js';
 export { TileMatrixSets } from './tms/index.js';
 export { Nztm2000QuadTms, Nztm2000Tms } from './tms/nztm2000.js';

--- a/packages/landing/src/components/map.switcher.tsx
+++ b/packages/landing/src/components/map.switcher.tsx
@@ -3,7 +3,7 @@ import { Component, ReactNode } from 'react';
 
 import { Config, GaEvent, gaEvent } from '../config.js';
 import { MapConfig } from '../config.map.js';
-import { getTileGrid } from '../tile.matrix.js';
+import { getTileGridStyle } from '../tile.matrix.js';
 import { onMapLoaded } from './map.js';
 
 export class MapSwitcher extends Component {
@@ -19,12 +19,11 @@ export class MapSwitcher extends Component {
 
     if (this.el == null) return;
     const cfg = Config.map;
-    const tileGrid = getTileGrid(cfg.tileMatrix.identifier);
 
     const target = this.getStyleType();
     this.currentStyle = `${target.layerId}::${target.style}`;
 
-    const style = tileGrid.getStyle({ layerId: target.layerId, style: target.style });
+    const style = getTileGridStyle(cfg.tileMatrix, { layerId: target.layerId, style: target.style });
     const location = cfg.transformedLocation;
 
     this.map = new maplibre.Map({
@@ -70,8 +69,7 @@ export class MapSwitcher extends Component {
     const target = this.getStyleType();
     const styleId = `${target.layerId}::${target.style}`;
     if (this.currentStyle !== styleId) {
-      const tileGrid = getTileGrid(Config.map.tileMatrix.identifier);
-      const style = tileGrid.getStyle({ layerId: target.layerId, style: target.style });
+      const style = getTileGridStyle(Config.map.tileMatrix, { layerId: target.layerId, style: target.style });
       this.currentStyle = styleId;
       this.map.setStyle(style);
     }

--- a/packages/landing/src/components/map.tsx
+++ b/packages/landing/src/components/map.tsx
@@ -5,7 +5,7 @@ import { Component, ReactNode } from 'react';
 
 import { MapAttribution } from '../attribution.js';
 import { Config } from '../config.js';
-import { getTileGrid, locationTransform } from '../tile.matrix.js';
+import { getTileGridStyle, locationTransform } from '../tile.matrix.js';
 import { Debug } from './debug.js';
 import { MapLabelControl } from './map.label.js';
 import { MapSwitcher } from './map.switcher.js';
@@ -134,8 +134,7 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
     this.ensureGeoControl();
     this.ensureScaleControl();
     this.ensureElevationControl();
-    const tileGrid = getTileGrid(Config.map.tileMatrix.identifier);
-    const style = tileGrid.getStyle(Config.map);
+    const style = getTileGridStyle(Config.map.tileMatrix, Config.map);
     this.map.setStyle(style);
     if (Config.map.tileMatrix !== GoogleTms) {
       this.map.setMaxBounds([-179.9, -85, 179.9, 85]);
@@ -153,8 +152,7 @@ export class Basemaps extends Component<unknown, { isLayerSwitcherEnabled: boole
 
     if (this.el == null) throw new Error('Unable to find #map element');
     const cfg = Config.map;
-    const tileGrid = getTileGrid(cfg.tileMatrix.identifier);
-    const style = tileGrid.getStyle(Config.map);
+    const style = getTileGridStyle(Config.map.tileMatrix, Config.map);
     const location = locationTransform(cfg.location, cfg.tileMatrix, GoogleTms);
 
     this.map = new maplibre.Map({

--- a/packages/landing/src/tile.matrix.ts
+++ b/packages/landing/src/tile.matrix.ts
@@ -1,4 +1,5 @@
 import { GoogleTms, Nztm2000QuadTms, Nztm2000Tms, Projection, TileMatrixSet } from '@basemaps/geo';
+import { Citm2000Tms } from '@basemaps/geo/src/tms/citm2000.js';
 import { BBox } from '@linzjs/geojson';
 import { StyleSpecification } from 'maplibre-gl';
 
@@ -13,12 +14,18 @@ export interface TileGridStyle {
   labels?: boolean | null;
 }
 
+// find the WebMercatorQuad zoom level that is closes to z0 of the provided matrix
+function findOffset(tileMatrix: TileMatrixSet): number {
+  const firstScale = tileMatrix.def.tileMatrix[0].scaleDenominator;
+  return GoogleTms.def.tileMatrix.findIndex((f) => Math.abs(f.scaleDenominator - firstScale) < 1e-5);
+}
+
 export class TileGrid {
   tileMatrix: TileMatrixSet;
   extraZoomLevels: number;
-  constructor(tileMatrix: TileMatrixSet, extraZoomLevels = 0) {
+  constructor(tileMatrix: TileMatrixSet) {
     this.tileMatrix = tileMatrix;
-    this.extraZoomLevels = extraZoomLevels;
+    this.extraZoomLevels = findOffset(tileMatrix);
   }
 
   getStyle(cfg: TileGridStyle): StyleSpecification | string {
@@ -34,11 +41,12 @@ export class TileGrid {
   }
 }
 
-const Nztm2000TileGrid = new TileGrid(Nztm2000Tms, 2);
+const Citm2000TileGrid = new TileGrid(Citm2000Tms);
+const Nztm2000TileGrid = new TileGrid(Nztm2000Tms);
 const Nztm2000QuadTileGrid = new TileGrid(Nztm2000QuadTms);
 const GoogleTileGrid = new TileGrid(GoogleTms);
 
-const Grids = [Nztm2000TileGrid, Nztm2000QuadTileGrid, GoogleTileGrid];
+const Grids = [Nztm2000TileGrid, Nztm2000QuadTileGrid, Citm2000TileGrid, GoogleTileGrid];
 
 export function getTileGrid(id: string): TileGrid {
   for (const g of Grids) {

--- a/packages/landing/src/tile.matrix.ts
+++ b/packages/landing/src/tile.matrix.ts
@@ -1,7 +1,5 @@
-import { GoogleTms, Nztm2000QuadTms, Nztm2000Tms, Projection, TileMatrixSet } from '@basemaps/geo';
-import { Citm2000Tms } from '@basemaps/geo/src/tms/citm2000.js';
+import { GoogleTms, Projection, TileMatrixSet } from '@basemaps/geo';
 import { BBox } from '@linzjs/geojson';
-import { StyleSpecification } from 'maplibre-gl';
 
 import { Config } from './config.js';
 import { MapLocation, MapOptionType, WindowUrl } from './url.js';
@@ -14,45 +12,16 @@ export interface TileGridStyle {
   labels?: boolean | null;
 }
 
-// find the WebMercatorQuad zoom level that is closes to z0 of the provided matrix
-function findOffset(tileMatrix: TileMatrixSet): number {
-  const firstScale = tileMatrix.def.tileMatrix[0].scaleDenominator;
-  return GoogleTms.def.tileMatrix.findIndex((f) => Math.abs(f.scaleDenominator - firstScale) < 1e-5);
-}
-
-export class TileGrid {
-  tileMatrix: TileMatrixSet;
-  extraZoomLevels: number;
-  constructor(tileMatrix: TileMatrixSet) {
-    this.tileMatrix = tileMatrix;
-    this.extraZoomLevels = findOffset(tileMatrix);
-  }
-
-  getStyle(cfg: TileGridStyle): StyleSpecification | string {
-    return WindowUrl.toTileUrl({
-      urlType: MapOptionType.Style,
-      tileMatrix: this.tileMatrix,
-      layerId: cfg.layerId,
-      style: cfg.style,
-      config: cfg.config ?? Config.map.config,
-      terrain: cfg.terrain ?? Config.map.terrain,
-      labels: cfg.labels ?? Config.map.labels,
-    });
-  }
-}
-
-const Citm2000TileGrid = new TileGrid(Citm2000Tms);
-const Nztm2000TileGrid = new TileGrid(Nztm2000Tms);
-const Nztm2000QuadTileGrid = new TileGrid(Nztm2000QuadTms);
-const GoogleTileGrid = new TileGrid(GoogleTms);
-
-const Grids = [Nztm2000TileGrid, Nztm2000QuadTileGrid, Citm2000TileGrid, GoogleTileGrid];
-
-export function getTileGrid(id: string): TileGrid {
-  for (const g of Grids) {
-    if (id === g.tileMatrix.identifier) return g;
-  }
-  return GoogleTileGrid;
+export function getTileGridStyle(tileMatrixSet: TileMatrixSet, cfg: TileGridStyle): string {
+  return WindowUrl.toTileUrl({
+    urlType: MapOptionType.Style,
+    tileMatrix: tileMatrixSet,
+    layerId: cfg.layerId,
+    style: cfg.style,
+    config: cfg.config ?? Config.map.config,
+    terrain: cfg.terrain ?? Config.map.terrain,
+    labels: cfg.labels ?? Config.map.labels,
+  });
 }
 
 function isGoogle(tms: TileMatrixSet): boolean {


### PR DESCRIPTION
### Motivation

We have datasets in CITM2000 we need a way to easily view them in CITM2000, the landing page as it uses maplibre needs to have custom projection logic for each tile matrix it uses, which is currently hardcoded and missing CITM

### Modifications

Remove the hard coded list of projections from the landing page, reusing the existing list that the server supports.

### Verification

Tested locally with CITM2000 imagery from 1982 
![image](https://github.com/user-attachments/assets/79eab91e-edae-4fb0-841c-cb0e05441489)

