### PR TITLE
release: v8.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
+
+
+### Bug Fixes
+
+* remove quoting from rimraf commands ([#3434](https://github.com/linz/basemaps/issues/3434)) ([58f31da](https://github.com/linz/basemaps/commit/58f31da0a56a654366881bfb39310f8adabcbd93))
+
+
+### Features
+
+* **cli-vector:** analyse mbtiles BM-1270 ([#3444](https://github.com/linz/basemaps/issues/3444)) ([e721392](https://github.com/linz/basemaps/commit/e721392d52866ef0d31e110d32e718460ce3008b))
+* **cli-vector:** New cli to create and join mbtiles for vector map. BM-1268 ([#3435](https://github.com/linz/basemaps/issues/3435)) ([8cbef0b](https://github.com/linz/basemaps/commit/8cbef0b0a9ef3db804d05b533b6858f55c9064c9))
+* **shared:** allow access to s3 nz-coastal public bucket ([#3453](https://github.com/linz/basemaps/issues/3453)) ([ab54746](https://github.com/linz/basemaps/commit/ab5474681084355b0168b85e89e5c22859177546))
+
+
+
+
+
 # [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
       "conventionalCommits": true
     }
   },
-  "version": "8.1.0"
+  "version": "8.2.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19467,13 +19467,13 @@
     },
     "packages/_infra": {
       "name": "@basemaps/infra",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "license": "MIT",
       "devDependencies": {
         "@aws-sdk/client-acm": "^3.470.0",
         "@aws-sdk/client-cloudformation": "^3.470.0",
-        "@basemaps/lambda-tiler": "^8.1.0",
-        "@basemaps/shared": "^8.1.0",
+        "@basemaps/lambda-tiler": "^8.2.0",
+        "@basemaps/shared": "^8.2.0",
         "@linzjs/cdk-tags": "^1.7.0",
         "aws-cdk": "2.162.x",
         "aws-cdk-lib": "2.162.x",
@@ -19497,11 +19497,11 @@
     },
     "packages/bathymetry": {
       "name": "@basemaps/bathymetry",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "license": "MIT",
       "dependencies": {
         "@basemaps/geo": "^8.0.0",
-        "@basemaps/shared": "^8.1.0",
+        "@basemaps/shared": "^8.2.0",
         "@rushstack/ts-command-line": "^4.3.13",
         "ulid": "^2.3.0"
       },
@@ -19524,13 +19524,13 @@
     },
     "packages/cli": {
       "name": "@basemaps/cli",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/cli-config": "^8.1.0",
-        "@basemaps/cli-raster": "^8.1.0",
-        "@basemaps/cli-vector": "^8.1.0",
-        "@basemaps/shared": "^8.1.0",
+        "@basemaps/cli-config": "^8.2.0",
+        "@basemaps/cli-raster": "^8.2.0",
+        "@basemaps/cli-vector": "^8.2.0",
+        "@basemaps/shared": "^8.2.0",
         "cmd-ts": "^0.13.0"
       },
       "bin": {
@@ -19542,13 +19542,13 @@
     },
     "packages/cli-config": {
       "name": "@basemaps/cli-config",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "license": "MIT",
       "dependencies": {
         "@basemaps/config": "^8.1.0",
-        "@basemaps/config-loader": "^8.1.0",
+        "@basemaps/config-loader": "^8.2.0",
         "@basemaps/geo": "^8.0.0",
-        "@basemaps/shared": "^8.1.0",
+        "@basemaps/shared": "^8.2.0",
         "@cotar/builder": "^6.0.1",
         "@cotar/core": "^6.0.1",
         "@cotar/tar": "^6.0.1",
@@ -19590,16 +19590,16 @@
     },
     "packages/cli-raster": {
       "name": "@basemaps/cli-raster",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "license": "MIT",
       "bin": {
         "cogify": "build/bin.js"
       },
       "devDependencies": {
         "@basemaps/config": "^8.1.0",
-        "@basemaps/config-loader": "^8.1.0",
+        "@basemaps/config-loader": "^8.2.0",
         "@basemaps/geo": "^8.0.0",
-        "@basemaps/shared": "^8.1.0",
+        "@basemaps/shared": "^8.2.0",
         "@linzjs/geojson": "^8.0.0",
         "@linzjs/metrics": "^8.0.0",
         "cmd-ts": "^0.12.1",
@@ -19612,12 +19612,12 @@
     },
     "packages/cli-vector": {
       "name": "@basemaps/cli-vector",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "license": "MIT",
       "dependencies": {
         "@basemaps/config": "^8.1.0",
         "@basemaps/geo": "^8.0.0",
-        "@basemaps/shared": "^8.1.0",
+        "@basemaps/shared": "^8.2.0",
         "@cotar/builder": "^6.0.1",
         "@cotar/core": "^6.0.1",
         "@linzjs/docker-command": "^7.5.0",
@@ -19717,12 +19717,12 @@
     },
     "packages/config-loader": {
       "name": "@basemaps/config-loader",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "license": "MIT",
       "dependencies": {
         "@basemaps/config": "^8.1.0",
         "@basemaps/geo": "^8.0.0",
-        "@basemaps/shared": "^8.1.0"
+        "@basemaps/shared": "^8.2.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -19754,12 +19754,12 @@
     },
     "packages/lambda-analytic-cloudfront": {
       "name": "@basemaps/lambda-analytic-cloudfront",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "license": "MIT",
       "dependencies": {
         "@basemaps/config": "^8.1.0",
         "@basemaps/geo": "^8.0.0",
-        "@basemaps/shared": "^8.1.0",
+        "@basemaps/shared": "^8.2.0",
         "@elastic/elasticsearch": "^8.16.2",
         "@linzjs/lambda": "^4.0.0",
         "ua-parser-js": "^1.0.39"
@@ -19773,12 +19773,12 @@
     },
     "packages/lambda-analytics": {
       "name": "@basemaps/lambda-analytics",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "license": "MIT",
       "dependencies": {
         "@basemaps/config": "^8.1.0",
         "@basemaps/geo": "^8.0.0",
-        "@basemaps/shared": "^8.1.0",
+        "@basemaps/shared": "^8.2.0",
         "ua-parser-js": "^1.0.2"
       },
       "devDependencies": {
@@ -19790,13 +19790,13 @@
     },
     "packages/lambda-tiler": {
       "name": "@basemaps/lambda-tiler",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "license": "MIT",
       "dependencies": {
         "@basemaps/config": "^8.1.0",
-        "@basemaps/config-loader": "^8.1.0",
+        "@basemaps/config-loader": "^8.2.0",
         "@basemaps/geo": "^8.0.0",
-        "@basemaps/shared": "^8.1.0",
+        "@basemaps/shared": "^8.2.0",
         "@basemaps/tiler": "^8.0.0",
         "@basemaps/tiler-sharp": "^8.1.0",
         "@linzjs/geojson": "^8.0.0",
@@ -19856,15 +19856,15 @@
     },
     "packages/landing": {
       "name": "@basemaps/landing",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "license": "MIT",
       "devDependencies": {
         "@basemaps/attribution": "^8.0.0",
-        "@basemaps/cli-config": "^8.1.0",
+        "@basemaps/cli-config": "^8.2.0",
         "@basemaps/config": "^8.1.0",
         "@basemaps/geo": "^8.0.0",
-        "@basemaps/infra": "^8.1.0",
-        "@basemaps/shared": "^8.1.0",
+        "@basemaps/infra": "^8.2.0",
+        "@basemaps/shared": "^8.2.0",
         "@linzjs/geojson": "^8.0.0",
         "@linzjs/lui": "^21.46.0",
         "@servie/events": "^3.0.0",
@@ -19932,7 +19932,7 @@
     },
     "packages/server": {
       "name": "@basemaps/server",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "license": "MIT",
       "dependencies": {
         "lerc": "^4.0.4",
@@ -19943,11 +19943,11 @@
       },
       "devDependencies": {
         "@basemaps/config": "^8.1.0",
-        "@basemaps/config-loader": "^8.1.0",
+        "@basemaps/config-loader": "^8.2.0",
         "@basemaps/geo": "^8.0.0",
-        "@basemaps/lambda-tiler": "^8.1.0",
+        "@basemaps/lambda-tiler": "^8.2.0",
         "@basemaps/landing": "^6.39.0",
-        "@basemaps/shared": "^8.1.0",
+        "@basemaps/shared": "^8.2.0",
         "@fastify/formbody": "^7.0.1",
         "@fastify/static": "^6.5.0",
         "cmd-ts": "^0.12.1",
@@ -19972,7 +19972,7 @@
     },
     "packages/shared": {
       "name": "@basemaps/shared",
-      "version": "8.1.0",
+      "version": "8.2.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.470.0",

--- a/packages/_infra/CHANGELOG.md
+++ b/packages/_infra/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
+
+**Note:** Version bump only for package @basemaps/infra
+
+
+
+
+
 # [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
 
 

--- a/packages/_infra/package.json
+++ b/packages/_infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/infra",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -26,8 +26,8 @@
   "devDependencies": {
     "@aws-sdk/client-acm": "^3.470.0",
     "@aws-sdk/client-cloudformation": "^3.470.0",
-    "@basemaps/lambda-tiler": "^8.1.0",
-    "@basemaps/shared": "^8.1.0",
+    "@basemaps/lambda-tiler": "^8.2.0",
+    "@basemaps/shared": "^8.2.0",
     "@linzjs/cdk-tags": "^1.7.0",
     "aws-cdk": "2.162.x",
     "aws-cdk-lib": "2.162.x",

--- a/packages/bathymetry/CHANGELOG.md
+++ b/packages/bathymetry/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
+
+**Note:** Version bump only for package @basemaps/bathymetry
+
+
+
+
+
 # [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
 
 **Note:** Version bump only for package @basemaps/bathymetry

--- a/packages/bathymetry/package.json
+++ b/packages/bathymetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/bathymetry",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "@basemaps/geo": "^8.0.0",
-    "@basemaps/shared": "^8.1.0",
+    "@basemaps/shared": "^8.2.0",
     "@rushstack/ts-command-line": "^4.3.13",
     "ulid": "^2.3.0"
   },

--- a/packages/cli-config/CHANGELOG.md
+++ b/packages/cli-config/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
+
+
+### Features
+
+* **cli-vector:** analyse mbtiles BM-1270 ([#3444](https://github.com/linz/basemaps/issues/3444)) ([e721392](https://github.com/linz/basemaps/commit/e721392d52866ef0d31e110d32e718460ce3008b))
+
+
+
+
+
 # [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
 
 

--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli-config",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -25,9 +25,9 @@
   },
   "dependencies": {
     "@basemaps/config": "^8.1.0",
-    "@basemaps/config-loader": "^8.1.0",
+    "@basemaps/config-loader": "^8.2.0",
     "@basemaps/geo": "^8.0.0",
-    "@basemaps/shared": "^8.1.0",
+    "@basemaps/shared": "^8.2.0",
     "@cotar/builder": "^6.0.1",
     "@cotar/core": "^6.0.1",
     "@cotar/tar": "^6.0.1",

--- a/packages/cli-raster/CHANGELOG.md
+++ b/packages/cli-raster/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
+
+**Note:** Version bump only for package @basemaps/cli-raster
+
+
+
+
+
 # [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
 
 **Note:** Version bump only for package @basemaps/cli-raster

--- a/packages/cli-raster/package.json
+++ b/packages/cli-raster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli-raster",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -41,9 +41,9 @@
   },
   "devDependencies": {
     "@basemaps/config": "^8.1.0",
-    "@basemaps/config-loader": "^8.1.0",
+    "@basemaps/config-loader": "^8.2.0",
     "@basemaps/geo": "^8.0.0",
-    "@basemaps/shared": "^8.1.0",
+    "@basemaps/shared": "^8.2.0",
     "@linzjs/geojson": "^8.0.0",
     "@linzjs/metrics": "^8.0.0",
     "cmd-ts": "^0.12.1",

--- a/packages/cli-vector/CHANGELOG.md
+++ b/packages/cli-vector/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
+
+
+### Features
+
+* **cli-vector:** analyse mbtiles BM-1270 ([#3444](https://github.com/linz/basemaps/issues/3444)) ([e721392](https://github.com/linz/basemaps/commit/e721392d52866ef0d31e110d32e718460ce3008b))
+* **cli-vector:** New cli to create and join mbtiles for vector map. BM-1268 ([#3435](https://github.com/linz/basemaps/issues/3435)) ([8cbef0b](https://github.com/linz/basemaps/commit/8cbef0b0a9ef3db804d05b533b6858f55c9064c9))
+
+
+
+
+
 # [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
 
 **Note:** Version bump only for package @basemaps/cli-vector

--- a/packages/cli-vector/package.json
+++ b/packages/cli-vector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli-vector",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -51,7 +51,7 @@
   "dependencies": {
     "@basemaps/config": "^8.1.0",
     "@basemaps/geo": "^8.0.0",
-    "@basemaps/shared": "^8.1.0",
+    "@basemaps/shared": "^8.2.0",
     "@cotar/builder": "^6.0.1",
     "@cotar/core": "^6.0.1",
     "@linzjs/docker-command": "^7.5.0",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
+
+
+### Features
+
+* **cli-vector:** analyse mbtiles BM-1270 ([#3444](https://github.com/linz/basemaps/issues/3444)) ([e721392](https://github.com/linz/basemaps/commit/e721392d52866ef0d31e110d32e718460ce3008b))
+* **cli-vector:** New cli to create and join mbtiles for vector map. BM-1268 ([#3435](https://github.com/linz/basemaps/issues/3435)) ([8cbef0b](https://github.com/linz/basemaps/commit/8cbef0b0a9ef3db804d05b533b6858f55c9064c9))
+
+
+
+
+
 # [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
 
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -41,10 +41,10 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
-    "@basemaps/cli-config": "^8.1.0",
-    "@basemaps/cli-raster": "^8.1.0",
-    "@basemaps/cli-vector": "^8.1.0",
-    "@basemaps/shared": "^8.1.0",
+    "@basemaps/cli-config": "^8.2.0",
+    "@basemaps/cli-raster": "^8.2.0",
+    "@basemaps/cli-vector": "^8.2.0",
+    "@basemaps/shared": "^8.2.0",
     "cmd-ts": "^0.13.0"
   },
   "publishConfig": {

--- a/packages/config-loader/CHANGELOG.md
+++ b/packages/config-loader/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
+
+**Note:** Version bump only for package @basemaps/config-loader
+
+
+
+
+
 # [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
 
 **Note:** Version bump only for package @basemaps/config-loader

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/config-loader",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -30,6 +30,6 @@
   "dependencies": {
     "@basemaps/config": "^8.1.0",
     "@basemaps/geo": "^8.0.0",
-    "@basemaps/shared": "^8.1.0"
+    "@basemaps/shared": "^8.2.0"
   }
 }

--- a/packages/lambda-analytic-cloudfront/CHANGELOG.md
+++ b/packages/lambda-analytic-cloudfront/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
+
+**Note:** Version bump only for package @basemaps/lambda-analytic-cloudfront
+
+
+
+
+
 # [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
 
 **Note:** Version bump only for package @basemaps/lambda-analytic-cloudfront

--- a/packages/lambda-analytic-cloudfront/package.json
+++ b/packages/lambda-analytic-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-analytic-cloudfront",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -20,7 +20,7 @@
   "dependencies": {
     "@basemaps/config": "^8.1.0",
     "@basemaps/geo": "^8.0.0",
-    "@basemaps/shared": "^8.1.0",
+    "@basemaps/shared": "^8.2.0",
     "@elastic/elasticsearch": "^8.16.2",
     "@linzjs/lambda": "^4.0.0",
     "ua-parser-js": "^1.0.39"

--- a/packages/lambda-analytics/CHANGELOG.md
+++ b/packages/lambda-analytics/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
+
+**Note:** Version bump only for package @basemaps/lambda-analytics
+
+
+
+
+
 # [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
 
 **Note:** Version bump only for package @basemaps/lambda-analytics

--- a/packages/lambda-analytics/package.json
+++ b/packages/lambda-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-analytics",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -20,7 +20,7 @@
   "dependencies": {
     "@basemaps/config": "^8.1.0",
     "@basemaps/geo": "^8.0.0",
-    "@basemaps/shared": "^8.1.0",
+    "@basemaps/shared": "^8.2.0",
     "ua-parser-js": "^1.0.2"
   },
   "scripts": {

--- a/packages/lambda-tiler/CHANGELOG.md
+++ b/packages/lambda-tiler/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
+
+**Note:** Version bump only for package @basemaps/lambda-tiler
+
+
+
+
+
 # [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
 
 

--- a/packages/lambda-tiler/package.json
+++ b/packages/lambda-tiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-tiler",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -23,9 +23,9 @@
   "license": "MIT",
   "dependencies": {
     "@basemaps/config": "^8.1.0",
-    "@basemaps/config-loader": "^8.1.0",
+    "@basemaps/config-loader": "^8.2.0",
     "@basemaps/geo": "^8.0.0",
-    "@basemaps/shared": "^8.1.0",
+    "@basemaps/shared": "^8.2.0",
     "@basemaps/tiler": "^8.0.0",
     "@basemaps/tiler-sharp": "^8.1.0",
     "@linzjs/geojson": "^8.0.0",

--- a/packages/landing/CHANGELOG.md
+++ b/packages/landing/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
+
+**Note:** Version bump only for package @basemaps/landing
+
+
+
+
+
 # [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
 
 **Note:** Version bump only for package @basemaps/landing

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/landing",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -29,11 +29,11 @@
   ],
   "devDependencies": {
     "@basemaps/attribution": "^8.0.0",
-    "@basemaps/cli-config": "^8.1.0",
+    "@basemaps/cli-config": "^8.2.0",
     "@basemaps/config": "^8.1.0",
     "@basemaps/geo": "^8.0.0",
-    "@basemaps/infra": "^8.1.0",
-    "@basemaps/shared": "^8.1.0",
+    "@basemaps/infra": "^8.2.0",
+    "@basemaps/shared": "^8.2.0",
     "@linzjs/geojson": "^8.0.0",
     "@linzjs/lui": "^21.46.0",
     "@servie/events": "^3.0.0",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
+
+**Note:** Version bump only for package @basemaps/server
+
+
+
+
+
 # [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
 
 **Note:** Version bump only for package @basemaps/server

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/server",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -53,11 +53,11 @@
   },
   "devDependencies": {
     "@basemaps/config": "^8.1.0",
-    "@basemaps/config-loader": "^8.1.0",
+    "@basemaps/config-loader": "^8.2.0",
     "@basemaps/geo": "^8.0.0",
-    "@basemaps/lambda-tiler": "^8.1.0",
+    "@basemaps/lambda-tiler": "^8.2.0",
     "@basemaps/landing": "^6.39.0",
-    "@basemaps/shared": "^8.1.0",
+    "@basemaps/shared": "^8.2.0",
     "@fastify/formbody": "^7.0.1",
     "@fastify/static": "^6.5.0",
     "cmd-ts": "^0.12.1",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
+
+
+### Features
+
+* **shared:** allow access to s3 nz-coastal public bucket ([#3453](https://github.com/linz/basemaps/issues/3453)) ([ab54746](https://github.com/linz/basemaps/commit/ab5474681084355b0168b85e89e5c22859177546))
+
+
+
+
+
 # [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
 
 **Note:** Version bump only for package @basemaps/shared

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/shared",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "private": false,
   "repository": {
     "type": "git",


### PR DESCRIPTION
# [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)

### Bug Fixes

* remove quoting from rimraf commands ([#3434](https://github.com/linz/basemaps/issues/3434)) ([58f31da](https://github.com/linz/basemaps/commit/58f31da0a56a654366881bfb39310f8adabcbd93))

### Features

* **cli-vector:** analyse mbtiles BM-1270 ([#3444](https://github.com/linz/basemaps/issues/3444)) ([e721392](https://github.com/linz/basemaps/commit/e721392d52866ef0d31e110d32e718460ce3008b))
* **cli-vector:** New cli to create and join mbtiles for vector map. BM-1268 ([#3435](https://github.com/linz/basemaps/issues/3435)) ([8cbef0b](https://github.com/linz/basemaps/commit/8cbef0b0a9ef3db804d05b533b6858f55c9064c9))
* **shared:** allow access to s3 nz-coastal public bucket ([#3453](https://github.com/linz/basemaps/issues/3453)) ([ab54746](https://github.com/linz/basemaps/commit/ab5474681084355b0168b85e89e5c22859177546))