### PR TITLE
release: v7.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,33 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.16.0](https://github.com/linz/basemaps/compare/v7.15.1...v7.16.0) (2025-04-07)
+
+
+### Bug Fixes
+
+* **lambda-tiler:** automatically choose pipelines ([#3416](https://github.com/linz/basemaps/issues/3416)) ([c206a8e](https://github.com/linz/basemaps/commit/c206a8e0a579bd542afa43f6a3186c88bf6a451c))
+* **landing:** fix developer api keys title BM-1181 ([#3423](https://github.com/linz/basemaps/issues/3423)) ([4066b31](https://github.com/linz/basemaps/commit/4066b3153dc5bce70e4e0ccab7286d98c108c16c))
+* **landing:** support viewing CITM2000Quad ([#3419](https://github.com/linz/basemaps/issues/3419)) ([10df2aa](https://github.com/linz/basemaps/commit/10df2aa0a91391435d5a02283e8706bd19700d86))
+* **tiler-sharp:** when resizing preserve input data type ([#3417](https://github.com/linz/basemaps/issues/3417)) ([41e0c38](https://github.com/linz/basemaps/commit/41e0c385c0c8d8e8c29a48c20c611a11da32810a))
+
+
+### Features
+
+* **lambda-tiler:** load config from s3 ([#3415](https://github.com/linz/basemaps/issues/3415)) ([e6b89c3](https://github.com/linz/basemaps/commit/e6b89c3c941c15b8fe2adcb0189a9fed46cbe024))
+* **landing:** add dsm to layer dropdown BM-1248 ([#3421](https://github.com/linz/basemaps/issues/3421)) ([b830dff](https://github.com/linz/basemaps/commit/b830dffd5393461ad1c424f673c05e96c4196231))
+* **landing:** add the dsm elevation tileset as a default elevation and hillshade debug option BM-1247 ([#3422](https://github.com/linz/basemaps/issues/3422)) ([1e529a5](https://github.com/linz/basemaps/commit/1e529a50410b2e0137e67c7b3a1f7860f1694a8f))
+* **landing:** change text 90day api keys to single user api keys BM-1181 ([#3420](https://github.com/linz/basemaps/issues/3420)) ([215da68](https://github.com/linz/basemaps/commit/215da68fd7fd874f110a0c09180dc296f611fb59))
+
+
+### Performance Improvements
+
+* **tiler-sharp:** split greyscale  color ramps into specalized function ([#3418](https://github.com/linz/basemaps/issues/3418)) ([30755fd](https://github.com/linz/basemaps/commit/30755fd8c2098b800405d8395058544704c27b21))
+
+
+
+
+
 ## [7.15.1](https://github.com/linz/basemaps/compare/v7.15.0...v7.15.1) (2025-03-24)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
       "conventionalCommits": true
     }
   },
-  "version": "7.15.1"
+  "version": "7.16.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19378,13 +19378,13 @@
     },
     "packages/_infra": {
       "name": "@basemaps/infra",
-      "version": "7.15.0",
+      "version": "7.16.0",
       "license": "MIT",
       "devDependencies": {
         "@aws-sdk/client-acm": "^3.470.0",
         "@aws-sdk/client-cloudformation": "^3.470.0",
-        "@basemaps/lambda-tiler": "^7.15.0",
-        "@basemaps/shared": "^7.15.0",
+        "@basemaps/lambda-tiler": "^7.16.0",
+        "@basemaps/shared": "^7.16.0",
         "@linzjs/cdk-tags": "^1.7.0",
         "aws-cdk": "2.162.x",
         "aws-cdk-lib": "2.162.x",
@@ -19396,10 +19396,10 @@
     },
     "packages/attribution": {
       "name": "@basemaps/attribution",
-      "version": "7.15.0",
+      "version": "7.16.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/geo": "^7.15.0",
+        "@basemaps/geo": "^7.16.0",
         "@linzjs/geojson": "^7.10.0"
       },
       "engines": {
@@ -19408,12 +19408,12 @@
     },
     "packages/bathymetry": {
       "name": "@basemaps/bathymetry",
-      "version": "7.15.0",
+      "version": "7.16.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/cli": "^7.15.0",
-        "@basemaps/geo": "^7.15.0",
-        "@basemaps/shared": "^7.15.0",
+        "@basemaps/cli": "^7.16.0",
+        "@basemaps/geo": "^7.16.0",
+        "@basemaps/shared": "^7.16.0",
         "@rushstack/ts-command-line": "^4.3.13",
         "ulid": "^2.3.0"
       },
@@ -19436,16 +19436,16 @@
     },
     "packages/cli": {
       "name": "@basemaps/cli",
-      "version": "7.15.0",
+      "version": "7.16.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^7.15.0",
-        "@basemaps/config-loader": "^7.15.0",
-        "@basemaps/geo": "^7.15.0",
-        "@basemaps/server": "^7.15.0",
-        "@basemaps/shared": "^7.15.0",
-        "@basemaps/tiler": "^7.15.0",
-        "@basemaps/tiler-sharp": "^7.15.0",
+        "@basemaps/config": "^7.16.0",
+        "@basemaps/config-loader": "^7.16.0",
+        "@basemaps/geo": "^7.16.0",
+        "@basemaps/server": "^7.16.0",
+        "@basemaps/shared": "^7.16.0",
+        "@basemaps/tiler": "^7.16.0",
+        "@basemaps/tiler-sharp": "^7.16.0",
         "@chunkd/source-memory": "^11.0.2",
         "@cotar/builder": "^6.0.1",
         "@cotar/tar": "^6.0.1",
@@ -19499,17 +19499,17 @@
     },
     "packages/cogify": {
       "name": "@basemaps/cogify",
-      "version": "7.15.0",
+      "version": "7.16.0",
       "license": "MIT",
       "bin": {
         "cogify": "build/bin.js"
       },
       "devDependencies": {
-        "@basemaps/cli": "^7.15.0",
-        "@basemaps/config": "^7.15.0",
-        "@basemaps/config-loader": "^7.15.0",
-        "@basemaps/geo": "^7.15.0",
-        "@basemaps/shared": "^7.15.0",
+        "@basemaps/cli": "^7.16.0",
+        "@basemaps/config": "^7.16.0",
+        "@basemaps/config-loader": "^7.16.0",
+        "@basemaps/geo": "^7.16.0",
+        "@basemaps/shared": "^7.16.0",
         "cmd-ts": "^0.12.1",
         "p-limit": "^4.0.0",
         "stac-ts": "^1.0.0"
@@ -19520,10 +19520,10 @@
     },
     "packages/config": {
       "name": "@basemaps/config",
-      "version": "7.15.0",
+      "version": "7.16.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/geo": "^7.15.0",
+        "@basemaps/geo": "^7.16.0",
         "base-x": "^4.0.0",
         "zod": "^3.17.3"
       },
@@ -19533,12 +19533,12 @@
     },
     "packages/config-loader": {
       "name": "@basemaps/config-loader",
-      "version": "7.15.0",
+      "version": "7.16.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^7.15.0",
-        "@basemaps/geo": "^7.15.0",
-        "@basemaps/shared": "^7.15.0"
+        "@basemaps/config": "^7.16.0",
+        "@basemaps/geo": "^7.16.0",
+        "@basemaps/shared": "^7.16.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -19546,7 +19546,7 @@
     },
     "packages/geo": {
       "name": "@basemaps/geo",
-      "version": "7.15.0",
+      "version": "7.16.0",
       "license": "MIT",
       "dependencies": {
         "@linzjs/tile-matrix-set": "^0.0.1",
@@ -19569,12 +19569,12 @@
     },
     "packages/lambda-analytic-cloudfront": {
       "name": "@basemaps/lambda-analytic-cloudfront",
-      "version": "7.15.0",
+      "version": "7.16.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^7.15.0",
-        "@basemaps/geo": "^7.15.0",
-        "@basemaps/shared": "^7.15.0",
+        "@basemaps/config": "^7.16.0",
+        "@basemaps/geo": "^7.16.0",
+        "@basemaps/shared": "^7.16.0",
         "@elastic/elasticsearch": "^8.16.2",
         "@linzjs/lambda": "^4.0.0",
         "ua-parser-js": "^1.0.39"
@@ -19588,12 +19588,12 @@
     },
     "packages/lambda-analytics": {
       "name": "@basemaps/lambda-analytics",
-      "version": "7.15.0",
+      "version": "7.16.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^7.15.0",
-        "@basemaps/geo": "^7.15.0",
-        "@basemaps/shared": "^7.15.0",
+        "@basemaps/config": "^7.16.0",
+        "@basemaps/geo": "^7.16.0",
+        "@basemaps/shared": "^7.16.0",
         "ua-parser-js": "^1.0.2"
       },
       "devDependencies": {
@@ -19605,15 +19605,15 @@
     },
     "packages/lambda-tiler": {
       "name": "@basemaps/lambda-tiler",
-      "version": "7.15.0",
+      "version": "7.16.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^7.15.0",
-        "@basemaps/config-loader": "^7.15.0",
-        "@basemaps/geo": "^7.15.0",
-        "@basemaps/shared": "^7.15.0",
-        "@basemaps/tiler": "^7.15.0",
-        "@basemaps/tiler-sharp": "^7.15.0",
+        "@basemaps/config": "^7.16.0",
+        "@basemaps/config-loader": "^7.16.0",
+        "@basemaps/geo": "^7.16.0",
+        "@basemaps/shared": "^7.16.0",
+        "@basemaps/tiler": "^7.16.0",
+        "@basemaps/tiler-sharp": "^7.16.0",
         "@linzjs/geojson": "^7.10.0",
         "@linzjs/lambda": "^4.0.0",
         "@mapbox/vector-tile": "^2.0.3",
@@ -19623,7 +19623,7 @@
         "sharp": "^0.33.0"
       },
       "devDependencies": {
-        "@basemaps/attribution": "^7.15.0",
+        "@basemaps/attribution": "^7.16.0",
         "@chunkd/fs": "^11.2.0",
         "@types/aws-lambda": "^8.10.75",
         "@types/pixelmatch": "^5.0.0",
@@ -19671,14 +19671,14 @@
     },
     "packages/landing": {
       "name": "@basemaps/landing",
-      "version": "7.15.1",
+      "version": "7.16.0",
       "license": "MIT",
       "devDependencies": {
-        "@basemaps/attribution": "^7.15.0",
-        "@basemaps/config": "^7.15.0",
-        "@basemaps/geo": "^7.15.0",
-        "@basemaps/infra": "^7.15.0",
-        "@basemaps/shared": "^7.15.0",
+        "@basemaps/attribution": "^7.16.0",
+        "@basemaps/config": "^7.16.0",
+        "@basemaps/geo": "^7.16.0",
+        "@basemaps/infra": "^7.16.0",
+        "@basemaps/shared": "^7.16.0",
         "@linzjs/lui": "^21.46.0",
         "@servie/events": "^3.0.0",
         "@types/proj4": "^2.5.2",
@@ -19744,7 +19744,7 @@
     },
     "packages/server": {
       "name": "@basemaps/server",
-      "version": "7.15.0",
+      "version": "7.16.0",
       "license": "MIT",
       "dependencies": {
         "lerc": "^4.0.4",
@@ -19754,12 +19754,12 @@
         "basemaps-server": "bin/basemaps-server.cjs"
       },
       "devDependencies": {
-        "@basemaps/config": "^7.15.0",
-        "@basemaps/config-loader": "^7.15.0",
-        "@basemaps/geo": "^7.15.0",
-        "@basemaps/lambda-tiler": "^7.15.0",
+        "@basemaps/config": "^7.16.0",
+        "@basemaps/config-loader": "^7.16.0",
+        "@basemaps/geo": "^7.16.0",
+        "@basemaps/lambda-tiler": "^7.16.0",
         "@basemaps/landing": "^6.39.0",
-        "@basemaps/shared": "^7.15.0",
+        "@basemaps/shared": "^7.16.0",
         "@fastify/formbody": "^7.0.1",
         "@fastify/static": "^6.5.0",
         "cmd-ts": "^0.12.1",
@@ -19784,14 +19784,14 @@
     },
     "packages/shared": {
       "name": "@basemaps/shared",
-      "version": "7.15.0",
+      "version": "7.16.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.470.0",
         "@aws-sdk/client-s3": "^3.472.0",
         "@aws-sdk/util-dynamodb": "^3.470.0",
-        "@basemaps/config": "^7.15.0",
-        "@basemaps/geo": "^7.15.0",
+        "@basemaps/config": "^7.16.0",
+        "@basemaps/geo": "^7.16.0",
         "@chunkd/fs": "^11.2.0",
         "@chunkd/fs-aws": "^11.3.0",
         "@chunkd/middleware": "^11.1.0",
@@ -19849,10 +19849,10 @@
     },
     "packages/tiler": {
       "name": "@basemaps/tiler",
-      "version": "7.15.0",
+      "version": "7.16.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/geo": "^7.15.0",
+        "@basemaps/geo": "^7.16.0",
         "@cogeotiff/core": "^9.0.3",
         "@linzjs/metrics": "^7.5.0"
       },
@@ -19868,12 +19868,12 @@
     },
     "packages/tiler-sharp": {
       "name": "@basemaps/tiler-sharp",
-      "version": "7.15.0",
+      "version": "7.16.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^7.15.0",
-        "@basemaps/geo": "^7.15.0",
-        "@basemaps/tiler": "^7.15.0",
+        "@basemaps/config": "^7.16.0",
+        "@basemaps/geo": "^7.16.0",
+        "@basemaps/tiler": "^7.16.0",
         "@linzjs/metrics": "^7.5.0",
         "lerc": "^4.0.4"
       },

--- a/packages/_infra/CHANGELOG.md
+++ b/packages/_infra/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.16.0](https://github.com/linz/basemaps/compare/v7.15.1...v7.16.0) (2025-04-07)
+
+**Note:** Version bump only for package @basemaps/infra
+
+
+
+
+
 # [7.15.0](https://github.com/linz/basemaps/compare/v7.14.0...v7.15.0) (2025-03-17)
 
 **Note:** Version bump only for package @basemaps/infra

--- a/packages/_infra/package.json
+++ b/packages/_infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/infra",
-  "version": "7.15.0",
+  "version": "7.16.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -26,8 +26,8 @@
   "devDependencies": {
     "@aws-sdk/client-acm": "^3.470.0",
     "@aws-sdk/client-cloudformation": "^3.470.0",
-    "@basemaps/lambda-tiler": "^7.15.0",
-    "@basemaps/shared": "^7.15.0",
+    "@basemaps/lambda-tiler": "^7.16.0",
+    "@basemaps/shared": "^7.16.0",
     "@linzjs/cdk-tags": "^1.7.0",
     "aws-cdk": "2.162.x",
     "aws-cdk-lib": "2.162.x",

--- a/packages/attribution/CHANGELOG.md
+++ b/packages/attribution/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.16.0](https://github.com/linz/basemaps/compare/v7.15.1...v7.16.0) (2025-04-07)
+
+**Note:** Version bump only for package @basemaps/attribution
+
+
+
+
+
 # [7.15.0](https://github.com/linz/basemaps/compare/v7.14.0...v7.15.0) (2025-03-17)
 
 **Note:** Version bump only for package @basemaps/attribution

--- a/packages/attribution/package.json
+++ b/packages/attribution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/attribution",
-  "version": "7.15.0",
+  "version": "7.16.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -30,7 +30,7 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/geo": "^7.15.0",
+    "@basemaps/geo": "^7.16.0",
     "@linzjs/geojson": "^7.10.0"
   },
   "bundle": {

--- a/packages/bathymetry/CHANGELOG.md
+++ b/packages/bathymetry/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.16.0](https://github.com/linz/basemaps/compare/v7.15.1...v7.16.0) (2025-04-07)
+
+**Note:** Version bump only for package @basemaps/bathymetry
+
+
+
+
+
 # [7.15.0](https://github.com/linz/basemaps/compare/v7.14.0...v7.15.0) (2025-03-17)
 
 **Note:** Version bump only for package @basemaps/bathymetry

--- a/packages/bathymetry/package.json
+++ b/packages/bathymetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/bathymetry",
-  "version": "7.15.0",
+  "version": "7.16.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -28,9 +28,9 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/cli": "^7.15.0",
-    "@basemaps/geo": "^7.15.0",
-    "@basemaps/shared": "^7.15.0",
+    "@basemaps/cli": "^7.16.0",
+    "@basemaps/geo": "^7.16.0",
+    "@basemaps/shared": "^7.16.0",
     "@rushstack/ts-command-line": "^4.3.13",
     "ulid": "^2.3.0"
   },

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.16.0](https://github.com/linz/basemaps/compare/v7.15.1...v7.16.0) (2025-04-07)
+
+**Note:** Version bump only for package @basemaps/cli
+
+
+
+
+
 # [7.15.0](https://github.com/linz/basemaps/compare/v7.14.0...v7.15.0) (2025-03-17)
 
 **Note:** Version bump only for package @basemaps/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli",
-  "version": "7.15.0",
+  "version": "7.16.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -40,13 +40,13 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
-    "@basemaps/config": "^7.15.0",
-    "@basemaps/config-loader": "^7.15.0",
-    "@basemaps/geo": "^7.15.0",
-    "@basemaps/server": "^7.15.0",
-    "@basemaps/shared": "^7.15.0",
-    "@basemaps/tiler": "^7.15.0",
-    "@basemaps/tiler-sharp": "^7.15.0",
+    "@basemaps/config": "^7.16.0",
+    "@basemaps/config-loader": "^7.16.0",
+    "@basemaps/geo": "^7.16.0",
+    "@basemaps/server": "^7.16.0",
+    "@basemaps/shared": "^7.16.0",
+    "@basemaps/tiler": "^7.16.0",
+    "@basemaps/tiler-sharp": "^7.16.0",
     "@chunkd/source-memory": "^11.0.2",
     "@cotar/builder": "^6.0.1",
     "@cotar/tar": "^6.0.1",

--- a/packages/cogify/CHANGELOG.md
+++ b/packages/cogify/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.16.0](https://github.com/linz/basemaps/compare/v7.15.1...v7.16.0) (2025-04-07)
+
+**Note:** Version bump only for package @basemaps/cogify
+
+
+
+
+
 # [7.15.0](https://github.com/linz/basemaps/compare/v7.14.0...v7.15.0) (2025-03-17)
 
 

--- a/packages/cogify/package.json
+++ b/packages/cogify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cogify",
-  "version": "7.15.0",
+  "version": "7.16.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -40,11 +40,11 @@
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "devDependencies": {
-    "@basemaps/cli": "^7.15.0",
-    "@basemaps/config": "^7.15.0",
-    "@basemaps/config-loader": "^7.15.0",
-    "@basemaps/geo": "^7.15.0",
-    "@basemaps/shared": "^7.15.0",
+    "@basemaps/cli": "^7.16.0",
+    "@basemaps/config": "^7.16.0",
+    "@basemaps/config-loader": "^7.16.0",
+    "@basemaps/geo": "^7.16.0",
+    "@basemaps/shared": "^7.16.0",
     "cmd-ts": "^0.12.1",
     "p-limit": "^4.0.0",
     "stac-ts": "^1.0.0"

--- a/packages/config-loader/CHANGELOG.md
+++ b/packages/config-loader/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.16.0](https://github.com/linz/basemaps/compare/v7.15.1...v7.16.0) (2025-04-07)
+
+**Note:** Version bump only for package @basemaps/config-loader
+
+
+
+
+
 # [7.15.0](https://github.com/linz/basemaps/compare/v7.14.0...v7.15.0) (2025-03-17)
 
 

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/config-loader",
-  "version": "7.15.0",
+  "version": "7.16.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -28,8 +28,8 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/config": "^7.15.0",
-    "@basemaps/geo": "^7.15.0",
-    "@basemaps/shared": "^7.15.0"
+    "@basemaps/config": "^7.16.0",
+    "@basemaps/geo": "^7.16.0",
+    "@basemaps/shared": "^7.16.0"
   }
 }

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.16.0](https://github.com/linz/basemaps/compare/v7.15.1...v7.16.0) (2025-04-07)
+
+**Note:** Version bump only for package @basemaps/config
+
+
+
+
+
 # [7.15.0](https://github.com/linz/basemaps/compare/v7.14.0...v7.15.0) (2025-03-17)
 
 **Note:** Version bump only for package @basemaps/config

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/config",
-  "version": "7.15.0",
+  "version": "7.16.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -28,7 +28,7 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/geo": "^7.15.0",
+    "@basemaps/geo": "^7.16.0",
     "base-x": "^4.0.0",
     "zod": "^3.17.3"
   }

--- a/packages/geo/CHANGELOG.md
+++ b/packages/geo/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.16.0](https://github.com/linz/basemaps/compare/v7.15.1...v7.16.0) (2025-04-07)
+
+
+### Bug Fixes
+
+* **landing:** support viewing CITM2000Quad ([#3419](https://github.com/linz/basemaps/issues/3419)) ([10df2aa](https://github.com/linz/basemaps/commit/10df2aa0a91391435d5a02283e8706bd19700d86))
+
+
+
+
+
 # [7.15.0](https://github.com/linz/basemaps/compare/v7.14.0...v7.15.0) (2025-03-17)
 
 

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/geo",
-  "version": "7.15.0",
+  "version": "7.16.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",

--- a/packages/lambda-analytic-cloudfront/CHANGELOG.md
+++ b/packages/lambda-analytic-cloudfront/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.16.0](https://github.com/linz/basemaps/compare/v7.15.1...v7.16.0) (2025-04-07)
+
+**Note:** Version bump only for package @basemaps/lambda-analytic-cloudfront
+
+
+
+
+
 # [7.15.0](https://github.com/linz/basemaps/compare/v7.14.0...v7.15.0) (2025-03-17)
 
 

--- a/packages/lambda-analytic-cloudfront/package.json
+++ b/packages/lambda-analytic-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-analytic-cloudfront",
-  "version": "7.15.0",
+  "version": "7.16.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -18,9 +18,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@basemaps/config": "^7.15.0",
-    "@basemaps/geo": "^7.15.0",
-    "@basemaps/shared": "^7.15.0",
+    "@basemaps/config": "^7.16.0",
+    "@basemaps/geo": "^7.16.0",
+    "@basemaps/shared": "^7.16.0",
     "@elastic/elasticsearch": "^8.16.2",
     "@linzjs/lambda": "^4.0.0",
     "ua-parser-js": "^1.0.39"

--- a/packages/lambda-analytics/CHANGELOG.md
+++ b/packages/lambda-analytics/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.16.0](https://github.com/linz/basemaps/compare/v7.15.1...v7.16.0) (2025-04-07)
+
+**Note:** Version bump only for package @basemaps/lambda-analytics
+
+
+
+
+
 # [7.15.0](https://github.com/linz/basemaps/compare/v7.14.0...v7.15.0) (2025-03-17)
 
 **Note:** Version bump only for package @basemaps/lambda-analytics

--- a/packages/lambda-analytics/package.json
+++ b/packages/lambda-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-analytics",
-  "version": "7.15.0",
+  "version": "7.16.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -18,9 +18,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@basemaps/config": "^7.15.0",
-    "@basemaps/geo": "^7.15.0",
-    "@basemaps/shared": "^7.15.0",
+    "@basemaps/config": "^7.16.0",
+    "@basemaps/geo": "^7.16.0",
+    "@basemaps/shared": "^7.16.0",
     "ua-parser-js": "^1.0.2"
   },
   "scripts": {

--- a/packages/lambda-tiler/CHANGELOG.md
+++ b/packages/lambda-tiler/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.16.0](https://github.com/linz/basemaps/compare/v7.15.1...v7.16.0) (2025-04-07)
+
+
+### Bug Fixes
+
+* **lambda-tiler:** automatically choose pipelines ([#3416](https://github.com/linz/basemaps/issues/3416)) ([c206a8e](https://github.com/linz/basemaps/commit/c206a8e0a579bd542afa43f6a3186c88bf6a451c))
+
+
+### Features
+
+* **lambda-tiler:** load config from s3 ([#3415](https://github.com/linz/basemaps/issues/3415)) ([e6b89c3](https://github.com/linz/basemaps/commit/e6b89c3c941c15b8fe2adcb0189a9fed46cbe024))
+
+
+
+
+
 # [7.15.0](https://github.com/linz/basemaps/compare/v7.14.0...v7.15.0) (2025-03-17)
 
 **Note:** Version bump only for package @basemaps/lambda-tiler

--- a/packages/lambda-tiler/package.json
+++ b/packages/lambda-tiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-tiler",
-  "version": "7.15.0",
+  "version": "7.16.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -22,12 +22,12 @@
   "types": "./build/index.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@basemaps/config": "^7.15.0",
-    "@basemaps/config-loader": "^7.15.0",
-    "@basemaps/geo": "^7.15.0",
-    "@basemaps/shared": "^7.15.0",
-    "@basemaps/tiler": "^7.15.0",
-    "@basemaps/tiler-sharp": "^7.15.0",
+    "@basemaps/config": "^7.16.0",
+    "@basemaps/config-loader": "^7.16.0",
+    "@basemaps/geo": "^7.16.0",
+    "@basemaps/shared": "^7.16.0",
+    "@basemaps/tiler": "^7.16.0",
+    "@basemaps/tiler-sharp": "^7.16.0",
     "@linzjs/geojson": "^7.10.0",
     "@linzjs/lambda": "^4.0.0",
     "@mapbox/vector-tile": "^2.0.3",
@@ -50,7 +50,7 @@
     "bundle": "./bundle.sh"
   },
   "devDependencies": {
-    "@basemaps/attribution": "^7.15.0",
+    "@basemaps/attribution": "^7.16.0",
     "@chunkd/fs": "^11.2.0",
     "@types/aws-lambda": "^8.10.75",
     "@types/pixelmatch": "^5.0.0",

--- a/packages/landing/CHANGELOG.md
+++ b/packages/landing/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.16.0](https://github.com/linz/basemaps/compare/v7.15.1...v7.16.0) (2025-04-07)
+
+
+### Bug Fixes
+
+* **landing:** fix developer api keys title BM-1181 ([#3423](https://github.com/linz/basemaps/issues/3423)) ([4066b31](https://github.com/linz/basemaps/commit/4066b3153dc5bce70e4e0ccab7286d98c108c16c))
+* **landing:** support viewing CITM2000Quad ([#3419](https://github.com/linz/basemaps/issues/3419)) ([10df2aa](https://github.com/linz/basemaps/commit/10df2aa0a91391435d5a02283e8706bd19700d86))
+
+
+### Features
+
+* **landing:** add dsm to layer dropdown BM-1248 ([#3421](https://github.com/linz/basemaps/issues/3421)) ([b830dff](https://github.com/linz/basemaps/commit/b830dffd5393461ad1c424f673c05e96c4196231))
+* **landing:** add the dsm elevation tileset as a default elevation and hillshade debug option BM-1247 ([#3422](https://github.com/linz/basemaps/issues/3422)) ([1e529a5](https://github.com/linz/basemaps/commit/1e529a50410b2e0137e67c7b3a1f7860f1694a8f))
+* **landing:** change text 90day api keys to single user api keys BM-1181 ([#3420](https://github.com/linz/basemaps/issues/3420)) ([215da68](https://github.com/linz/basemaps/commit/215da68fd7fd874f110a0c09180dc296f611fb59))
+
+
+
+
+
 ## [7.15.1](https://github.com/linz/basemaps/compare/v7.15.0...v7.15.1) (2025-03-24)
 
 

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/landing",
-  "version": "7.15.1",
+  "version": "7.16.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -28,11 +28,11 @@
     "last 2 Chrome versions"
   ],
   "devDependencies": {
-    "@basemaps/attribution": "^7.15.0",
-    "@basemaps/config": "^7.15.0",
-    "@basemaps/geo": "^7.15.0",
-    "@basemaps/infra": "^7.15.0",
-    "@basemaps/shared": "^7.15.0",
+    "@basemaps/attribution": "^7.16.0",
+    "@basemaps/config": "^7.16.0",
+    "@basemaps/geo": "^7.16.0",
+    "@basemaps/infra": "^7.16.0",
+    "@basemaps/shared": "^7.16.0",
     "@linzjs/lui": "^21.46.0",
     "@servie/events": "^3.0.0",
     "@types/proj4": "^2.5.2",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.16.0](https://github.com/linz/basemaps/compare/v7.15.1...v7.16.0) (2025-04-07)
+
+**Note:** Version bump only for package @basemaps/server
+
+
+
+
+
 # [7.15.0](https://github.com/linz/basemaps/compare/v7.14.0...v7.15.0) (2025-03-17)
 
 **Note:** Version bump only for package @basemaps/server

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/server",
-  "version": "7.15.0",
+  "version": "7.16.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -52,12 +52,12 @@
     "sharp": "^0.33.0"
   },
   "devDependencies": {
-    "@basemaps/config": "^7.15.0",
-    "@basemaps/config-loader": "^7.15.0",
-    "@basemaps/geo": "^7.15.0",
-    "@basemaps/lambda-tiler": "^7.15.0",
+    "@basemaps/config": "^7.16.0",
+    "@basemaps/config-loader": "^7.16.0",
+    "@basemaps/geo": "^7.16.0",
+    "@basemaps/lambda-tiler": "^7.16.0",
     "@basemaps/landing": "^6.39.0",
-    "@basemaps/shared": "^7.15.0",
+    "@basemaps/shared": "^7.16.0",
     "@fastify/formbody": "^7.0.1",
     "@fastify/static": "^6.5.0",
     "cmd-ts": "^0.12.1",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.16.0](https://github.com/linz/basemaps/compare/v7.15.1...v7.16.0) (2025-04-07)
+
+**Note:** Version bump only for package @basemaps/shared
+
+
+
+
+
 # [7.15.0](https://github.com/linz/basemaps/compare/v7.14.0...v7.15.0) (2025-03-17)
 
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/shared",
-  "version": "7.15.0",
+  "version": "7.16.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -26,8 +26,8 @@
     "@aws-sdk/client-dynamodb": "^3.470.0",
     "@aws-sdk/client-s3": "^3.472.0",
     "@aws-sdk/util-dynamodb": "^3.470.0",
-    "@basemaps/config": "^7.15.0",
-    "@basemaps/geo": "^7.15.0",
+    "@basemaps/config": "^7.16.0",
+    "@basemaps/geo": "^7.16.0",
     "@chunkd/fs": "^11.2.0",
     "@chunkd/fs-aws": "^11.3.0",
     "@chunkd/middleware": "^11.1.0",

--- a/packages/tiler-sharp/CHANGELOG.md
+++ b/packages/tiler-sharp/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.16.0](https://github.com/linz/basemaps/compare/v7.15.1...v7.16.0) (2025-04-07)
+
+
+### Bug Fixes
+
+* **tiler-sharp:** when resizing preserve input data type ([#3417](https://github.com/linz/basemaps/issues/3417)) ([41e0c38](https://github.com/linz/basemaps/commit/41e0c385c0c8d8e8c29a48c20c611a11da32810a))
+
+
+### Performance Improvements
+
+* **tiler-sharp:** split greyscale  color ramps into specalized function ([#3418](https://github.com/linz/basemaps/issues/3418)) ([30755fd](https://github.com/linz/basemaps/commit/30755fd8c2098b800405d8395058544704c27b21))
+
+
+
+
+
 # [7.15.0](https://github.com/linz/basemaps/compare/v7.14.0...v7.15.0) (2025-03-17)
 
 **Note:** Version bump only for package @basemaps/tiler-sharp

--- a/packages/tiler-sharp/package.json
+++ b/packages/tiler-sharp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/tiler-sharp",
-  "version": "7.15.0",
+  "version": "7.16.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -22,9 +22,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@basemaps/config": "^7.15.0",
-    "@basemaps/geo": "^7.15.0",
-    "@basemaps/tiler": "^7.15.0",
+    "@basemaps/config": "^7.16.0",
+    "@basemaps/geo": "^7.16.0",
+    "@basemaps/tiler": "^7.16.0",
     "@linzjs/metrics": "^7.5.0",
     "lerc": "^4.0.4"
   },

--- a/packages/tiler/CHANGELOG.md
+++ b/packages/tiler/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.16.0](https://github.com/linz/basemaps/compare/v7.15.1...v7.16.0) (2025-04-07)
+
+**Note:** Version bump only for package @basemaps/tiler
+
+
+
+
+
 # [7.15.0](https://github.com/linz/basemaps/compare/v7.14.0...v7.15.0) (2025-03-17)
 
 **Note:** Version bump only for package @basemaps/tiler

--- a/packages/tiler/package.json
+++ b/packages/tiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/tiler",
-  "version": "7.15.0",
+  "version": "7.16.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -22,7 +22,7 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@basemaps/geo": "^7.15.0",
+    "@basemaps/geo": "^7.16.0",
     "@cogeotiff/core": "^9.0.3",
     "@linzjs/metrics": "^7.5.0"
   },


### PR DESCRIPTION
# [7.16.0](https://github.com/linz/basemaps/compare/v7.15.1...v7.16.0) (2025-04-07)


### Bug Fixes

* **lambda-tiler:** automatically choose pipelines ([#3416](https://github.com/linz/basemaps/issues/3416)) ([c206a8e](https://github.com/linz/basemaps/commit/c206a8e0a579bd542afa43f6a3186c88bf6a451c))
* **landing:** fix developer api keys title BM-1181 ([#3423](https://github.com/linz/basemaps/issues/3423)) ([4066b31](https://github.com/linz/basemaps/commit/4066b3153dc5bce70e4e0ccab7286d98c108c16c))
* **landing:** support viewing CITM2000Quad ([#3419](https://github.com/linz/basemaps/issues/3419)) ([10df2aa](https://github.com/linz/basemaps/commit/10df2aa0a91391435d5a02283e8706bd19700d86))
* **tiler-sharp:** when resizing preserve input data type ([#3417](https://github.com/linz/basemaps/issues/3417)) ([41e0c38](https://github.com/linz/basemaps/commit/41e0c385c0c8d8e8c29a48c20c611a11da32810a))


### Features

* **lambda-tiler:** load config from s3 ([#3415](https://github.com/linz/basemaps/issues/3415)) ([e6b89c3](https://github.com/linz/basemaps/commit/e6b89c3c941c15b8fe2adcb0189a9fed46cbe024))
* **landing:** add dsm to layer dropdown BM-1248 ([#3421](https://github.com/linz/basemaps/issues/3421)) ([b830dff](https://github.com/linz/basemaps/commit/b830dffd5393461ad1c424f673c05e96c4196231))
* **landing:** add the dsm elevation tileset as a default elevation and hillshade debug option BM-1247 ([#3422](https://github.com/linz/basemaps/issues/3422)) ([1e529a5](https://github.com/linz/basemaps/commit/1e529a50410b2e0137e67c7b3a1f7860f1694a8f))
* **landing:** change text 90day api keys to single user api keys BM-1181 ([#3420](https://github.com/linz/basemaps/issues/3420)) ([215da68](https://github.com/linz/basemaps/commit/215da68fd7fd874f110a0c09180dc296f611fb59))


### Performance Improvements

* **tiler-sharp:** split greyscale  color ramps into specalized function ([#3418](https://github.com/linz/basemaps/issues/3418)) ([30755fd](https://github.com/linz/basemaps/commit/30755fd8c2098b800405d8395058544704c27b21))