### PR TITLE
fix(landing): Fix debug page automatically hide topographic-v2. BM-1302

### DIFF
--- a/packages/landing/src/config.map.ts
+++ b/packages/landing/src/config.map.ts
@@ -103,7 +103,7 @@ export class MapConfig extends Emitter<MapConfigEvents> {
   }
 
   get isVector(): boolean {
-    return this.layerId === 'topographic';
+    return this.layerId.startsWith('topographic');
   }
 
   /** Key to reference the combined layer & style  */
@@ -151,7 +151,7 @@ export class MapConfig extends Emitter<MapConfigEvents> {
       this.labels = labels !== 'false';
     }
 
-    if (this.layerId === 'topographic' && this.style == null) this.style = 'topographic';
+    if (this.layerId.startsWith('topographic') && this.style == null) this.style = this.layerId;
     this.emit('tileMatrix', this.tileMatrix);
     this.emit('layer', this.layerId, this.style, this.pipeline, this.imageFormat);
     if (previousUrl !== MapConfig.toUrl(this)) this.emit('change');

--- a/packages/landing/src/debug.map.ts
+++ b/packages/landing/src/debug.map.ts
@@ -126,7 +126,7 @@ export class DebugMap {
     const layers = styleJson.layers?.filter((f) => f.type !== 'background' && f.source === 'LINZ Basemaps') ?? [];
 
     // Do not hide topographic layers when trying to inspect the topographic layer
-    if (Config.map.layerId === 'topographic') return;
+    if (Config.map.isVector) return;
     // Force all the layers to be invisible to start, otherwise the map will "flash" on then off
     for (const layer of layers) {
       const paint = (layer.paint ?? {}) as Record<string, unknown>;


### PR DESCRIPTION
### Motivation

Debug page is hiding the layers that is not equal to `topographic`, which will hide the layer when `i=topographic-v2`.

### Modifications
Update the check as startWith('topographic') to include all the versions in future.

### Verification
Broken in production: 
https://basemaps.linz.govt.nz/@-41.8899962,174.0492437,z5?style=topographic-v2&i=topographic-v2&debug=true
![image](https://github.com/user-attachments/assets/bb9fcabc-ee54-4349-9e69-5246c5f6ae5c)

Fixed in local test:
![image](https://github.com/user-attachments/assets/81f4ee42-09c6-4d99-abf3-120201f91f17)


