### PR TITLE
feat(shared): allow access to s3 nz-coastal public bucket

### DIFF
--- a/packages/shared/src/file.system.ts
+++ b/packages/shared/src/file.system.ts
@@ -79,6 +79,7 @@ fsa.register('https://', new FsHttp());
 fsa.register('s3://', s3Fs);
 fsa.register('s3://nz-imagery', s3FsPublic);
 fsa.register('s3://nz-elevation', s3FsPublic);
+fsa.register('s3://nz-coastal', s3FsPublic);
 
 export const Fsa = fsa;
 


### PR DESCRIPTION
### Motivation

Allow basemaps to access data from nz-coastal bucket.

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->
Assign `nz-coastal` as a bucket that can be accessed without signing the requests.

### Verification

<!-- TODO: Say how you tested your changes. -->
