### PR TITLE
release: v8.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.4.0](https://github.com/linz/basemaps/compare/v8.3.0...v8.4.0) (2025-06-25)
+
+
+### Bug Fixes
+
+* **cli-vector:** Fix the stac item format missing datetime in properties. BM-1317 ([#3464](https://github.com/linz/basemaps/issues/3464)) ([6c7719f](https://github.com/linz/basemaps/commit/6c7719f7514160158b6ad14b680fe1bdd10fd1e3))
+* **cli-vector:** revert polylabel version to 1.1.0 BM-1309 ([#3467](https://github.com/linz/basemaps/issues/3467)) ([e2039fa](https://github.com/linz/basemaps/commit/e2039fa587467010e399f064f187381eee8a3ac0))
+
+
+### Features
+
+* **cli-config:** Support vector preview links and reports for NZTM. BM-1253 ([#3463](https://github.com/linz/basemaps/issues/3463)) ([5ab6a5b](https://github.com/linz/basemaps/commit/5ab6a5bdd19885f8a461bece0d2736c7ed7269d9))
+* **cli-vector:** adjust the layers assigned to each schema layer BM-1299 ([#3462](https://github.com/linz/basemaps/issues/3462)) ([0770163](https://github.com/linz/basemaps/commit/0770163665557390feab74f865132139fa9c3560))
+
+
+
+
+
 # [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
       "conventionalCommits": true
     }
   },
-  "version": "8.3.0"
+  "version": "8.4.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19516,12 +19516,12 @@
     },
     "packages/cli": {
       "name": "@basemaps/cli",
-      "version": "8.3.0",
+      "version": "8.4.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/cli-config": "^8.3.0",
+        "@basemaps/cli-config": "^8.4.0",
         "@basemaps/cli-raster": "^8.3.0",
-        "@basemaps/cli-vector": "^8.3.0",
+        "@basemaps/cli-vector": "^8.4.0",
         "@basemaps/shared": "^8.3.0",
         "cmd-ts": "^0.13.0"
       },
@@ -19534,7 +19534,7 @@
     },
     "packages/cli-config": {
       "name": "@basemaps/cli-config",
-      "version": "8.3.0",
+      "version": "8.4.0",
       "license": "MIT",
       "dependencies": {
         "@basemaps/config": "^8.3.0",
@@ -19604,7 +19604,7 @@
     },
     "packages/cli-vector": {
       "name": "@basemaps/cli-vector",
-      "version": "8.3.0",
+      "version": "8.4.0",
       "license": "MIT",
       "dependencies": {
         "@basemaps/config": "^8.3.0",
@@ -19863,11 +19863,11 @@
     },
     "packages/landing": {
       "name": "@basemaps/landing",
-      "version": "8.3.0",
+      "version": "8.4.0",
       "license": "MIT",
       "devDependencies": {
         "@basemaps/attribution": "^8.3.0",
-        "@basemaps/cli-config": "^8.3.0",
+        "@basemaps/cli-config": "^8.4.0",
         "@basemaps/config": "^8.3.0",
         "@basemaps/geo": "^8.3.0",
         "@basemaps/infra": "^8.3.0",

--- a/packages/cli-config/CHANGELOG.md
+++ b/packages/cli-config/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.4.0](https://github.com/linz/basemaps/compare/v8.3.0...v8.4.0) (2025-06-25)
+
+
+### Features
+
+* **cli-config:** Support vector preview links and reports for NZTM. BM-1253 ([#3463](https://github.com/linz/basemaps/issues/3463)) ([5ab6a5b](https://github.com/linz/basemaps/commit/5ab6a5bdd19885f8a461bece0d2736c7ed7269d9))
+
+
+
+
+
 # [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
 
 

--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli-config",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "private": false,
   "repository": {
     "type": "git",

--- a/packages/cli-vector/CHANGELOG.md
+++ b/packages/cli-vector/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.4.0](https://github.com/linz/basemaps/compare/v8.3.0...v8.4.0) (2025-06-25)
+
+
+### Bug Fixes
+
+* **cli-vector:** Fix the stac item format missing datetime in properties. BM-1317 ([#3464](https://github.com/linz/basemaps/issues/3464)) ([6c7719f](https://github.com/linz/basemaps/commit/6c7719f7514160158b6ad14b680fe1bdd10fd1e3))
+* **cli-vector:** revert polylabel version to 1.1.0 BM-1309 ([#3467](https://github.com/linz/basemaps/issues/3467)) ([e2039fa](https://github.com/linz/basemaps/commit/e2039fa587467010e399f064f187381eee8a3ac0))
+
+
+### Features
+
+* **cli-vector:** adjust the layers assigned to each schema layer BM-1299 ([#3462](https://github.com/linz/basemaps/issues/3462)) ([0770163](https://github.com/linz/basemaps/commit/0770163665557390feab74f865132139fa9c3560))
+
+
+
+
+
 # [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
 
 

--- a/packages/cli-vector/package.json
+++ b/packages/cli-vector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli-vector",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "private": false,
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.4.0](https://github.com/linz/basemaps/compare/v8.3.0...v8.4.0) (2025-06-25)
+
+**Note:** Version bump only for package @basemaps/cli
+
+
+
+
+
 # [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
 
 **Note:** Version bump only for package @basemaps/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -41,9 +41,9 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
-    "@basemaps/cli-config": "^8.3.0",
+    "@basemaps/cli-config": "^8.4.0",
     "@basemaps/cli-raster": "^8.3.0",
-    "@basemaps/cli-vector": "^8.3.0",
+    "@basemaps/cli-vector": "^8.4.0",
     "@basemaps/shared": "^8.3.0",
     "cmd-ts": "^0.13.0"
   },

--- a/packages/landing/CHANGELOG.md
+++ b/packages/landing/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.4.0](https://github.com/linz/basemaps/compare/v8.3.0...v8.4.0) (2025-06-25)
+
+**Note:** Version bump only for package @basemaps/landing
+
+
+
+
+
 # [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
 
 

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/landing",
-  "version": "8.3.0",
+  "version": "8.4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -29,7 +29,7 @@
   ],
   "devDependencies": {
     "@basemaps/attribution": "^8.3.0",
-    "@basemaps/cli-config": "^8.3.0",
+    "@basemaps/cli-config": "^8.4.0",
     "@basemaps/config": "^8.3.0",
     "@basemaps/geo": "^8.3.0",
     "@basemaps/infra": "^8.3.0",


### PR DESCRIPTION
# [8.4.0](https://github.com/linz/basemaps/compare/v8.3.0...v8.4.0) (2025-06-25)

### Bug Fixes

* **cli-vector:** Fix the stac item format missing datetime in properties. BM-1317 ([#3464](https://github.com/linz/basemaps/issues/3464)) ([6c7719f](https://github.com/linz/basemaps/commit/6c7719f7514160158b6ad14b680fe1bdd10fd1e3))
* **cli-vector:** revert polylabel version to 1.1.0 BM-1309 ([#3467](https://github.com/linz/basemaps/issues/3467)) ([e2039fa](https://github.com/linz/basemaps/commit/e2039fa587467010e399f064f187381eee8a3ac0))

### Features

* **cli-config:** Support vector preview links and reports for NZTM. BM-1253 ([#3463](https://github.com/linz/basemaps/issues/3463)) ([5ab6a5b](https://github.com/linz/basemaps/commit/5ab6a5bdd19885f8a461bece0d2736c7ed7269d9))
* **cli-vector:** adjust the layers assigned to each schema layer BM-1299 ([#3462](https://github.com/linz/basemaps/issues/3462)) ([0770163](https://github.com/linz/basemaps/commit/0770163665557390feab74f865132139fa9c3560))