### PR TITLE
fix: ensure api key blocks are set in ci/cd

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -124,6 +124,7 @@ jobs:
           npx lerna run bundle --stream
           npx lerna run deploy:deploy --stream
         env:
+          BASEMAPS_API_KEY_BLOCKS: ${{ secrets.BASEMAPS_API_KEY_BLOCKS }}
           GOOGLE_ANALYTICS: ${{ secrets.GOOGLE_ANALYTICS }}
           NODE_ENV: 'dev'
 
@@ -179,8 +180,9 @@ jobs:
           npx lerna run bundle --stream
           npx lerna run deploy:deploy --stream
         env:
-          NODE_ENV: 'production'
+          BASEMAPS_API_KEY_BLOCKS: ${{ secrets.BASEMAPS_API_KEY_BLOCKS }}
           GOOGLE_ANALYTICS: ${{ secrets.GOOGLE_ANALYTICS }}
+          NODE_ENV: 'production'
 
       - name: (Prod) After Deploy Smoke Test
         run: |


### PR DESCRIPTION
### Motivation

a github environment secret sets the api key blocks, but it was not being passed to the CD process so the blocks are not being set automatically on deployment.

### Modifications

Allow the CD process to have access to the blocked api keys

### Verification

will check nonprod after deployment.
