### PR TITLE
feat(cli-vector): Add stac collection and stac catalog for the extract command. BM-1307

### DIFF
--- a/packages/cli-vector/src/cli/cli.extract.ts
+++ b/packages/cli-vector/src/cli/cli.extract.ts
@@ -90,7 +90,10 @@ export const ExtractCommand = command({
         const stacCollectionFile = new URL(layer.cache.path.href.replace(layer.cache.fileName, 'collection.json'));
         if (await fsa.exists(stacCollectionFile)) {
           const collection = await fsa.readJson<StacCollection>(stacCollectionFile);
-          collection.links.push({ rel: 'item', href: `./${layer.cache.fileName.replace(/\.mbtiles$/, '.json')}` });
+          const itemPath = `./${layer.cache.fileName.replace(/\.mbtiles$/, '.json')}`;
+          if (collection.links.find((l) => l.href === itemPath) == null) {
+            collection.links.push({ rel: 'item', href: itemPath });
+          }
           await fsa.write(stacCollectionFile, JSON.stringify(collection, null, 2));
         } else {
           const title = `Mbtiles cache for ${layer.name}`;

--- a/packages/cli-vector/src/cli/cli.extract.ts
+++ b/packages/cli-vector/src/cli/cli.extract.ts
@@ -3,10 +3,10 @@ import { fsa, Url } from '@basemaps/shared';
 import { CliInfo } from '@basemaps/shared/build/cli/info.js';
 import { getLogger, logArguments } from '@basemaps/shared/build/cli/log.js';
 import { command, oneOf, option, string } from 'cmd-ts';
+import { StacCatalog, StacCollection, StacLink } from 'stac-ts';
 
 import { SchemaLoader } from '../schema-loader/schema.loader.js';
 import { VectorCreationOptions, VectorStac } from '../stac.js';
-import { StacCatalog, StacCollection, StacLink } from 'stac-ts';
 
 function pathToURLFolder(path: string): URL {
   const url = fsa.toUrl(path);

--- a/packages/cli-vector/src/cli/cli.extract.ts
+++ b/packages/cli-vector/src/cli/cli.extract.ts
@@ -6,6 +6,7 @@ import { command, oneOf, option, string } from 'cmd-ts';
 
 import { SchemaLoader } from '../schema-loader/schema.loader.js';
 import { VectorCreationOptions, VectorStac } from '../stac.js';
+import { StacCatalog, StacCollection, StacLink } from 'stac-ts';
 
 function pathToURLFolder(path: string): URL {
   const url = fsa.toUrl(path);
@@ -55,6 +56,7 @@ export const ExtractCommand = command({
     const schemas = await schemaLoader.load();
     const smallLayers = [];
     const largeLayers = [];
+    const collectionLinks: StacLink[] = [];
     let total = 0;
     const allFiles = [];
     const vectorStac = new VectorStac(logger);
@@ -71,7 +73,7 @@ export const ExtractCommand = command({
 
         // Create stac file for the cache mbtiles
         logger.info({ layer: schema.name, id: layer.id }, 'Extract: StacItem');
-        const stacFile = new URL(layer.cache.path.href.replace(/\.mbtiles$/, '.json'));
+        const stacItemFile = new URL(layer.cache.path.href.replace(/\.mbtiles$/, '.json'));
         const stacLink = await vectorStac.createStacLink(schema.name, layer);
         const options: VectorCreationOptions = {
           name: schema.name,
@@ -79,20 +81,58 @@ export const ExtractCommand = command({
           tileMatrix: tileMatrix.identifier,
           layer,
         };
+
+        // Create the STAC item for the layer
         const stacItem = vectorStac.createStacItem([stacLink], layer.cache.fileName, tileMatrix, options);
-        await fsa.write(stacFile, JSON.stringify(stacItem, null, 2));
+        await fsa.write(stacItemFile, JSON.stringify(stacItem, null, 2));
+
+        // Create STAC collection
+        const stacCollectionFile = new URL(layer.cache.path.href.replace(layer.cache.fileName, 'collection.json'));
+        if (await fsa.exists(stacCollectionFile)) {
+          const collection = await fsa.readJson<StacCollection>(stacCollectionFile);
+          collection.links.push({ rel: 'item', href: `./${layer.cache.fileName.replace(/\.mbtiles$/, '.json')}` });
+          await fsa.write(stacCollectionFile, JSON.stringify(collection, null, 2));
+        } else {
+          const title = `Mbtiles cache for ${layer.name}`;
+          const collection = vectorStac.createStacCollection(stacItem.bbox!, [], layer.cache.fileName, title);
+          await fsa.write(stacCollectionFile, JSON.stringify(collection, null, 2));
+        }
+
+        // Prepare Stac collection links for catalog
+        collectionLinks.push({
+          href: `./${layer.id}/collection.json`,
+          title: layer.name,
+          type: 'application/json',
+          rel: 'child',
+        });
 
         // Prepare task to process
         logger.info({ layer: schema.name, id: layer.id }, 'Extract: ToProcess');
 
         // Separate large layer as individual task
         if (layer.largeLayer) {
-          largeLayers.push({ path: stacFile.href });
+          largeLayers.push({ path: stacItemFile.href });
         } else {
-          smallLayers.push({ path: stacFile.href });
+          smallLayers.push({ path: stacItemFile.href });
         }
         total++;
       }
+    }
+
+    // Create STAC catalog
+    const stacCatalogFile = new URL(`${tileMatrix.projection.code}/catalog.json`, cache);
+    if (await fsa.exists(stacCatalogFile)) {
+      const catalog = await fsa.readJson<StacCatalog>(stacCatalogFile);
+      for (const link of collectionLinks) {
+        if (catalog.links.find((l) => l.href === link.href) == null) {
+          catalog.links.push(link);
+        }
+      }
+      await fsa.write(stacCatalogFile, JSON.stringify(catalog, null, 2));
+    } else {
+      const catalog = vectorStac.createStacCatalog();
+      catalog.links.push(...collectionLinks);
+      await fsa.write(stacCatalogFile, JSON.stringify(catalog, null, 2));
     }
 
     logger.info({ ToProcess: total }, 'CheckUpdate: Finish');

--- a/packages/cli-vector/src/cli/cli.extract.ts
+++ b/packages/cli-vector/src/cli/cli.extract.ts
@@ -88,16 +88,17 @@ export const ExtractCommand = command({
 
         // Create STAC collection
         const stacCollectionFile = new URL(layer.cache.path.href.replace(layer.cache.fileName, 'collection.json'));
+        const itemfileName = layer.cache.fileName.replace(/\.mbtiles$/, '');
         if (await fsa.exists(stacCollectionFile)) {
           const collection = await fsa.readJson<StacCollection>(stacCollectionFile);
-          const itemPath = `./${layer.cache.fileName.replace(/\.mbtiles$/, '.json')}`;
-          if (collection.links.find((l) => l.href === itemPath) == null) {
-            collection.links.push({ rel: 'item', href: itemPath });
+
+          if (collection.links.find((l) => l.href === `./${itemfileName}.json`) == null) {
+            collection.links.push({ rel: 'item', href: `./${itemfileName}.json` });
           }
           await fsa.write(stacCollectionFile, JSON.stringify(collection, null, 2));
         } else {
           const title = `Mbtiles cache for ${layer.name}`;
-          const collection = vectorStac.createStacCollection(stacItem.bbox!, [], layer.cache.fileName, title);
+          const collection = vectorStac.createStacCollection(stacItem.bbox!, [], itemfileName, title);
           await fsa.write(stacCollectionFile, JSON.stringify(collection, null, 2));
         }
 

--- a/packages/cli-vector/src/stac.ts
+++ b/packages/cli-vector/src/stac.ts
@@ -101,7 +101,10 @@ export class VectorStac {
       collection: CliId,
       stac_version: '1.0.0',
       stac_extensions: [],
-      geometry: null,
+      geometry: {
+        type: 'Polygon',
+        coordinates: tileMatrix.extent.toPolygon(),
+      },
       bbox: tileMatrix.extent.toBbox(),
       links: [
         { href: `./${filename}.json`, rel: 'self' },


### PR DESCRIPTION
### Motivation

We need to validate the stac files for mbtile cache, so adding collection.json and catalog.json will make the validation recursively for all the stac files.

### Modifications
Create stac files in the following structure.
- `s3://linz-basemaps-staging/mbtiles-cache/3857/catalog.json`
- `s3://linz-basemaps-staging/mbtiles-cache/3857/50348/collection.json`

### Verification
Validates in argo: https://argo.linzaccess.com/workflows/argo/test-basemaps-vector-etl-shortbread-stac-pqvcp?tab=workflow&nodeId=test-basemaps-vector-etl-shortbread-stac-pqvcp-1403105050&uid=870c6422-5dc6-4333-9e22-2ba266fce6c7

![image](https://github.com/user-attachments/assets/71862cf0-4746-4238-87a8-f897216b2aee)
![image](https://github.com/user-attachments/assets/a0c15a1c-a276-4368-971c-098544e51b72)

