### PR TITLE
fix: ensure all linzjs packages are correctly labeled as deps

### DIFF
--- a/packages/cli-raster/package.json
+++ b/packages/cli-raster/package.json
@@ -44,6 +44,8 @@
     "@basemaps/config-loader": "^7.16.0",
     "@basemaps/geo": "^7.16.0",
     "@basemaps/shared": "^7.16.0",
+    "@linzjs/geojson": "^7.10.0",
+    "@linzjs/metrics": "^7.5.0",
     "cmd-ts": "^0.12.1",
     "p-limit": "^4.0.0",
     "stac-ts": "^1.0.0"

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -32,6 +32,7 @@
     "@types/proj4": "^2.5.2"
   },
   "dependencies": {
+    "@linzjs/geojson": "^7.10.0",
     "@linzjs/tile-matrix-set": "^0.0.1",
     "proj4": "^2.8.0"
   }

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -34,6 +34,7 @@
     "@basemaps/geo": "^7.16.0",
     "@basemaps/infra": "^7.16.0",
     "@basemaps/shared": "^7.16.0",
+    "@linzjs/geojson": "^7.10.0",
     "@linzjs/lui": "^21.46.0",
     "@servie/events": "^3.0.0",
     "@types/mime-types": "^2.1.4",

--- a/scripts/detect.unlinked.dep.mjs
+++ b/scripts/detect.unlinked.dep.mjs
@@ -27,11 +27,13 @@ async function main() {
   const packages = await fs.readdir('./packages');
 
   // Set of all packages in this repository eg `@basemaps/geo` or `@linzjs/geojson`
-  const localPackages = new Set(
+  const localPackageNames = new Set(
     await Promise.all(packages.map(async (f) => JSON.parse(await fs.readFile(`./packages/${f}/package.json`)).name)),
   );
 
-  console.log('Found local packages: ', localPackages);
+  const packageNames = [...localPackageNames];
+  packageNames.sort();
+  console.log('Found local packages: ', packageNames);
 
   let hasFailures = false;
   for (const pkg of packages) {
@@ -45,13 +47,13 @@ async function main() {
 
     const allDeps = Object.keys(pkgJson.dependencies || {}).concat(Object.keys(pkgJson.devDependencies || {}));
 
-    const localDeps = new Set(allDeps.filter((packageName) => localPackages.has(packageName)));
+    const localDeps = new Set(allDeps.filter((packageName) => localPackageNames.has(packageName)));
     const allImports = getAllImports(pkgPath);
     // console.log(pkg, allImports);
 
     for (const importedPackage of allImports) {
       // If the package is external ignore
-      if (!localPackages.has(importedPackage)) continue;
+      if (!localPackageNames.has(importedPackage)) continue;
       // Package is missing from the package.json
       if (!localDeps.has(importedPackage)) {
         if (importedPackage.includes('/build/')) continue;


### PR DESCRIPTION
### Motivation

There is a weird behaviour in this monorepo that when importing packages that are present inside the monorepo can be imported freely anywhere inside the monorepo, but when the package is published it needs to exist inside the package.json or it will not be installed correctly.

We have a script that detects when this happens `scripts/detect.unlinked.dep.mjs` but it was only functioning for `@basemaps/*` packages in this repository there are a few `@linzjs/` packages.

### Modifications

Ensure linzjs packages are also checked as part of CI
Add the missing links between a few packages and `@linzjs/geojson` and `@linzjs/metrics`

### Verification

`detect.unlinked.dep.mjs` found these packages once it was updated to include looking for `@linzjs`

Fixes #3438 