### PR TITLE
feat(landing): add dsm to layer dropdown BM-1248

### DIFF
--- a/packages/landing/src/config.map.ts
+++ b/packages/landing/src/config.map.ts
@@ -413,8 +413,17 @@ function addDefaultLayers(output: Map<string, LayerInfo>): void {
 
     {
       id: 'elevation',
-      title: 'Elevation',
+      title: 'Elevation DEM',
       projections: new Set([EpsgCode.Google]),
+      category: 'Basemaps',
+      pipeline: 'terrain-rgb',
+      imageFormat: 'png',
+    },
+
+    {
+      id: 'elevation-dsm',
+      title: 'Elevation DSM',
+      projections: new Set([EpsgCode.Nztm2000, EpsgCode.Google]),
       category: 'Basemaps',
       pipeline: 'terrain-rgb',
       imageFormat: 'png',

--- a/packages/landing/src/config.map.ts
+++ b/packages/landing/src/config.map.ts
@@ -423,7 +423,7 @@ function addDefaultLayers(output: Map<string, LayerInfo>): void {
     {
       id: 'elevation-dsm',
       title: 'Elevation DSM',
-      projections: new Set([EpsgCode.Nztm2000, EpsgCode.Google]),
+      projections: new Set([EpsgCode.Google]),
       category: 'Basemaps',
       pipeline: 'terrain-rgb',
       imageFormat: 'png',


### PR DESCRIPTION
### Motivation

We've recently published an [Elevation DSM Basemap][dsm-config]. This work add a new "Elevation DSM" entry to the `Layers` dropdown, so that customers can view the new Basemap in our application.

### Modifications

1. Added a new "Elevation DSM" entry to the `Layers` dropdown.
2. Renamed the existing "Elevation" entry to "Elevation DEM".

### Verification

| Before | After |
| - | - |
| ![][img_before] | ![][img_after] |

[dsm-config]: https://github.com/linz/basemaps-config/blob/master/config/tileset/elevation.dsm.json

[img_before]: https://github.com/user-attachments/assets/1cf65ae8-fd0d-4f95-9590-709a57723aba
[img_after]: https://github.com/user-attachments/assets/e68dbba3-0d09-43ec-8d30-5ebaf1ec9cad