### PR TITLE
fix(cli-vector): revert polylabel version to 1.1.0 BM-1309

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15800,15 +15800,6 @@
         "splaytree": "^3.1.0"
       }
     },
-    "node_modules/polylabel": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/polylabel/-/polylabel-2.0.1.tgz",
-      "integrity": "sha512-B6Yu+Bdl/8SGtjVhyUfZzD3DwciCS9SPVtHiNdt8idHHatvTHp5Ss8XGDRmQFtfF1ZQnfK+Cj5dXdpkUXBbXgA==",
-      "license": "ISC",
-      "dependencies": {
-        "tinyqueue": "^3.0.0"
-      }
-    },
     "node_modules/popmotion": {
       "version": "9.3.6",
       "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-9.3.6.tgz",
@@ -18292,7 +18283,8 @@
     "node_modules/tinyqueue": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
-      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g=="
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "dev": true
     },
     "node_modules/tippy.js": {
       "version": "6.3.7",
@@ -19626,7 +19618,7 @@
         "mustache": "^4.2.0",
         "object-sizeof": "^2.6.5",
         "p-limit": "^6.2.0",
-        "polylabel": "^2.0.1",
+        "polylabel": "^1.1.0",
         "stac-ts": "^1.0.0",
         "tar-stream": "^2.2.0",
         "zod": "^3.24.4"
@@ -19637,7 +19629,7 @@
       "devDependencies": {
         "@types/geojson": "^7946.0.7",
         "@types/mustache": "^4.2.6",
-        "@types/polylabel": "^1.1.3",
+        "@types/polylabel": "^1.0.5",
         "@types/tar-stream": "^2.2.2"
       },
       "engines": {
@@ -19667,6 +19659,21 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "packages/cli-vector/node_modules/polylabel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/polylabel/-/polylabel-1.1.0.tgz",
+      "integrity": "sha512-bxaGcA40sL3d6M4hH72Z4NdLqxpXRsCFk8AITYg6x1rn1Ei3izf00UMLklerBZTO49aPA3CYrIwVulx2Bce2pA==",
+      "license": "ISC",
+      "dependencies": {
+        "tinyqueue": "^2.0.3"
+      }
+    },
+    "packages/cli-vector/node_modules/tinyqueue": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
+      "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
+      "license": "ISC"
     },
     "packages/cli/node_modules/cmd-ts": {
       "version": "0.13.0",

--- a/packages/cli-vector/package.json
+++ b/packages/cli-vector/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "@types/geojson": "^7946.0.7",
     "@types/mustache": "^4.2.6",
-    "@types/polylabel": "^1.1.3",
+    "@types/polylabel": "^1.0.5",
     "@types/tar-stream": "^2.2.2"
   },
   "publishConfig": {
@@ -60,7 +60,7 @@
     "mustache": "^4.2.0",
     "object-sizeof": "^2.6.5",
     "p-limit": "^6.2.0",
-    "polylabel": "^2.0.1",
+    "polylabel": "^1.1.0",
     "stac-ts": "^1.0.0",
     "tar-stream": "^2.2.0",
     "zod": "^3.24.4"


### PR DESCRIPTION
### Motivation

The Airport labels for our `topographic-v2` basemap are in the wrong place. This is because we use a newer version of [polylabel](https://github.com/mapbox/polylabel) in our `cli-vector` package (2.0.1), compared to `basemaps-team` (1.1.0). Evidently, with the default precision value of `1.0`, the algorithm renders different results between the two versions.

| [topographic] | [topographic-v2] |
| - | - |
| ![][img_v1] | ![][img_v2] |

[img_v1]: https://github.com/user-attachments/assets/e818542f-345f-4bb2-beec-d23feb6ce0cd
[img_v2]: https://github.com/user-attachments/assets/4cb2b91e-79a1-4a09-9f39-97990a9504b8

[topographic]: https://basemaps.linz.govt.nz/@-41.3270061,174.8124381,z14.48?style=topographic&i=topographic
[topographic-v2]: https://basemaps.linz.govt.nz/@-41.3270061,174.8124381,z14.48?style=topographic-v2&i=topographic-v2

Adjusting the precision value (e.g. `0.000001`) with polylabel version `2.0.1` does render precise pole of inaccessiblity points. However, the locations produced with polylabel version `1.1.0` are more ideal for where we want our labels to appear.

More discussion in this [Slack thread](https://linz.slack.com/archives/C5TCTQUJG/p1750735625977969).

### Modifications

#### Packages

- **cli-vector**

   - Revert the `polylabel` dependency's version from `2.0.1` to `1.1.0`
   - Revert the `@types/polylabel` dev dependency's version from `1.1.3` to `1.0.5`

### Verification

I've captured the following screenshots in QGIS showing the Airport label point for our `topographic` and `topographic-v2` basemaps. The last column shows where the new Airport label point will be. The same location as it is in our `topographic` basemap.

| [topographic] (Ideal) | [topographic-v2] (Wrong) | topographic-v2 (Corrected) |
| - | - | - |
| ![][img_qgis_v1] | ![][img_qgis_v2] | ![][img_qgis_updated] |

[img_qgis_v1]: https://github.com/user-attachments/assets/d5f233f1-9694-4ec6-b852-448728ebdd68
[img_qgis_v2]: https://github.com/user-attachments/assets/703d88a9-e6fe-40ca-81ec-561c92559b67
[img_qgis_updated]: https://github.com/user-attachments/assets/72bd11a0-dcce-44f8-964d-d9a7ba6cba0c
