### PR TITLE
feat(landing): add the dsm elevation tileset as a default elevation and hillshade debug option BM-1247

### DIFF
--- a/packages/landing/src/components/debug.tsx
+++ b/packages/landing/src/components/debug.tsx
@@ -29,8 +29,9 @@ export interface DebugState {
 const HillShadeLayerId = 'debug-hillshade';
 /** dynamic hillshade sources are prefixed with this key */
 const HillShadePrefix = '__hillshade-';
-/** dynamic linz-elevation source key */
-const elevationProdId = 'LINZ-Terrain-Prod';
+/** dynamic linz-elevation source keys */
+const elevationDemProdId = 'LINZ-Elevation-DEM-Prod';
+const elevationDsmProdId = 'LINZ-Elevation-DSM-Prod';
 
 interface DropDownContext {
   /** Label for the drop down */
@@ -242,8 +243,8 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
         {this.renderCaptureAreaToggle()}
         {this.renderTileToggle()}
         {this.renderRasterSourceDropdown()}
-        {this.renderDemSourceDropdown(demSources)}
-        {this.renderDemHillShadeSourceDropdown(demSources)}
+        {this.renderElevationSourceDropdown(demSources)}
+        {this.renderHillShadeSourceDropdown(demSources)}
       </div>
     );
   }
@@ -367,12 +368,13 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
   }
 
   /**
-   * Add a terrain source that points to production elevation data for debug
+   * Add terrain sources that point to production elevation tilesets
    */
   ensureElevationProd(): void {
     const map = this.props.map;
-    // Enable default linz-elevation terrain
-    if (map.getSource(elevationProdId) == null) {
+
+    // Enable default linz-elevation (dem)
+    if (map.getSource(elevationDemProdId) == null) {
       const url = WindowUrl.toTileUrl({
         urlType: MapOptionType.TileRaster,
         tileMatrix: Config.map.tileMatrix,
@@ -380,7 +382,23 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
         pipeline: 'terrain-rgb',
         imageFormat: 'png',
       });
-      map.addSource(elevationProdId, {
+      map.addSource(elevationDemProdId, {
+        type: 'raster-dem',
+        tiles: [url],
+        tileSize: 256,
+      });
+    }
+
+    // Enable default linz-elevation (dsm)
+    if (map.getSource(elevationDsmProdId) == null) {
+      const url = WindowUrl.toTileUrl({
+        urlType: MapOptionType.TileRaster,
+        tileMatrix: Config.map.tileMatrix,
+        layerId: 'elevation-dsm',
+        pipeline: 'terrain-rgb',
+        imageFormat: 'png',
+      });
+      map.addSource(elevationDsmProdId, {
         type: 'raster-dem',
         tiles: [url],
         tileSize: 256,
@@ -521,7 +539,7 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
     });
   }
 
-  renderDemSourceDropdown(sourceIds: string[]): ReactNode | null {
+  renderElevationSourceDropdown(sourceIds: string[]): ReactNode | null {
     if (sourceIds.length === 0) return;
     return debugSourceDropdown({
       label: 'Elevation',
@@ -531,7 +549,7 @@ export class Debug extends Component<{ map: maplibregl.Map }, DebugState> {
     });
   }
 
-  renderDemHillShadeSourceDropdown(sourceIds: string[]): ReactNode | null {
+  renderHillShadeSourceDropdown(sourceIds: string[]): ReactNode | null {
     if (sourceIds.length === 0) return;
     return debugSourceDropdown({
       label: 'Hillshade',


### PR DESCRIPTION
### Motivation

We have recently published a new [DSM Elevation tileset]. This works adds the tileset to the **Elevation** and **Hillshade** dropdown components as a default option, when viewing Basemaps in `debug` mode.

| Debug Page: Dropdowns |
| - |
| ![][dropdowns] |

[dropdowns]: https://github.com/user-attachments/assets/20423505-892c-4d45-884c-8a8ca806f5a5

### Modifications

1. Adds the DSM Elevation Tileset to the map as a `raster-dem` source. This ensures that both the **Elevation** and **Hillshade** dropdown components capture the source as one their default options.

2. Renamed the existing `Linz-Terrain-Prod` option to `Linz-Elevation-DEM-Prod`. This option represents the existing DEM Elevation tileset.

3. Refactors some comments and function names to consider that there are now two (DEM and DSM) elevation sources.

### Verification

#### 1. Dropdown Components

Each dropdown component includes both two elevation sources as default options:

| Dropdown | Before | After |
| - | - | - |
| Elevation | ![][el_dd_before] | ![][el_dd_after] |
| Hillshade | ![][hs_dd_before] | ![][hs_dd_after] |

[el_dd_before]: https://github.com/user-attachments/assets/f6d15b93-bafc-4405-b61b-87f2a713cd86
[hs_dd_before]: https://github.com/user-attachments/assets/6cc0be0f-29eb-40a8-9508-06523f79fe40

[el_dd_after]: https://github.com/user-attachments/assets/b71ddc67-1e11-4088-9415-1f3b5d54619e
[hs_dd_after]: https://github.com/user-attachments/assets/f1d0a60f-8874-49ac-b117-c126ed7314b6

Note the rename of the existing `Linz-Terrain-Prod` option to `Linz-Elevation-DEM-Prod` as mentioned earlier.

#### 2. Elevation Sources

When selected, each elevation option applies its corresponding source to the map as expected:

| [DEM][local_el_dem] | [DSM][local_el_dsm] |
| - | - |
| ![][el_dem] | ![][el_dsm] |

[el_dem]: https://github.com/user-attachments/assets/34abb16e-0b70-4b3f-8a19-845511972b95
[local_el_dem]: http://localhost:5000/@-41.2883882,174.7760546,z16.51,b-80,p78?debug=true&debug.terrain=LINZ-Elevation-DEM-Prod

[el_dsm]: https://github.com/user-attachments/assets/b4eb3f2b-299e-414a-b070-23a8f7c89515
[local_el_dsm]: http://localhost:5000/@-41.2883882,174.7760546,z16.51,b-80,p78?debug=true&debug.terrain=LINZ-Elevation-DSM-Prod

#### 3. Hillshade Sources

When selected, each hillshade option applies its corresponding source to the map as expected:

| [DEM][local_hs_dem] | [DSM][local_hs_dsm] |
| - | - |
| ![][hs_dem] | ![][hs_dsm] |

I've enabled the **Topographic** imagery overlay so that each hillshade is easier to see.

[hs_dem]: https://github.com/user-attachments/assets/102481c8-3259-467c-83d4-f55a5be10b72
[local_hs_dem]: http://localhost:5000/@-41.2932725,174.7705096,z15?debug=true&debug.layer.linz-topographic=1&debug.hillshade=LINZ-Elevation-DEM-Prod

[hs_dsm]: https://github.com/user-attachments/assets/78110dc9-3e47-4b1c-b5c3-0bda082bfbc1
[local_hs_dsm]: http://localhost:5000/@-41.2932725,174.7705096,z15?debug=true&debug.layer.linz-topographic=1&debug.hillshade=LINZ-Elevation-DSM-Prod

[DSM Elevation tileset]: https://github.com/linz/basemaps-config/pull/1065
