### PR TITLE
release: v7.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.17.0](https://github.com/linz/basemaps/compare/v7.16.0...v7.17.0) (2025-04-08)
+
+
+### Features
+
+* **landing:** Add hillshade and hillshade igor into the layer dropdown. BM-1250 ([#3425](https://github.com/linz/basemaps/issues/3425)) ([a02fb6a](https://github.com/linz/basemaps/commit/a02fb6a250f2a7d66d0bd6640f72a6ea4ad8322a))
+
+
+
+
+
 # [7.16.0](https://github.com/linz/basemaps/compare/v7.15.1...v7.16.0) (2025-04-07)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
       "conventionalCommits": true
     }
   },
-  "version": "7.16.0"
+  "version": "7.17.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19671,7 +19671,7 @@
     },
     "packages/landing": {
       "name": "@basemaps/landing",
-      "version": "7.16.0",
+      "version": "7.17.0",
       "license": "MIT",
       "devDependencies": {
         "@basemaps/attribution": "^7.16.0",

--- a/packages/landing/CHANGELOG.md
+++ b/packages/landing/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [7.17.0](https://github.com/linz/basemaps/compare/v7.16.0...v7.17.0) (2025-04-08)
+
+
+### Features
+
+* **landing:** Add hillshade and hillshade igor into the layer dropdown. BM-1250 ([#3425](https://github.com/linz/basemaps/issues/3425)) ([a02fb6a](https://github.com/linz/basemaps/commit/a02fb6a250f2a7d66d0bd6640f72a6ea4ad8322a))
+
+
+
+
+
 # [7.16.0](https://github.com/linz/basemaps/compare/v7.15.1...v7.16.0) (2025-04-07)
 
 

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/landing",
-  "version": "7.16.0",
+  "version": "7.17.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",


### PR DESCRIPTION

# [7.17.0](https://github.com/linz/basemaps/compare/v7.16.0...v7.17.0) (2025-04-08)


### Features

* **landing:** Add hillshade and hillshade igor into the layer dropdown. BM-1250 ([#3425](https://github.com/linz/basemaps/issues/3425)) ([a02fb6a](https://github.com/linz/basemaps/commit/a02fb6a250f2a7d66d0bd6640f72a6ea4ad8322a))




