### PR TITLE
fix: parsing of blocked api keys

### DIFF
--- a/packages/_infra/src/serve/lambda.tiler.ts
+++ b/packages/_infra/src/serve/lambda.tiler.ts
@@ -41,8 +41,8 @@ export class LambdaTiler extends Construct {
     }
 
     // Set blocked api keys if some are present
-    const blockedKeys = Env.get(Env.BlockedApiKeys);
-    if (blockedKeys != null) {
+    const blockedKeys = Env.get(Env.BlockedApiKeys) ?? '';
+    if (blockedKeys.length > 0) {
       const listOfKeys = JSON.parse(blockedKeys) as string[];
       if (!Array.isArray(listOfKeys)) throw new Error(` ${Env.BlockedApiKeys} is not valid`);
       for (const key of listOfKeys) {


### PR DESCRIPTION
### Motivation

Dev deployments are currently broken as the enviroment variable is `''` and not `null` so the check to skip blocked keys is not guarding correctly

### Modifications

Check for string length to see if there is any content

### Verification

diffed locally.
