### PR TITLE
build: ensure production tags are made before container tags are made

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -35,6 +35,16 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: (Prod) Ensure tag exists
+        if: github.ref == 'refs/heads/master' && startsWith(github.event.head_commit.message, 'release:')
+        run: |
+          git fetch --depth=1 origin +refs/tags/*:refs/tags/* # see https://stackoverflow.com/a/60184319/9285308
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          CURRENT_VERSION=$(node -p "require('./lerna.json').version")
+          git tag v${CURRENT_VERSION} -m v${CURRENT_VERSION} || true # Only create the tag if it doesn't exist
+
       - name: Setup tags
         id: version
         run: |


### PR DESCRIPTION
### Motivation

When releases are made, the production `v8.0.1` tag is created after the containers are built causing the containers to be released on the wrong tag.

### Modifications

Ensure the production tags are created before containers are tagged.

### Verification

Wait for containers to build
