### PR TITLE
release: v8.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
+
+
+### Bug Fixes
+
+* **cli-vector:** collapse large analysis report in pr comment ([#3457](https://github.com/linz/basemaps/issues/3457)) ([19a4d85](https://github.com/linz/basemaps/commit/19a4d85bb90058694c0a5cd3cd2530cd9e60b9a1))
+* **infra:** increase lambda tiler memory to 3072MB ([#3459](https://github.com/linz/basemaps/issues/3459)) ([786bb54](https://github.com/linz/basemaps/commit/786bb5406823fb7438cb1205e1c345c407406bc5))
+* **landing:** Fix debug page automatically hide topographic-v2. BM-1302 ([#3456](https://github.com/linz/basemaps/issues/3456)) ([53134c0](https://github.com/linz/basemaps/commit/53134c0782cdea7fb683170eda30fb675d60923a))
+
+
+### Features
+
+* **cli-config:** Generate topographic previews with the v2 in the url. BM-1203 ([#3455](https://github.com/linz/basemaps/issues/3455)) ([1a2f220](https://github.com/linz/basemaps/commit/1a2f220b42689d433e07183557cd42b69e5e22d3))
+* **cli-vector:** Support NZTM mbtiles creation.BM-1300 ([#3452](https://github.com/linz/basemaps/issues/3452)) ([f601a73](https://github.com/linz/basemaps/commit/f601a73185aad7f22f6e0e5551d41ba49588c932))
+* **landing:** Support NZTM vector Links in the menu page. BM-1301 ([#3458](https://github.com/linz/basemaps/issues/3458)) ([a57059e](https://github.com/linz/basemaps/commit/a57059e2fa81b3be228ce46807b610c09379a4ee))
+
+
+
+
+
 # [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
       "conventionalCommits": true
     }
   },
-  "version": "8.2.0"
+  "version": "8.3.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19467,13 +19467,13 @@
     },
     "packages/_infra": {
       "name": "@basemaps/infra",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "license": "MIT",
       "devDependencies": {
         "@aws-sdk/client-acm": "^3.470.0",
         "@aws-sdk/client-cloudformation": "^3.470.0",
-        "@basemaps/lambda-tiler": "^8.2.0",
-        "@basemaps/shared": "^8.2.0",
+        "@basemaps/lambda-tiler": "^8.3.0",
+        "@basemaps/shared": "^8.3.0",
         "@linzjs/cdk-tags": "^1.7.0",
         "aws-cdk": "2.162.x",
         "aws-cdk-lib": "2.162.x",
@@ -19485,10 +19485,10 @@
     },
     "packages/attribution": {
       "name": "@basemaps/attribution",
-      "version": "8.0.0",
+      "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/geo": "^8.0.0",
+        "@basemaps/geo": "^8.3.0",
         "@linzjs/geojson": "^8.0.0"
       },
       "engines": {
@@ -19497,11 +19497,11 @@
     },
     "packages/bathymetry": {
       "name": "@basemaps/bathymetry",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/geo": "^8.0.0",
-        "@basemaps/shared": "^8.2.0",
+        "@basemaps/geo": "^8.3.0",
+        "@basemaps/shared": "^8.3.0",
         "@rushstack/ts-command-line": "^4.3.13",
         "ulid": "^2.3.0"
       },
@@ -19524,13 +19524,13 @@
     },
     "packages/cli": {
       "name": "@basemaps/cli",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/cli-config": "^8.2.0",
-        "@basemaps/cli-raster": "^8.2.0",
-        "@basemaps/cli-vector": "^8.2.0",
-        "@basemaps/shared": "^8.2.0",
+        "@basemaps/cli-config": "^8.3.0",
+        "@basemaps/cli-raster": "^8.3.0",
+        "@basemaps/cli-vector": "^8.3.0",
+        "@basemaps/shared": "^8.3.0",
         "cmd-ts": "^0.13.0"
       },
       "bin": {
@@ -19542,13 +19542,13 @@
     },
     "packages/cli-config": {
       "name": "@basemaps/cli-config",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^8.1.0",
-        "@basemaps/config-loader": "^8.2.0",
-        "@basemaps/geo": "^8.0.0",
-        "@basemaps/shared": "^8.2.0",
+        "@basemaps/config": "^8.3.0",
+        "@basemaps/config-loader": "^8.3.0",
+        "@basemaps/geo": "^8.3.0",
+        "@basemaps/shared": "^8.3.0",
         "@cotar/builder": "^6.0.1",
         "@cotar/core": "^6.0.1",
         "@cotar/tar": "^6.0.1",
@@ -19590,16 +19590,16 @@
     },
     "packages/cli-raster": {
       "name": "@basemaps/cli-raster",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "license": "MIT",
       "bin": {
         "cogify": "build/bin.js"
       },
       "devDependencies": {
-        "@basemaps/config": "^8.1.0",
-        "@basemaps/config-loader": "^8.2.0",
-        "@basemaps/geo": "^8.0.0",
-        "@basemaps/shared": "^8.2.0",
+        "@basemaps/config": "^8.3.0",
+        "@basemaps/config-loader": "^8.3.0",
+        "@basemaps/geo": "^8.3.0",
+        "@basemaps/shared": "^8.3.0",
         "@linzjs/geojson": "^8.0.0",
         "@linzjs/metrics": "^8.0.0",
         "cmd-ts": "^0.12.1",
@@ -19612,12 +19612,12 @@
     },
     "packages/cli-vector": {
       "name": "@basemaps/cli-vector",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^8.1.0",
-        "@basemaps/geo": "^8.0.0",
-        "@basemaps/shared": "^8.2.0",
+        "@basemaps/config": "^8.3.0",
+        "@basemaps/geo": "^8.3.0",
+        "@basemaps/shared": "^8.3.0",
         "@cotar/builder": "^6.0.1",
         "@cotar/core": "^6.0.1",
         "@linzjs/docker-command": "^7.5.0",
@@ -19704,10 +19704,10 @@
     },
     "packages/config": {
       "name": "@basemaps/config",
-      "version": "8.1.0",
+      "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/geo": "^8.0.0",
+        "@basemaps/geo": "^8.3.0",
         "base-x": "^4.0.0",
         "zod": "^3.17.3"
       },
@@ -19717,12 +19717,12 @@
     },
     "packages/config-loader": {
       "name": "@basemaps/config-loader",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^8.1.0",
-        "@basemaps/geo": "^8.0.0",
-        "@basemaps/shared": "^8.2.0"
+        "@basemaps/config": "^8.3.0",
+        "@basemaps/geo": "^8.3.0",
+        "@basemaps/shared": "^8.3.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -19730,7 +19730,7 @@
     },
     "packages/geo": {
       "name": "@basemaps/geo",
-      "version": "8.0.0",
+      "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
         "@linzjs/geojson": "^8.0.0",
@@ -19754,12 +19754,12 @@
     },
     "packages/lambda-analytic-cloudfront": {
       "name": "@basemaps/lambda-analytic-cloudfront",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^8.1.0",
-        "@basemaps/geo": "^8.0.0",
-        "@basemaps/shared": "^8.2.0",
+        "@basemaps/config": "^8.3.0",
+        "@basemaps/geo": "^8.3.0",
+        "@basemaps/shared": "^8.3.0",
         "@elastic/elasticsearch": "^8.16.2",
         "@linzjs/lambda": "^4.0.0",
         "ua-parser-js": "^1.0.39"
@@ -19773,12 +19773,12 @@
     },
     "packages/lambda-analytics": {
       "name": "@basemaps/lambda-analytics",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^8.1.0",
-        "@basemaps/geo": "^8.0.0",
-        "@basemaps/shared": "^8.2.0",
+        "@basemaps/config": "^8.3.0",
+        "@basemaps/geo": "^8.3.0",
+        "@basemaps/shared": "^8.3.0",
         "ua-parser-js": "^1.0.2"
       },
       "devDependencies": {
@@ -19790,15 +19790,15 @@
     },
     "packages/lambda-tiler": {
       "name": "@basemaps/lambda-tiler",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^8.1.0",
-        "@basemaps/config-loader": "^8.2.0",
-        "@basemaps/geo": "^8.0.0",
-        "@basemaps/shared": "^8.2.0",
-        "@basemaps/tiler": "^8.0.0",
-        "@basemaps/tiler-sharp": "^8.1.0",
+        "@basemaps/config": "^8.3.0",
+        "@basemaps/config-loader": "^8.3.0",
+        "@basemaps/geo": "^8.3.0",
+        "@basemaps/shared": "^8.3.0",
+        "@basemaps/tiler": "^8.3.0",
+        "@basemaps/tiler-sharp": "^8.3.0",
         "@linzjs/geojson": "^8.0.0",
         "@linzjs/lambda": "^4.0.0",
         "@mapbox/vector-tile": "^2.0.3",
@@ -19808,7 +19808,7 @@
         "sharp": "^0.33.0"
       },
       "devDependencies": {
-        "@basemaps/attribution": "^8.0.0",
+        "@basemaps/attribution": "^8.3.0",
         "@chunkd/fs": "^11.2.0",
         "@types/aws-lambda": "^8.10.75",
         "@types/pixelmatch": "^5.0.0",
@@ -19856,15 +19856,15 @@
     },
     "packages/landing": {
       "name": "@basemaps/landing",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "license": "MIT",
       "devDependencies": {
-        "@basemaps/attribution": "^8.0.0",
-        "@basemaps/cli-config": "^8.2.0",
-        "@basemaps/config": "^8.1.0",
-        "@basemaps/geo": "^8.0.0",
-        "@basemaps/infra": "^8.2.0",
-        "@basemaps/shared": "^8.2.0",
+        "@basemaps/attribution": "^8.3.0",
+        "@basemaps/cli-config": "^8.3.0",
+        "@basemaps/config": "^8.3.0",
+        "@basemaps/geo": "^8.3.0",
+        "@basemaps/infra": "^8.3.0",
+        "@basemaps/shared": "^8.3.0",
         "@linzjs/geojson": "^8.0.0",
         "@linzjs/lui": "^21.46.0",
         "@servie/events": "^3.0.0",
@@ -19932,7 +19932,7 @@
     },
     "packages/server": {
       "name": "@basemaps/server",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
         "lerc": "^4.0.4",
@@ -19942,12 +19942,12 @@
         "basemaps-server": "bin/basemaps-server.cjs"
       },
       "devDependencies": {
-        "@basemaps/config": "^8.1.0",
-        "@basemaps/config-loader": "^8.2.0",
-        "@basemaps/geo": "^8.0.0",
-        "@basemaps/lambda-tiler": "^8.2.0",
+        "@basemaps/config": "^8.3.0",
+        "@basemaps/config-loader": "^8.3.0",
+        "@basemaps/geo": "^8.3.0",
+        "@basemaps/lambda-tiler": "^8.3.0",
         "@basemaps/landing": "^6.39.0",
-        "@basemaps/shared": "^8.2.0",
+        "@basemaps/shared": "^8.3.0",
         "@fastify/formbody": "^7.0.1",
         "@fastify/static": "^6.5.0",
         "cmd-ts": "^0.12.1",
@@ -19972,14 +19972,14 @@
     },
     "packages/shared": {
       "name": "@basemaps/shared",
-      "version": "8.2.0",
+      "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.470.0",
         "@aws-sdk/client-s3": "^3.472.0",
         "@aws-sdk/util-dynamodb": "^3.470.0",
-        "@basemaps/config": "^8.1.0",
-        "@basemaps/geo": "^8.0.0",
+        "@basemaps/config": "^8.3.0",
+        "@basemaps/geo": "^8.3.0",
         "@chunkd/fs": "^11.2.0",
         "@chunkd/fs-aws": "^11.3.0",
         "@chunkd/middleware": "^11.1.0",
@@ -20038,10 +20038,10 @@
     },
     "packages/tiler": {
       "name": "@basemaps/tiler",
-      "version": "8.0.0",
+      "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/geo": "^8.0.0",
+        "@basemaps/geo": "^8.3.0",
         "@cogeotiff/core": "^9.0.3",
         "@linzjs/metrics": "^8.0.0"
       },
@@ -20057,12 +20057,12 @@
     },
     "packages/tiler-sharp": {
       "name": "@basemaps/tiler-sharp",
-      "version": "8.1.0",
+      "version": "8.3.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^8.1.0",
-        "@basemaps/geo": "^8.0.0",
-        "@basemaps/tiler": "^8.0.0",
+        "@basemaps/config": "^8.3.0",
+        "@basemaps/geo": "^8.3.0",
+        "@basemaps/tiler": "^8.3.0",
         "@linzjs/metrics": "^8.0.0",
         "lerc": "^4.0.4"
       },

--- a/packages/_infra/CHANGELOG.md
+++ b/packages/_infra/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
+
+
+### Bug Fixes
+
+* **infra:** increase lambda tiler memory to 3072MB ([#3459](https://github.com/linz/basemaps/issues/3459)) ([786bb54](https://github.com/linz/basemaps/commit/786bb5406823fb7438cb1205e1c345c407406bc5))
+
+
+
+
+
 # [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
 
 **Note:** Version bump only for package @basemaps/infra

--- a/packages/_infra/package.json
+++ b/packages/_infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/infra",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -26,8 +26,8 @@
   "devDependencies": {
     "@aws-sdk/client-acm": "^3.470.0",
     "@aws-sdk/client-cloudformation": "^3.470.0",
-    "@basemaps/lambda-tiler": "^8.2.0",
-    "@basemaps/shared": "^8.2.0",
+    "@basemaps/lambda-tiler": "^8.3.0",
+    "@basemaps/shared": "^8.3.0",
     "@linzjs/cdk-tags": "^1.7.0",
     "aws-cdk": "2.162.x",
     "aws-cdk-lib": "2.162.x",

--- a/packages/attribution/CHANGELOG.md
+++ b/packages/attribution/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
+
+**Note:** Version bump only for package @basemaps/attribution
+
+
+
+
+
 # [8.0.0](https://github.com/linz/basemaps/compare/v7.17.0...v8.0.0) (2025-05-11)
 
 **Note:** Version bump only for package @basemaps/attribution

--- a/packages/attribution/package.json
+++ b/packages/attribution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/attribution",
-  "version": "8.0.0",
+  "version": "8.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -30,7 +30,7 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/geo": "^8.0.0",
+    "@basemaps/geo": "^8.3.0",
     "@linzjs/geojson": "^8.0.0"
   },
   "bundle": {

--- a/packages/bathymetry/CHANGELOG.md
+++ b/packages/bathymetry/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
+
+**Note:** Version bump only for package @basemaps/bathymetry
+
+
+
+
+
 # [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
 
 **Note:** Version bump only for package @basemaps/bathymetry

--- a/packages/bathymetry/package.json
+++ b/packages/bathymetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/bathymetry",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -28,8 +28,8 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/geo": "^8.0.0",
-    "@basemaps/shared": "^8.2.0",
+    "@basemaps/geo": "^8.3.0",
+    "@basemaps/shared": "^8.3.0",
     "@rushstack/ts-command-line": "^4.3.13",
     "ulid": "^2.3.0"
   },

--- a/packages/cli-config/CHANGELOG.md
+++ b/packages/cli-config/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
+
+
+### Bug Fixes
+
+* **cli-vector:** collapse large analysis report in pr comment ([#3457](https://github.com/linz/basemaps/issues/3457)) ([19a4d85](https://github.com/linz/basemaps/commit/19a4d85bb90058694c0a5cd3cd2530cd9e60b9a1))
+
+
+### Features
+
+* **cli-config:** Generate topographic previews with the v2 in the url. BM-1203 ([#3455](https://github.com/linz/basemaps/issues/3455)) ([1a2f220](https://github.com/linz/basemaps/commit/1a2f220b42689d433e07183557cd42b69e5e22d3))
+
+
+
+
+
 # [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
 
 

--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli-config",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@basemaps/config": "^8.1.0",
-    "@basemaps/config-loader": "^8.2.0",
-    "@basemaps/geo": "^8.0.0",
-    "@basemaps/shared": "^8.2.0",
+    "@basemaps/config": "^8.3.0",
+    "@basemaps/config-loader": "^8.3.0",
+    "@basemaps/geo": "^8.3.0",
+    "@basemaps/shared": "^8.3.0",
     "@cotar/builder": "^6.0.1",
     "@cotar/core": "^6.0.1",
     "@cotar/tar": "^6.0.1",

--- a/packages/cli-raster/CHANGELOG.md
+++ b/packages/cli-raster/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
+
+**Note:** Version bump only for package @basemaps/cli-raster
+
+
+
+
+
 # [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
 
 **Note:** Version bump only for package @basemaps/cli-raster

--- a/packages/cli-raster/package.json
+++ b/packages/cli-raster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli-raster",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -40,10 +40,10 @@
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "devDependencies": {
-    "@basemaps/config": "^8.1.0",
-    "@basemaps/config-loader": "^8.2.0",
-    "@basemaps/geo": "^8.0.0",
-    "@basemaps/shared": "^8.2.0",
+    "@basemaps/config": "^8.3.0",
+    "@basemaps/config-loader": "^8.3.0",
+    "@basemaps/geo": "^8.3.0",
+    "@basemaps/shared": "^8.3.0",
     "@linzjs/geojson": "^8.0.0",
     "@linzjs/metrics": "^8.0.0",
     "cmd-ts": "^0.12.1",

--- a/packages/cli-vector/CHANGELOG.md
+++ b/packages/cli-vector/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
+
+
+### Bug Fixes
+
+* **cli-vector:** collapse large analysis report in pr comment ([#3457](https://github.com/linz/basemaps/issues/3457)) ([19a4d85](https://github.com/linz/basemaps/commit/19a4d85bb90058694c0a5cd3cd2530cd9e60b9a1))
+
+
+### Features
+
+* **cli-vector:** Support NZTM mbtiles creation.BM-1300 ([#3452](https://github.com/linz/basemaps/issues/3452)) ([f601a73](https://github.com/linz/basemaps/commit/f601a73185aad7f22f6e0e5551d41ba49588c932))
+
+
+
+
+
 # [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
 
 

--- a/packages/cli-vector/package.json
+++ b/packages/cli-vector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli-vector",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -49,9 +49,9 @@
     "dist/"
   ],
   "dependencies": {
-    "@basemaps/config": "^8.1.0",
-    "@basemaps/geo": "^8.0.0",
-    "@basemaps/shared": "^8.2.0",
+    "@basemaps/config": "^8.3.0",
+    "@basemaps/geo": "^8.3.0",
+    "@basemaps/shared": "^8.3.0",
     "@cotar/builder": "^6.0.1",
     "@cotar/core": "^6.0.1",
     "@linzjs/docker-command": "^7.5.0",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
+
+**Note:** Version bump only for package @basemaps/cli
+
+
+
+
+
 # [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
 
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -41,10 +41,10 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
-    "@basemaps/cli-config": "^8.2.0",
-    "@basemaps/cli-raster": "^8.2.0",
-    "@basemaps/cli-vector": "^8.2.0",
-    "@basemaps/shared": "^8.2.0",
+    "@basemaps/cli-config": "^8.3.0",
+    "@basemaps/cli-raster": "^8.3.0",
+    "@basemaps/cli-vector": "^8.3.0",
+    "@basemaps/shared": "^8.3.0",
     "cmd-ts": "^0.13.0"
   },
   "publishConfig": {

--- a/packages/config-loader/CHANGELOG.md
+++ b/packages/config-loader/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
+
+**Note:** Version bump only for package @basemaps/config-loader
+
+
+
+
+
 # [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
 
 **Note:** Version bump only for package @basemaps/config-loader

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/config-loader",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -28,8 +28,8 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/config": "^8.1.0",
-    "@basemaps/geo": "^8.0.0",
-    "@basemaps/shared": "^8.2.0"
+    "@basemaps/config": "^8.3.0",
+    "@basemaps/geo": "^8.3.0",
+    "@basemaps/shared": "^8.3.0"
   }
 }

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
+
+**Note:** Version bump only for package @basemaps/config
+
+
+
+
+
 # [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
 
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/config",
-  "version": "8.1.0",
+  "version": "8.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -28,7 +28,7 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/geo": "^8.0.0",
+    "@basemaps/geo": "^8.3.0",
     "base-x": "^4.0.0",
     "zod": "^3.17.3"
   }

--- a/packages/geo/CHANGELOG.md
+++ b/packages/geo/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
+
+
+### Features
+
+* **cli-vector:** Support NZTM mbtiles creation.BM-1300 ([#3452](https://github.com/linz/basemaps/issues/3452)) ([f601a73](https://github.com/linz/basemaps/commit/f601a73185aad7f22f6e0e5551d41ba49588c932))
+
+
+
+
+
 # [8.0.0](https://github.com/linz/basemaps/compare/v7.17.0...v8.0.0) (2025-05-11)
 
 

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/geo",
-  "version": "8.0.0",
+  "version": "8.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",

--- a/packages/lambda-analytic-cloudfront/CHANGELOG.md
+++ b/packages/lambda-analytic-cloudfront/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
+
+**Note:** Version bump only for package @basemaps/lambda-analytic-cloudfront
+
+
+
+
+
 # [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
 
 **Note:** Version bump only for package @basemaps/lambda-analytic-cloudfront

--- a/packages/lambda-analytic-cloudfront/package.json
+++ b/packages/lambda-analytic-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-analytic-cloudfront",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -18,9 +18,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@basemaps/config": "^8.1.0",
-    "@basemaps/geo": "^8.0.0",
-    "@basemaps/shared": "^8.2.0",
+    "@basemaps/config": "^8.3.0",
+    "@basemaps/geo": "^8.3.0",
+    "@basemaps/shared": "^8.3.0",
     "@elastic/elasticsearch": "^8.16.2",
     "@linzjs/lambda": "^4.0.0",
     "ua-parser-js": "^1.0.39"

--- a/packages/lambda-analytics/CHANGELOG.md
+++ b/packages/lambda-analytics/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
+
+**Note:** Version bump only for package @basemaps/lambda-analytics
+
+
+
+
+
 # [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
 
 **Note:** Version bump only for package @basemaps/lambda-analytics

--- a/packages/lambda-analytics/package.json
+++ b/packages/lambda-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-analytics",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -18,9 +18,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@basemaps/config": "^8.1.0",
-    "@basemaps/geo": "^8.0.0",
-    "@basemaps/shared": "^8.2.0",
+    "@basemaps/config": "^8.3.0",
+    "@basemaps/geo": "^8.3.0",
+    "@basemaps/shared": "^8.3.0",
     "ua-parser-js": "^1.0.2"
   },
   "scripts": {

--- a/packages/lambda-tiler/CHANGELOG.md
+++ b/packages/lambda-tiler/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
+
+**Note:** Version bump only for package @basemaps/lambda-tiler
+
+
+
+
+
 # [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
 
 **Note:** Version bump only for package @basemaps/lambda-tiler

--- a/packages/lambda-tiler/package.json
+++ b/packages/lambda-tiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-tiler",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -22,12 +22,12 @@
   "types": "./build/index.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@basemaps/config": "^8.1.0",
-    "@basemaps/config-loader": "^8.2.0",
-    "@basemaps/geo": "^8.0.0",
-    "@basemaps/shared": "^8.2.0",
-    "@basemaps/tiler": "^8.0.0",
-    "@basemaps/tiler-sharp": "^8.1.0",
+    "@basemaps/config": "^8.3.0",
+    "@basemaps/config-loader": "^8.3.0",
+    "@basemaps/geo": "^8.3.0",
+    "@basemaps/shared": "^8.3.0",
+    "@basemaps/tiler": "^8.3.0",
+    "@basemaps/tiler-sharp": "^8.3.0",
     "@linzjs/geojson": "^8.0.0",
     "@linzjs/lambda": "^4.0.0",
     "@mapbox/vector-tile": "^2.0.3",
@@ -50,7 +50,7 @@
     "bundle": "./bundle.sh"
   },
   "devDependencies": {
-    "@basemaps/attribution": "^8.0.0",
+    "@basemaps/attribution": "^8.3.0",
     "@chunkd/fs": "^11.2.0",
     "@types/aws-lambda": "^8.10.75",
     "@types/pixelmatch": "^5.0.0",

--- a/packages/landing/CHANGELOG.md
+++ b/packages/landing/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
+
+
+### Bug Fixes
+
+* **landing:** Fix debug page automatically hide topographic-v2. BM-1302 ([#3456](https://github.com/linz/basemaps/issues/3456)) ([53134c0](https://github.com/linz/basemaps/commit/53134c0782cdea7fb683170eda30fb675d60923a))
+
+
+### Features
+
+* **cli-vector:** Support NZTM mbtiles creation.BM-1300 ([#3452](https://github.com/linz/basemaps/issues/3452)) ([f601a73](https://github.com/linz/basemaps/commit/f601a73185aad7f22f6e0e5551d41ba49588c932))
+* **landing:** Support NZTM vector Links in the menu page. BM-1301 ([#3458](https://github.com/linz/basemaps/issues/3458)) ([a57059e](https://github.com/linz/basemaps/commit/a57059e2fa81b3be228ce46807b610c09379a4ee))
+
+
+
+
+
 # [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
 
 **Note:** Version bump only for package @basemaps/landing

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/landing",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -28,12 +28,12 @@
     "last 2 Chrome versions"
   ],
   "devDependencies": {
-    "@basemaps/attribution": "^8.0.0",
-    "@basemaps/cli-config": "^8.2.0",
-    "@basemaps/config": "^8.1.0",
-    "@basemaps/geo": "^8.0.0",
-    "@basemaps/infra": "^8.2.0",
-    "@basemaps/shared": "^8.2.0",
+    "@basemaps/attribution": "^8.3.0",
+    "@basemaps/cli-config": "^8.3.0",
+    "@basemaps/config": "^8.3.0",
+    "@basemaps/geo": "^8.3.0",
+    "@basemaps/infra": "^8.3.0",
+    "@basemaps/shared": "^8.3.0",
     "@linzjs/geojson": "^8.0.0",
     "@linzjs/lui": "^21.46.0",
     "@servie/events": "^3.0.0",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
+
+**Note:** Version bump only for package @basemaps/server
+
+
+
+
+
 # [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
 
 **Note:** Version bump only for package @basemaps/server

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/server",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -52,12 +52,12 @@
     "sharp": "^0.33.0"
   },
   "devDependencies": {
-    "@basemaps/config": "^8.1.0",
-    "@basemaps/config-loader": "^8.2.0",
-    "@basemaps/geo": "^8.0.0",
-    "@basemaps/lambda-tiler": "^8.2.0",
+    "@basemaps/config": "^8.3.0",
+    "@basemaps/config-loader": "^8.3.0",
+    "@basemaps/geo": "^8.3.0",
+    "@basemaps/lambda-tiler": "^8.3.0",
     "@basemaps/landing": "^6.39.0",
-    "@basemaps/shared": "^8.2.0",
+    "@basemaps/shared": "^8.3.0",
     "@fastify/formbody": "^7.0.1",
     "@fastify/static": "^6.5.0",
     "cmd-ts": "^0.12.1",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
+
+**Note:** Version bump only for package @basemaps/shared
+
+
+
+
+
 # [8.2.0](https://github.com/linz/basemaps/compare/v8.1.0...v8.2.0) (2025-06-12)
 
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/shared",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -26,8 +26,8 @@
     "@aws-sdk/client-dynamodb": "^3.470.0",
     "@aws-sdk/client-s3": "^3.472.0",
     "@aws-sdk/util-dynamodb": "^3.470.0",
-    "@basemaps/config": "^8.1.0",
-    "@basemaps/geo": "^8.0.0",
+    "@basemaps/config": "^8.3.0",
+    "@basemaps/geo": "^8.3.0",
     "@chunkd/fs": "^11.2.0",
     "@chunkd/fs-aws": "^11.3.0",
     "@chunkd/middleware": "^11.1.0",

--- a/packages/tiler-sharp/CHANGELOG.md
+++ b/packages/tiler-sharp/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
+
+**Note:** Version bump only for package @basemaps/tiler-sharp
+
+
+
+
+
 # [8.1.0](https://github.com/linz/basemaps/compare/v8.0.0...v8.1.0) (2025-05-18)
 
 **Note:** Version bump only for package @basemaps/tiler-sharp

--- a/packages/tiler-sharp/package.json
+++ b/packages/tiler-sharp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/tiler-sharp",
-  "version": "8.1.0",
+  "version": "8.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -22,9 +22,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@basemaps/config": "^8.1.0",
-    "@basemaps/geo": "^8.0.0",
-    "@basemaps/tiler": "^8.0.0",
+    "@basemaps/config": "^8.3.0",
+    "@basemaps/geo": "^8.3.0",
+    "@basemaps/tiler": "^8.3.0",
     "@linzjs/metrics": "^8.0.0",
     "lerc": "^4.0.4"
   },

--- a/packages/tiler/CHANGELOG.md
+++ b/packages/tiler/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
+
+**Note:** Version bump only for package @basemaps/tiler
+
+
+
+
+
 # [8.0.0](https://github.com/linz/basemaps/compare/v7.17.0...v8.0.0) (2025-05-11)
 
 **Note:** Version bump only for package @basemaps/tiler

--- a/packages/tiler/package.json
+++ b/packages/tiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/tiler",
-  "version": "8.0.0",
+  "version": "8.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -22,7 +22,7 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@basemaps/geo": "^8.0.0",
+    "@basemaps/geo": "^8.3.0",
     "@cogeotiff/core": "^9.0.3",
     "@linzjs/metrics": "^8.0.0"
   },


### PR DESCRIPTION
### Motivation

# [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)


### Bug Fixes

* **cli-vector:** collapse large analysis report in pr comment ([#3457](https://github.com/linz/basemaps/issues/3457)) ([19a4d85](https://github.com/linz/basemaps/commit/19a4d85bb90058694c0a5cd3cd2530cd9e60b9a1))
* **infra:** increase lambda tiler memory to 3072MB ([#3459](https://github.com/linz/basemaps/issues/3459)) ([786bb54](https://github.com/linz/basemaps/commit/786bb5406823fb7438cb1205e1c345c407406bc5))
* **landing:** Fix debug page automatically hide topographic-v2. BM-1302 ([#3456](https://github.com/linz/basemaps/issues/3456)) ([53134c0](https://github.com/linz/basemaps/commit/53134c0782cdea7fb683170eda30fb675d60923a))


### Features

* **cli-config:** Generate topographic previews with the v2 in the url. BM-1203 ([#3455](https://github.com/linz/basemaps/issues/3455)) ([1a2f220](https://github.com/linz/basemaps/commit/1a2f220b42689d433e07183557cd42b69e5e22d3))
* **cli-vector:** Support NZTM mbtiles creation.BM-1300 ([#3452](https://github.com/linz/basemaps/issues/3452)) ([f601a73](https://github.com/linz/basemaps/commit/f601a73185aad7f22f6e0e5551d41ba49588c932))
* **landing:** Support NZTM vector Links in the menu page. BM-1301 ([#3458](https://github.com/linz/basemaps/issues/3458)) ([a57059e](https://github.com/linz/basemaps/commit/a57059e2fa81b3be228ce46807b610c09379a4ee))

