### PR TITLE
feat(lambda-tiler)!: allow API keys to be disabled BM-1281

### DIFF
--- a/packages/_infra/src/serve/lambda.tiler.ts
+++ b/packages/_infra/src/serve/lambda.tiler.ts
@@ -1,4 +1,6 @@
-import { Env } from '@basemaps/shared';
+import assert from 'node:assert';
+
+import { Env, isValidApiKey } from '@basemaps/shared';
 import * as cdk from 'aws-cdk-lib';
 import { Duration } from 'aws-cdk-lib';
 import iam from 'aws-cdk-lib/aws-iam';
@@ -36,6 +38,17 @@ export class LambdaTiler extends Construct {
 
     if (props.staticBucketName) {
       environment[Env.StaticAssetLocation] = `s3://${props.staticBucketName}/`;
+    }
+
+    // Set blocked api keys if some are present
+    const blockedKeys = Env.get(Env.BlockedApiKeys);
+    if (blockedKeys != null) {
+      const listOfKeys = JSON.parse(blockedKeys) as string[];
+      if (!Array.isArray(listOfKeys)) throw new Error(` ${Env.BlockedApiKeys} is not valid`);
+      for (const key of listOfKeys) {
+        assert.ok(isValidApiKey(key).valid, `${key} is not a valid api key to block ${Env.BlockedApiKeys}`);
+      }
+      environment[Env.BlockedApiKeys] = blockedKeys;
     }
 
     const code = lambda.Code.fromAsset(CODE_PATH);

--- a/packages/lambda-tiler/src/util/__test__/validate.test.ts
+++ b/packages/lambda-tiler/src/util/__test__/validate.test.ts
@@ -6,6 +6,24 @@ import { GoogleTms, Nztm2000QuadTms, Nztm2000Tms } from '@basemaps/geo';
 import { mockUrlRequest } from '../../__tests__/xyz.util.js';
 import { Validate } from '../validate.js';
 
+describe('Validate.blockedApiKeys', () => {
+  const validApiKey = 'c01jswmpe1yn3mwne7e0ggtp8vg';
+  it('should disable api keys', () => {
+    const req = mockUrlRequest('/v1/blank', `api=${validApiKey}`);
+    const parsedKey = Validate.apiKey(req);
+    assert.equal(parsedKey, validApiKey);
+  });
+
+  it('should disable api keys', () => {
+    const req = mockUrlRequest('/v1/blank', `api=${validApiKey}`);
+    Validate.blockedApiKeys.add(validApiKey);
+    assert.throws(() => Validate.apiKey(req));
+
+    Validate.blockedApiKeys.delete(validApiKey);
+    assert.equal(Validate.apiKey(req), validApiKey);
+  });
+});
+
 describe('GetImageFormats', () => {
   it('should parse all formats', () => {
     const req = mockUrlRequest('/v1/blank', 'format=png&format=jpeg');

--- a/packages/shared/src/const.ts
+++ b/packages/shared/src/const.ts
@@ -42,6 +42,13 @@ export const Env = {
   /** Github api token */
   GitHubToken: 'GITHUB_API_TOKEN',
 
+  /**
+   * JSON encoded array of api keys to block
+   *
+   * @example '["apiKeyA","apiKeyB"]'
+   */
+  BlockedApiKeys: 'BASEMAPS_API_KEY_BLOCKS',
+
   Gdal: {
     /** Should the gdal docker container be used? */
     UseDocker: 'GDAL_DOCKER',


### PR DESCRIPTION
### Motivation

We have seen a increase of consumer api keys using scripted methods to pull large amounts of data from basemaps.linz.govt.nz these users should be using bulk data access methods like linz/imagery or limz/elevation, as the keys are only consumer we have no easy way of contacting them.

Our only option is to disable their keys and hope that they reach out.


### Modifications

Add a environment variable to allow us to block API keys 

### Verification

unit tests and further tests in nonprod.
