### PR TITLE
[DO NOT MERGE] feat(cli-vector): use flatgeobuf instead of ndjson

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4011,6 +4011,13 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@petamoriken/float16": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.2.tgz",
+      "integrity": "sha512-VgffxawQde93xKxT3qap3OH+meZf7VaSB5Sqd4Rqc+FP5alWbpOyan/7tRbOAvynjpG3GpdtAuGU/NdhQpmrog==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -4254,6 +4261,12 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
       }
+    },
+    "node_modules/@repeaterjs/repeater": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.6.tgz",
+      "integrity": "sha512-Javneu5lsuhwNCryN+pXH93VPQ8g0dBX7wItHFgYiwQmzE1sVdg5tWHiOgHywzL2W21XQopa7IwIEnNbmeUJYA==",
+      "license": "MIT"
     },
     "node_modules/@rushstack/ts-command-line": {
       "version": "4.11.1",
@@ -5435,6 +5448,13 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
       "dev": true
+    },
+    "node_modules/@types/rbush": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/rbush/-/rbush-4.0.0.tgz",
+      "integrity": "sha512-+N+2H39P8X+Hy1I5mC6awlTX54k3FhiUmvt7HWzGJZvF+syUAAxP/stwppS8JE84YHqFgRMv6fCy31202CMFxQ==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/react": {
       "version": "18.2.43",
@@ -8819,7 +8839,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.0.tgz",
       "integrity": "sha512-41Fs7Q/PLq1SDbqjsgcY7GA42T0jvaCNGXgGtsNdvg+Yv8eIu06bxv4/PoREkZ9nMDNwnUSG9OFB9+yv8eKhDg==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -10055,9 +10075,24 @@
       }
     },
     "node_modules/flatbuffers": {
-      "version": "24.3.25",
-      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.3.25.tgz",
-      "integrity": "sha512-3HDgPbgiwWMI9zVB7VYBHaMrbOO7Gm0v+yD2FV/sCKj+9NDeVL7BOBYUuhWAQGKWOzBo8S9WdMvV0eixO233XQ=="
+      "version": "24.12.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.12.23.tgz",
+      "integrity": "sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/flatgeobuf": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flatgeobuf/-/flatgeobuf-4.0.1.tgz",
+      "integrity": "sha512-KhK+34kFaCw1knOSq1vAq3eWf3UzsNlQ38+ursdQMG2iWmCV67RsovrLZKG29XHysQVLIoFHaV7dLEbdUpLwcw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@repeaterjs/repeater": "3.0.6",
+        "flatbuffers": "24.12.23",
+        "slice-source": "0.4.1"
+      },
+      "optionalDependencies": {
+        "ol": ">=3"
+      }
     },
     "node_modules/flatted": {
       "version": "3.3.1",
@@ -10355,6 +10390,46 @@
       "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
       "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
       "dev": true
+    },
+    "node_modules/geotiff": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.3.tgz",
+      "integrity": "sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@petamoriken/float16": "^3.4.7",
+        "lerc": "^3.0.0",
+        "pako": "^2.0.4",
+        "parse-headers": "^2.0.2",
+        "quick-lru": "^6.1.1",
+        "web-worker": "^1.2.0",
+        "xml-utils": "^1.0.2",
+        "zstddec": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10.19"
+      }
+    },
+    "node_modules/geotiff/node_modules/lerc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
+    "node_modules/geotiff/node_modules/quick-lru": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
+      "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -14947,6 +15022,37 @@
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
       "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig=="
     },
+    "node_modules/ol": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ol/-/ol-10.5.0.tgz",
+      "integrity": "sha512-nHFx8gkGmvYImsa7iKkwUnZidd5gn1XbMZd9GNOorvm9orjW9gQvT3Naw/MjIasVJ3cB9EJUdCGR2EFAulMHsQ==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "dependencies": {
+        "@types/rbush": "4.0.0",
+        "earcut": "^3.0.0",
+        "geotiff": "^2.1.3",
+        "pbf": "4.0.1",
+        "rbush": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/openlayers"
+      }
+    },
+    "node_modules/ol/node_modules/pbf": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz",
@@ -15482,6 +15588,13 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)",
+      "optional": true
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -15501,6 +15614,13 @@
       "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A=",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/parse-headers": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
+      "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -16149,7 +16269,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
       "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -16159,6 +16279,40 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/rbush": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/rbush/-/rbush-4.0.1.tgz",
