### PR TITLE
feat(lambda-tiler): expose configuration id and hash if present

### DIFF
--- a/packages/config/src/memory/memory.config.ts
+++ b/packages/config/src/memory/memory.config.ts
@@ -69,8 +69,14 @@ function removeUndefined(obj: unknown): void {
 export class ConfigProviderMemory extends BasemapsConfigProvider {
   override type = 'memory' as const;
 
+  static is(cfg: BasemapsConfigProvider): cfg is ConfigProviderMemory {
+    return cfg.type === 'memory';
+  }
+
   /** Optional id of the configuration */
   id?: string;
+  /** Optional hash of the config if the config was loaded from JSON */
+  hash?: string;
 
   Imagery = new MemoryConfigObject<ConfigImagery>(this, ConfigPrefix.Imagery);
   Style = new MemoryConfigObject<ConfigVectorStyle>(this, ConfigPrefix.Style);
@@ -245,6 +251,7 @@ export class ConfigProviderMemory extends BasemapsConfigProvider {
 
     mem.assets = cfg.assets;
     mem.id = cfg.id;
+    mem.hash = cfg.hash;
 
     return mem;
   }

--- a/packages/lambda-tiler/src/routes/version.ts
+++ b/packages/lambda-tiler/src/routes/version.ts
@@ -1,6 +1,16 @@
-import { HttpHeader, LambdaHttpResponse } from '@linzjs/lambda';
+import { BasemapsConfigProvider, ConfigProviderMemory } from '@basemaps/config';
+import { HttpHeader, LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambda';
 
-export function versionGet(): Promise<LambdaHttpResponse> {
+import { ConfigLoader } from '../util/config.loader.js';
+
+function getConfigHash(cfg: BasemapsConfigProvider): { id: string; hash?: string } | undefined {
+  if (!ConfigProviderMemory.is(cfg)) return undefined;
+  if (cfg.id == null) return undefined;
+  return { id: cfg.id, hash: cfg.hash };
+}
+
+export async function versionGet(req: LambdaHttpRequest): Promise<LambdaHttpResponse> {
+  const config = await ConfigLoader.load(req);
   const response = new LambdaHttpResponse(200, 'ok');
   response.header(HttpHeader.CacheControl, 'no-store');
   response.json({
@@ -9,16 +19,26 @@ export function versionGet(): Promise<LambdaHttpResponse> {
      * @example "v6.42.1"
      */
     version: process.env['GIT_VERSION'] ?? 'dev',
+
     /**
      * Full git commit hash
      * @example "e4231b1ee62c276c8657c56677ced02681dfe5d6"
      */
     hash: process.env['GIT_HASH'],
+
     /**
+     *
      * The exact build that this release was run from
      * @example "1658821493-3"
      */
     buildId: process.env['BUILD_ID'],
+
+    /**
+     * Configuration id that was used to power this config
+     * @example { "id": "cb_01JTQ7ZK49F8EY4N5DRJ3XFT73", hash: "HcByZ8WS2zpaTxFJp6wSKg2eUpwahLqAGEQdcDxKxqp6" }
+     */
+    config: getConfigHash(config),
   });
+
   return Promise.resolve(response);
 }


### PR DESCRIPTION
### Motivation

I would like to know what configuration is in use on each instance of basemaps, we have a version endpoint `/v1/version` that gives the build information (commit hash, github actions run id) but does not say what configuration is being used.

### Modifications

If the current configuration has a `id` and `hash` return those as `{ config: { id, hash} }`

```json
{ 
  "id": "cb_01JTQ7ZK49F8EY4N5DRJ3XFT73", 
  "hash": "HcByZ8WS2zpaTxFJp6wSKg2eUpwahLqAGEQdcDxKxqp6" 
}
```

### Verification

Unit tests + running locally