### PR TITLE
release: v8.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
+
+
+### Bug Fixes
+
+* correct cli-config 'import' parameters ([#3445](https://github.com/linz/basemaps/issues/3445)) ([f349080](https://github.com/linz/basemaps/commit/f349080c473100cc5361162719011c2b152ea299)), closes [/github.com/linz/basemaps/pull/3427/commits/01a90a2b98bab02632a9637bfed2067c9c047c61#diff-48a5e932b724482f9a280931b7bb1188d26ef004b87c331aadfc7a7948ec7f70](https://github.com//github.com/linz/basemaps/pull/3427/commits/01a90a2b98bab02632a9637bfed2067c9c047c61/issues/diff-48a5e932b724482f9a280931b7bb1188d26ef004b87c331aadfc7a7948ec7f70) [/github.com/linz/basemaps-config/blob/a5b8b9baaa9941314a13058e53945bc5db5f5357/.github/workflows/build.yml#L131](https://github.com//github.com/linz/basemaps-config/blob/a5b8b9baaa9941314a13058e53945bc5db5f5357/.github/workflows/build.yml/issues/L131)
+* parsing of blocked api keys ([#3448](https://github.com/linz/basemaps/issues/3448)) ([ab8bf72](https://github.com/linz/basemaps/commit/ab8bf7221df32eac59beb2d4e5cad78015c88395))
+
+
+### Features
+
+* **lambda-tiler:** expose configuration id and hash if present ([#3446](https://github.com/linz/basemaps/issues/3446)) ([43803b4](https://github.com/linz/basemaps/commit/43803b48a404591417453331ac9e3aa16c85248f))
+
+
+
+
+
 # [8.0.0](https://github.com/linz/basemaps/compare/v7.17.0...v8.0.0) (2025-05-11)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
       "conventionalCommits": true
     }
   },
-  "version": "8.0.0"
+  "version": "8.1.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19413,13 +19413,13 @@
     },
     "packages/_infra": {
       "name": "@basemaps/infra",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "devDependencies": {
         "@aws-sdk/client-acm": "^3.470.0",
         "@aws-sdk/client-cloudformation": "^3.470.0",
-        "@basemaps/lambda-tiler": "^8.0.0",
-        "@basemaps/shared": "^8.0.0",
+        "@basemaps/lambda-tiler": "^8.1.0",
+        "@basemaps/shared": "^8.1.0",
         "@linzjs/cdk-tags": "^1.7.0",
         "aws-cdk": "2.162.x",
         "aws-cdk-lib": "2.162.x",
@@ -19443,11 +19443,11 @@
     },
     "packages/bathymetry": {
       "name": "@basemaps/bathymetry",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
         "@basemaps/geo": "^8.0.0",
-        "@basemaps/shared": "^8.0.0",
+        "@basemaps/shared": "^8.1.0",
         "@rushstack/ts-command-line": "^4.3.13",
         "ulid": "^2.3.0"
       },
@@ -19470,12 +19470,12 @@
     },
     "packages/cli": {
       "name": "@basemaps/cli",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/cli-config": "^8.0.0",
-        "@basemaps/cli-raster": "^8.0.0",
-        "@basemaps/shared": "^8.0.0",
+        "@basemaps/cli-config": "^8.1.0",
+        "@basemaps/cli-raster": "^8.1.0",
+        "@basemaps/shared": "^8.1.0",
         "cmd-ts": "^0.13.0"
       },
       "bin": {
@@ -19487,13 +19487,13 @@
     },
     "packages/cli-config": {
       "name": "@basemaps/cli-config",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^8.0.0",
-        "@basemaps/config-loader": "^8.0.0",
+        "@basemaps/config": "^8.1.0",
+        "@basemaps/config-loader": "^8.1.0",
         "@basemaps/geo": "^8.0.0",
-        "@basemaps/shared": "^8.0.0",
+        "@basemaps/shared": "^8.1.0",
         "@cotar/builder": "^6.0.1",
         "@cotar/core": "^6.0.1",
         "@cotar/tar": "^6.0.1",
@@ -19535,16 +19535,16 @@
     },
     "packages/cli-raster": {
       "name": "@basemaps/cli-raster",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "bin": {
         "cogify": "build/bin.js"
       },
       "devDependencies": {
-        "@basemaps/config": "^8.0.0",
-        "@basemaps/config-loader": "^8.0.0",
+        "@basemaps/config": "^8.1.0",
+        "@basemaps/config-loader": "^8.1.0",
         "@basemaps/geo": "^8.0.0",
-        "@basemaps/shared": "^8.0.0",
+        "@basemaps/shared": "^8.1.0",
         "@linzjs/geojson": "^8.0.0",
         "@linzjs/metrics": "^8.0.0",
         "cmd-ts": "^0.12.1",
@@ -19557,14 +19557,14 @@
     },
     "packages/cli-vector": {
       "name": "@basemaps/cli-vector",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "bin": {
         "etl": "build/bin.js"
       },
       "devDependencies": {
-        "@basemaps/config": "^8.0.0",
-        "@basemaps/shared": "^8.0.0",
+        "@basemaps/config": "^8.1.0",
+        "@basemaps/shared": "^8.1.0",
         "@types/node-fetch": "^2.6.12",
         "cmd-ts": "^0.12.1",
         "p-limit": "^4.0.0",
@@ -19610,7 +19610,7 @@
     },
     "packages/config": {
       "name": "@basemaps/config",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
         "@basemaps/geo": "^8.0.0",
@@ -19623,12 +19623,12 @@
     },
     "packages/config-loader": {
       "name": "@basemaps/config-loader",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^8.0.0",
+        "@basemaps/config": "^8.1.0",
         "@basemaps/geo": "^8.0.0",
-        "@basemaps/shared": "^8.0.0"
+        "@basemaps/shared": "^8.1.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -19660,12 +19660,12 @@
     },
     "packages/lambda-analytic-cloudfront": {
       "name": "@basemaps/lambda-analytic-cloudfront",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^8.0.0",
+        "@basemaps/config": "^8.1.0",
         "@basemaps/geo": "^8.0.0",
-        "@basemaps/shared": "^8.0.0",
+        "@basemaps/shared": "^8.1.0",
         "@elastic/elasticsearch": "^8.16.2",
         "@linzjs/lambda": "^4.0.0",
         "ua-parser-js": "^1.0.39"
@@ -19679,12 +19679,12 @@
     },
     "packages/lambda-analytics": {
       "name": "@basemaps/lambda-analytics",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^8.0.0",
+        "@basemaps/config": "^8.1.0",
         "@basemaps/geo": "^8.0.0",
-        "@basemaps/shared": "^8.0.0",
+        "@basemaps/shared": "^8.1.0",
         "ua-parser-js": "^1.0.2"
       },
       "devDependencies": {
@@ -19696,15 +19696,15 @@
     },
     "packages/lambda-tiler": {
       "name": "@basemaps/lambda-tiler",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^8.0.0",
-        "@basemaps/config-loader": "^8.0.0",
+        "@basemaps/config": "^8.1.0",
+        "@basemaps/config-loader": "^8.1.0",
         "@basemaps/geo": "^8.0.0",
-        "@basemaps/shared": "^8.0.0",
+        "@basemaps/shared": "^8.1.0",
         "@basemaps/tiler": "^8.0.0",
-        "@basemaps/tiler-sharp": "^8.0.0",
+        "@basemaps/tiler-sharp": "^8.1.0",
         "@linzjs/geojson": "^8.0.0",
         "@linzjs/lambda": "^4.0.0",
         "@mapbox/vector-tile": "^2.0.3",
@@ -19762,15 +19762,15 @@
     },
     "packages/landing": {
       "name": "@basemaps/landing",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "devDependencies": {
         "@basemaps/attribution": "^8.0.0",
-        "@basemaps/cli-config": "^8.0.0",
-        "@basemaps/config": "^8.0.0",
+        "@basemaps/cli-config": "^8.1.0",
+        "@basemaps/config": "^8.1.0",
         "@basemaps/geo": "^8.0.0",
-        "@basemaps/infra": "^8.0.0",
-        "@basemaps/shared": "^8.0.0",
+        "@basemaps/infra": "^8.1.0",
+        "@basemaps/shared": "^8.1.0",
         "@linzjs/geojson": "^8.0.0",
         "@linzjs/lui": "^21.46.0",
         "@servie/events": "^3.0.0",
@@ -19838,7 +19838,7 @@
     },
     "packages/server": {
       "name": "@basemaps/server",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
         "lerc": "^4.0.4",
@@ -19848,12 +19848,12 @@
         "basemaps-server": "bin/basemaps-server.cjs"
       },
       "devDependencies": {
-        "@basemaps/config": "^8.0.0",
-        "@basemaps/config-loader": "^8.0.0",
+        "@basemaps/config": "^8.1.0",
+        "@basemaps/config-loader": "^8.1.0",
         "@basemaps/geo": "^8.0.0",
-        "@basemaps/lambda-tiler": "^8.0.0",
+        "@basemaps/lambda-tiler": "^8.1.0",
         "@basemaps/landing": "^6.39.0",
-        "@basemaps/shared": "^8.0.0",
+        "@basemaps/shared": "^8.1.0",
         "@fastify/formbody": "^7.0.1",
         "@fastify/static": "^6.5.0",
         "cmd-ts": "^0.12.1",
@@ -19878,13 +19878,13 @@
     },
     "packages/shared": {
       "name": "@basemaps/shared",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.470.0",
         "@aws-sdk/client-s3": "^3.472.0",
         "@aws-sdk/util-dynamodb": "^3.470.0",
-        "@basemaps/config": "^8.0.0",
+        "@basemaps/config": "^8.1.0",
         "@basemaps/geo": "^8.0.0",
         "@chunkd/fs": "^11.2.0",
         "@chunkd/fs-aws": "^11.3.0",
@@ -19963,10 +19963,10 @@
     },
     "packages/tiler-sharp": {
       "name": "@basemaps/tiler-sharp",
-      "version": "8.0.0",
+      "version": "8.1.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^8.0.0",
+        "@basemaps/config": "^8.1.0",
         "@basemaps/geo": "^8.0.0",
         "@basemaps/tiler": "^8.0.0",
         "@linzjs/metrics": "^8.0.0",

--- a/packages/_infra/CHANGELOG.md
+++ b/packages/_infra/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
+
+
+### Bug Fixes
+
+* parsing of blocked api keys ([#3448](https://github.com/linz/basemaps/issues/3448)) ([ab8bf72](https://github.com/linz/basemaps/commit/ab8bf7221df32eac59beb2d4e5cad78015c88395))
+
+
+
+
+
 # [8.0.0](https://github.com/linz/basemaps/compare/v7.17.0...v8.0.0) (2025-05-11)
 
 **Note:** Version bump only for package @basemaps/infra

--- a/packages/_infra/package.json
+++ b/packages/_infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/infra",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -26,8 +26,8 @@
   "devDependencies": {
     "@aws-sdk/client-acm": "^3.470.0",
     "@aws-sdk/client-cloudformation": "^3.470.0",
-    "@basemaps/lambda-tiler": "^8.0.0",
-    "@basemaps/shared": "^8.0.0",
+    "@basemaps/lambda-tiler": "^8.1.0",
+    "@basemaps/shared": "^8.1.0",
     "@linzjs/cdk-tags": "^1.7.0",
     "aws-cdk": "2.162.x",
     "aws-cdk-lib": "2.162.x",

--- a/packages/bathymetry/CHANGELOG.md
+++ b/packages/bathymetry/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
+
+**Note:** Version bump only for package @basemaps/bathymetry
+
+
+
+
+
 # [8.0.0](https://github.com/linz/basemaps/compare/v7.17.0...v8.0.0) (2025-05-11)
 
 

--- a/packages/bathymetry/package.json
+++ b/packages/bathymetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/bathymetry",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "@basemaps/geo": "^8.0.0",
-    "@basemaps/shared": "^8.0.0",
+    "@basemaps/shared": "^8.1.0",
     "@rushstack/ts-command-line": "^4.3.13",
     "ulid": "^2.3.0"
   },

--- a/packages/cli-config/CHANGELOG.md
+++ b/packages/cli-config/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
+
+
+### Bug Fixes
+
+* correct cli-config 'import' parameters ([#3445](https://github.com/linz/basemaps/issues/3445)) ([f349080](https://github.com/linz/basemaps/commit/f349080c473100cc5361162719011c2b152ea299)), closes [/github.com/linz/basemaps/pull/3427/commits/01a90a2b98bab02632a9637bfed2067c9c047c61#diff-48a5e932b724482f9a280931b7bb1188d26ef004b87c331aadfc7a7948ec7f70](https://github.com//github.com/linz/basemaps/pull/3427/commits/01a90a2b98bab02632a9637bfed2067c9c047c61/issues/diff-48a5e932b724482f9a280931b7bb1188d26ef004b87c331aadfc7a7948ec7f70) [/github.com/linz/basemaps-config/blob/a5b8b9baaa9941314a13058e53945bc5db5f5357/.github/workflows/build.yml#L131](https://github.com//github.com/linz/basemaps-config/blob/a5b8b9baaa9941314a13058e53945bc5db5f5357/.github/workflows/build.yml/issues/L131)
+
+
+
+
+
 # [8.0.0](https://github.com/linz/basemaps/compare/v7.17.0...v8.0.0) (2025-05-11)
 
 

--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli-config",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@basemaps/config": "^8.0.0",
-    "@basemaps/config-loader": "^8.0.0",
+    "@basemaps/config": "^8.1.0",
+    "@basemaps/config-loader": "^8.1.0",
     "@basemaps/geo": "^8.0.0",
-    "@basemaps/shared": "^8.0.0",
+    "@basemaps/shared": "^8.1.0",
     "@cotar/builder": "^6.0.1",
     "@cotar/core": "^6.0.1",
     "@cotar/tar": "^6.0.1",

--- a/packages/cli-raster/CHANGELOG.md
+++ b/packages/cli-raster/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
+
+**Note:** Version bump only for package @basemaps/cli-raster
+
+
+
+
+
 # [8.0.0](https://github.com/linz/basemaps/compare/v7.17.0...v8.0.0) (2025-05-11)
 
 

--- a/packages/cli-raster/package.json
+++ b/packages/cli-raster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli-raster",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -40,10 +40,10 @@
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "devDependencies": {
-    "@basemaps/config": "^8.0.0",
-    "@basemaps/config-loader": "^8.0.0",
+    "@basemaps/config": "^8.1.0",
+    "@basemaps/config-loader": "^8.1.0",
     "@basemaps/geo": "^8.0.0",
-    "@basemaps/shared": "^8.0.0",
+    "@basemaps/shared": "^8.1.0",
     "@linzjs/geojson": "^8.0.0",
     "@linzjs/metrics": "^8.0.0",
     "cmd-ts": "^0.12.1",

--- a/packages/cli-vector/CHANGELOG.md
+++ b/packages/cli-vector/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
+
+**Note:** Version bump only for package @basemaps/cli-vector
+
+
+
+
+
 # [8.0.0](https://github.com/linz/basemaps/compare/v7.17.0...v8.0.0) (2025-05-11)
 
 

--- a/packages/cli-vector/package.json
+++ b/packages/cli-vector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli-vector",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -36,8 +36,8 @@
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "devDependencies": {
-    "@basemaps/config": "^8.0.0",
-    "@basemaps/shared": "^8.0.0",
+    "@basemaps/config": "^8.1.0",
+    "@basemaps/shared": "^8.1.0",
     "@types/node-fetch": "^2.6.12",
     "cmd-ts": "^0.12.1",
     "p-limit": "^4.0.0",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
+
+
+### Bug Fixes
+
+* correct cli-config 'import' parameters ([#3445](https://github.com/linz/basemaps/issues/3445)) ([f349080](https://github.com/linz/basemaps/commit/f349080c473100cc5361162719011c2b152ea299)), closes [/github.com/linz/basemaps/pull/3427/commits/01a90a2b98bab02632a9637bfed2067c9c047c61#diff-48a5e932b724482f9a280931b7bb1188d26ef004b87c331aadfc7a7948ec7f70](https://github.com//github.com/linz/basemaps/pull/3427/commits/01a90a2b98bab02632a9637bfed2067c9c047c61/issues/diff-48a5e932b724482f9a280931b7bb1188d26ef004b87c331aadfc7a7948ec7f70) [/github.com/linz/basemaps-config/blob/a5b8b9baaa9941314a13058e53945bc5db5f5357/.github/workflows/build.yml#L131](https://github.com//github.com/linz/basemaps-config/blob/a5b8b9baaa9941314a13058e53945bc5db5f5357/.github/workflows/build.yml/issues/L131)
+
+
+
+
+
 # [8.0.0](https://github.com/linz/basemaps/compare/v7.17.0...v8.0.0) (2025-05-11)
 
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -40,9 +40,9 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
-    "@basemaps/cli-config": "^8.0.0",
-    "@basemaps/cli-raster": "^8.0.0",
-    "@basemaps/shared": "^8.0.0",
+    "@basemaps/cli-config": "^8.1.0",
+    "@basemaps/cli-raster": "^8.1.0",
+    "@basemaps/shared": "^8.1.0",
     "cmd-ts": "^0.13.0"
   },
   "publishConfig": {

--- a/packages/config-loader/CHANGELOG.md
+++ b/packages/config-loader/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
+
+**Note:** Version bump only for package @basemaps/config-loader
+
+
+
+
+
 # [8.0.0](https://github.com/linz/basemaps/compare/v7.17.0...v8.0.0) (2025-05-11)
 
 **Note:** Version bump only for package @basemaps/config-loader

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/config-loader",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -28,8 +28,8 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/config": "^8.0.0",
+    "@basemaps/config": "^8.1.0",
     "@basemaps/geo": "^8.0.0",
-    "@basemaps/shared": "^8.0.0"
+    "@basemaps/shared": "^8.1.0"
   }
 }

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
+
+
+### Features
+
+* **lambda-tiler:** expose configuration id and hash if present ([#3446](https://github.com/linz/basemaps/issues/3446)) ([43803b4](https://github.com/linz/basemaps/commit/43803b48a404591417453331ac9e3aa16c85248f))
+
+
+
+
+
 # [8.0.0](https://github.com/linz/basemaps/compare/v7.17.0...v8.0.0) (2025-05-11)
 
 **Note:** Version bump only for package @basemaps/config

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/config",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",

--- a/packages/lambda-analytic-cloudfront/CHANGELOG.md
+++ b/packages/lambda-analytic-cloudfront/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
+
+**Note:** Version bump only for package @basemaps/lambda-analytic-cloudfront
+
+
+
+
+
 # [8.0.0](https://github.com/linz/basemaps/compare/v7.17.0...v8.0.0) (2025-05-11)
 
 **Note:** Version bump only for package @basemaps/lambda-analytic-cloudfront

--- a/packages/lambda-analytic-cloudfront/package.json
+++ b/packages/lambda-analytic-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-analytic-cloudfront",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -18,9 +18,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@basemaps/config": "^8.0.0",
+    "@basemaps/config": "^8.1.0",
     "@basemaps/geo": "^8.0.0",
-    "@basemaps/shared": "^8.0.0",
+    "@basemaps/shared": "^8.1.0",
     "@elastic/elasticsearch": "^8.16.2",
     "@linzjs/lambda": "^4.0.0",
     "ua-parser-js": "^1.0.39"

--- a/packages/lambda-analytics/CHANGELOG.md
+++ b/packages/lambda-analytics/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
+
+**Note:** Version bump only for package @basemaps/lambda-analytics
+
+
+
+
+
 # [8.0.0](https://github.com/linz/basemaps/compare/v7.17.0...v8.0.0) (2025-05-11)
 
 **Note:** Version bump only for package @basemaps/lambda-analytics

--- a/packages/lambda-analytics/package.json
+++ b/packages/lambda-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-analytics",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -18,9 +18,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@basemaps/config": "^8.0.0",
+    "@basemaps/config": "^8.1.0",
     "@basemaps/geo": "^8.0.0",
-    "@basemaps/shared": "^8.0.0",
+    "@basemaps/shared": "^8.1.0",
     "ua-parser-js": "^1.0.2"
   },
   "scripts": {

--- a/packages/lambda-tiler/CHANGELOG.md
+++ b/packages/lambda-tiler/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
+
+
+### Features
+
+* **lambda-tiler:** expose configuration id and hash if present ([#3446](https://github.com/linz/basemaps/issues/3446)) ([43803b4](https://github.com/linz/basemaps/commit/43803b48a404591417453331ac9e3aa16c85248f))
+
+
+
+
+
 # [8.0.0](https://github.com/linz/basemaps/compare/v7.17.0...v8.0.0) (2025-05-11)
 
 **Note:** Version bump only for package @basemaps/lambda-tiler

--- a/packages/lambda-tiler/package.json
+++ b/packages/lambda-tiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-tiler",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -22,12 +22,12 @@
   "types": "./build/index.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@basemaps/config": "^8.0.0",
-    "@basemaps/config-loader": "^8.0.0",
+    "@basemaps/config": "^8.1.0",
+    "@basemaps/config-loader": "^8.1.0",
     "@basemaps/geo": "^8.0.0",
-    "@basemaps/shared": "^8.0.0",
+    "@basemaps/shared": "^8.1.0",
     "@basemaps/tiler": "^8.0.0",
-    "@basemaps/tiler-sharp": "^8.0.0",
+    "@basemaps/tiler-sharp": "^8.1.0",
     "@linzjs/geojson": "^8.0.0",
     "@linzjs/lambda": "^4.0.0",
     "@mapbox/vector-tile": "^2.0.3",

--- a/packages/landing/CHANGELOG.md
+++ b/packages/landing/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
+
+**Note:** Version bump only for package @basemaps/landing
+
+
+
+
+
 # [8.0.0](https://github.com/linz/basemaps/compare/v7.17.0...v8.0.0) (2025-05-11)
 
 

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/landing",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -29,11 +29,11 @@
   ],
   "devDependencies": {
     "@basemaps/attribution": "^8.0.0",
-    "@basemaps/cli-config": "^8.0.0",
-    "@basemaps/config": "^8.0.0",
+    "@basemaps/cli-config": "^8.1.0",
+    "@basemaps/config": "^8.1.0",
     "@basemaps/geo": "^8.0.0",
-    "@basemaps/infra": "^8.0.0",
-    "@basemaps/shared": "^8.0.0",
+    "@basemaps/infra": "^8.1.0",
+    "@basemaps/shared": "^8.1.0",
     "@linzjs/geojson": "^8.0.0",
     "@linzjs/lui": "^21.46.0",
     "@servie/events": "^3.0.0",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
+
+**Note:** Version bump only for package @basemaps/server
+
+
+
+
+
 # [8.0.0](https://github.com/linz/basemaps/compare/v7.17.0...v8.0.0) (2025-05-11)
 
 **Note:** Version bump only for package @basemaps/server

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/server",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -52,12 +52,12 @@
     "sharp": "^0.33.0"
   },
   "devDependencies": {
-    "@basemaps/config": "^8.0.0",
-    "@basemaps/config-loader": "^8.0.0",
+    "@basemaps/config": "^8.1.0",
+    "@basemaps/config-loader": "^8.1.0",
     "@basemaps/geo": "^8.0.0",
-    "@basemaps/lambda-tiler": "^8.0.0",
+    "@basemaps/lambda-tiler": "^8.1.0",
     "@basemaps/landing": "^6.39.0",
-    "@basemaps/shared": "^8.0.0",
+    "@basemaps/shared": "^8.1.0",
     "@fastify/formbody": "^7.0.1",
     "@fastify/static": "^6.5.0",
     "cmd-ts": "^0.12.1",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
+
+**Note:** Version bump only for package @basemaps/shared
+
+
+
+
+
 # [8.0.0](https://github.com/linz/basemaps/compare/v7.17.0...v8.0.0) (2025-05-11)
 
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/shared",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -26,7 +26,7 @@
     "@aws-sdk/client-dynamodb": "^3.470.0",
     "@aws-sdk/client-s3": "^3.472.0",
     "@aws-sdk/util-dynamodb": "^3.470.0",
-    "@basemaps/config": "^8.0.0",
+    "@basemaps/config": "^8.1.0",
     "@basemaps/geo": "^8.0.0",
     "@chunkd/fs": "^11.2.0",
     "@chunkd/fs-aws": "^11.3.0",

--- a/packages/tiler-sharp/CHANGELOG.md
+++ b/packages/tiler-sharp/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
+
+**Note:** Version bump only for package @basemaps/tiler-sharp
+
+
+
+
+
 # [8.0.0](https://github.com/linz/basemaps/compare/v7.17.0...v8.0.0) (2025-05-11)
 
 **Note:** Version bump only for package @basemaps/tiler-sharp

--- a/packages/tiler-sharp/package.json
+++ b/packages/tiler-sharp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/tiler-sharp",
-  "version": "8.0.0",
+  "version": "8.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -22,7 +22,7 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@basemaps/config": "^8.0.0",
+    "@basemaps/config": "^8.1.0",
     "@basemaps/geo": "^8.0.0",
     "@basemaps/tiler": "^8.0.0",
     "@linzjs/metrics": "^8.0.0",


### PR DESCRIPTION
### [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0)


### Bug Fixes

* correct cli-config 'import' parameters ([#3445](https://github.com/linz/basemaps/issues/3445)) ([f349080](https://github.com/linz/basemaps/commit/f349080c473100cc5361162719011c2b152ea299)), closes [/github.com/linz/basemaps/pull/3427/commits/01a90a2b98bab02632a9637bfed2067c9c047c61#diff-48a5e932b724482f9a280931b7bb1188d26ef004b87c331aadfc7a7948ec7f70](https://github.com//github.com/linz/basemaps/pull/3427/commits/01a90a2b98bab02632a9637bfed2067c9c047c61/issues/diff-48a5e932b724482f9a280931b7bb1188d26ef004b87c331aadfc7a7948ec7f70) [/github.com/linz/basemaps-config/blob/a5b8b9baaa9941314a13058e53945bc5db5f5357/.github/workflows/build.yml#L131](https://github.com//github.com/linz/basemaps-config/blob/a5b8b9baaa9941314a13058e53945bc5db5f5357/.github/workflows/build.yml/issues/L131)
* parsing of blocked api keys ([#3448](https://github.com/linz/basemaps/issues/3448)) ([ab8bf72](https://github.com/linz/basemaps/commit/ab8bf7221df32eac59beb2d4e5cad78015c88395))


### Features

* **lambda-tiler:** expose configuration id and hash if present ([#3446](https://github.com/linz/basemaps/issues/3446)) ([43803b4](https://github.com/linz/basemaps/commit/43803b48a404591417453331ac9e3aa16c85248f))