+      "integrity": "sha512-IP0UpfeWQujYC8Jg162rMNc01Rf0gWMMAb2Uxus/Q0qOFw4lCcq6ZnQEZwUoJqWyUGJ9th7JjwI4yIWo+uvoAQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "quickselect": "^3.0.0"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react": {
@@ -17634,6 +17788,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/slice-source": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/slice-source/-/slice-source-0.4.1.tgz",
+      "integrity": "sha512-YiuPbxpCj4hD9Qs06hGAz/OZhQ0eDuALN0lRWJez0eD/RevzKqGdUx1IOMUnXgpr+sXZLq3g8ERwbAH0bCb8vg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/slugify": {
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
@@ -19055,6 +19215,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -19356,6 +19523,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/xml-utils": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.2.tgz",
+      "integrity": "sha512-RqM+2o1RYs6T8+3DzDSoTRAUfrvaejbVHcp3+thnAtDKo8LskR+HomLajEy5UjTz24rpka7AxVBRR3g2wTUkJA==",
+      "license": "CC0-1.0",
+      "optional": true
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -19448,6 +19622,19 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/zod-geojson": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/zod-geojson/-/zod-geojson-0.0.3.tgz",
+      "integrity": "sha512-swL9Tatws3djCG6yux98SuaIdfa8dHh3lEITNeI8HOCxM26XBgqOVrw4KC5YtNwxE1kmfaJnR8rG+fRc5y7Eog==",
+      "license": "MIT"
+    },
+    "node_modules/zstddec": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
+      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==",
+      "license": "MIT AND BSD-3-Clause",
+      "optional": true
     },
     "packages/__tests__": {
       "name": "@basemaps/test",
@@ -19613,10 +19800,10 @@
         "@cotar/builder": "^6.0.1",
         "@cotar/core": "^6.0.1",
         "@linzjs/docker-command": "^7.5.0",
-        "@linzjs/geojson": "^8.0.0",
-        "cmd-ts": "^0.12.1",
-        "mustache": "^4.2.0",
-        "object-sizeof": "^2.6.5",
+        "@mapbox/geojson-area": "^0.2.2",
+        "better-sqlite3": "^9.4.3",
+        "flatgeobuf": "^4.0.1",
+        "geojson": "^0.5.0",
         "p-limit": "^6.2.0",
         "polylabel": "^1.1.0",
         "stac-ts": "^1.0.0",

--- a/packages/cli-vector/package.json
+++ b/packages/cli-vector/package.json
@@ -36,10 +36,17 @@
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "devDependencies": {
-    "@types/geojson": "^7946.0.7",
-    "@types/mustache": "^4.2.6",
-    "@types/polylabel": "^1.0.5",
-    "@types/tar-stream": "^2.2.2"
+    "@basemaps/config": "^8.1.0",
+    "@basemaps/geo": "^8.0.0",
+    "@basemaps/shared": "^8.1.0",
+    "@types/better-sqlite3": "^7.6.9",
+    "@types/geojson": "^7946.0.16",
+    "@types/mapbox__geojson-area": "^0.2.6",
+    "@types/p-limit": "^2.1.0",
+    "@types/polylabel": "^1.1.3",
+    "@types/tar-stream": "^2.2.2",
+    "cmd-ts": "^0.12.1",
+    "stac-ts": "^1.0.0"
   },
   "publishConfig": {
     "access": "public"
@@ -55,14 +62,14 @@
     "@cotar/builder": "^6.0.1",
     "@cotar/core": "^6.0.1",
     "@linzjs/docker-command": "^7.5.0",
-    "@linzjs/geojson": "^8.0.0",
-    "cmd-ts": "^0.12.1",
-    "mustache": "^4.2.0",
-    "object-sizeof": "^2.6.5",
+    "@mapbox/geojson-area": "^0.2.2",
+    "better-sqlite3": "^9.4.3",
+    "flatgeobuf": "^4.0.1",
+    "geojson": "^0.5.0",
     "p-limit": "^6.2.0",
-    "polylabel": "^1.1.0",
-    "stac-ts": "^1.0.0",
+    "polylabel": "^2.0.1",
     "tar-stream": "^2.2.0",
-    "zod": "^3.24.4"
+    "zod": "^3.24.4",
+    "zod-geojson": "^0.0.3"
   }
 }

--- a/packages/cli-vector/src/util.ts
+++ b/packages/cli-vector/src/util.ts
@@ -38,11 +38,11 @@ export interface TmpPaths {
     contentType: (typeof ContentType)[keyof typeof ContentType];
   };
 
-  /** @example "tmp/create/layers/50248/50248.ndjson" */
-  ndjson: URL;
+  /** @example "tmp/create/layers/50248/50248.fgb" */
+  fgb: URL;
 
-  /** @example "tmp/create/transform/aerialways/50248/50248-gen.ndjson" */
-  genNdjson: URL;
+  /** @example "tmp/create/transform/aerialways/50248/50248.ndjson" */
+  ndjson: URL;
 
   /** @example "tmp/create/transform/aerialways/50248/50248.mbtiles" */
   mbtiles: URL;
@@ -80,8 +80,8 @@ export function prepareTmpPaths(
       format,
       contentType: ContentType[format],
     },
-    ndjson: new URL(`${layerId}.ndjson`, LayersDir),
-    genNdjson: new URL(`${layerId}-gen.ndjson`, TransformDir),
+    fgb: new URL(`${layerId}.fgb`, LayersDir),
+    ndjson: new URL(`${layerId}.ndjson`, TransformDir),
     mbtiles: new URL(`${layerId}.mbtiles`, TransformDir),
     mbtilesCopy: new URL(path.href.replace(/\.json$/, '.mbtiles')),
   };


### PR DESCRIPTION
### Motivation

This is an attempt for using the `flatgeobuf` format instead of the `ndjson` format, such that we:

1. Convert source: `GeoPackage` to `flatgeobuf`
2. Generalise features: `flatgeobuf` to `ndjson`
3. Tippecanoe: `ndjson` to `MBTiles`

This stash was branched off a very early iteration of the `cli-vector` package (the `etl-create` branch) and that branch has long since been deleted. So, this likely doesn't compile anymore. Worked fine at the time, though. Needs a lot of re-work, but the core strategy lives [here](https://github.com/linz/basemaps/blob/ddfb20f3fa3c34aaf9f69c17d844fcd3f639a4a7/packages/cli-vector/src/generalization/generalization.ts#L29).

Instead of giving the `deserialize` function a Buffer, we instead want to give it a ReadableStream. The `deserialize` function should [accept that](https://unpkg.com/flatgeobuf@4.0.2/dist/doc/functions/geojson.deserialize.html#deserialize-2), too. However, I get runtime errors when trying to do that.

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
