### PR TITLE
feat(landing): change text 90day api keys to single user api keys BM-1181

### DIFF
--- a/packages/landing/src/components/layout.header.tsx
+++ b/packages/landing/src/components/layout.header.tsx
@@ -159,9 +159,12 @@ Your Service/App URL:
   renderLinks(): ReactNode {
     return (
       <Fragment>
-        <h6>90 day API keys</h6>
-        <p>API keys expire after 90 days, if a longer duration is needed please request a developer API key</p>
-        <Copyable header="Api Key" value={Config.ApiKey} />
+        <h6>Individual API keys</h6>
+        <p>
+          These API keys are for individual users. For use in shared or public maps, apps or tools, please request a
+          free Developer API key.
+        </p>
+        <Copyable header="API Key" value={Config.ApiKey} />
         {this.renderLinksTiles()}
       </Fragment>
     );


### PR DESCRIPTION
### Motivation

API keys not expiring after 90 days, make that clear in the UI

### Modifications

Updated text from `API keys expire after 90 days, if a longer duration is needed please request a developer API key` to `These API keys are for individual users. For use in shared or public maps, apps or tools, please request a free Developer API key.`

### Verification

| Before | After |
| - | - |
| ![][img_before] | ![][img_after] |

[dsm-config]: https://github.com/linz/basemaps-config/blob/master/config/tileset/elevation.dsm.json

[img_before]: https://github.com/user-attachments/assets/10649af1-cf5e-433c-82b1-c69326303135
[img_after]: https://github.com/user-attachments/assets/565aaf45-c692-4a89-9408-90948aedb1f4

