### PR TITLE
feat(cli-config): Generate topographic previews with the v2 in the url. BM-1203

### DIFF
--- a/packages/cli-config/src/util.ts
+++ b/packages/cli-config/src/util.ts
@@ -150,3 +150,13 @@ export function nameImageryTitle(title: string): string {
     })
     .replace(/[^\w-_]/gi, '');
 }
+
+/**
+ * Get vector tileset versions
+ * @example
+ *  'topographic-v2' => 'v2' or 'topographic' => undefined
+ */
+export function getVectorVersion(tilesetName: string): string | undefined {
+  const match = tilesetName.match(/-(v\d+)$/);
+  return match ? match[1] : undefined;
+}


### PR DESCRIPTION
### Motivation

Once we introduce versions to the vector styles like `topographic-v2`, we should generate the correct preview link instead of hardcode vector to `topographic`. 

### Modifications
Extract the version from name and apply to the url.

### Verification

![image](https://github.com/user-attachments/assets/76e094cc-b15d-4ee1-a578-1616c240b237)
