### PR TITLE
feat(lambda-tiler): add export URL for mbtiles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19977,6 +19977,7 @@
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.470.0",
         "@aws-sdk/client-s3": "^3.472.0",
+        "@aws-sdk/s3-request-presigner": "^3.472.0",
         "@aws-sdk/util-dynamodb": "^3.470.0",
         "@basemaps/config": "^8.3.0",
         "@basemaps/geo": "^8.3.0",
@@ -19997,6 +19998,40 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "packages/shared/node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.472.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.472.0.tgz",
+      "integrity": "sha512-BynrM9F1Wn2qdllJQPQR/ilkf/RZTmNnWdPrjHsA8n26UL/O2qt5zvPlx/uRF+2kqN5jR+AeRjik84/gBU7xVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "3.470.0",
+        "@aws-sdk/types": "3.468.0",
+        "@aws-sdk/util-format-url": "3.468.0",
+        "@smithy/middleware-endpoint": "^2.2.3",
+        "@smithy/protocol-http": "^3.0.11",
+        "@smithy/smithy-client": "^2.1.18",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "packages/shared/node_modules/@aws-sdk/util-format-url": {
+      "version": "3.468.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.468.0.tgz",
+      "integrity": "sha512-CtHApPmudJz/Z2MHVogWfkaSw4wWHQKVLQs4Q5XjvLcDSzODzxHbiOIckFCXQm2Mme4+TTe4GFU9g869ufegXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.468.0",
+        "@smithy/querystring-builder": "^2.0.15",
+        "@smithy/types": "^2.7.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "packages/smoke": {

--- a/packages/lambda-tiler/src/index.ts
+++ b/packages/lambda-tiler/src/index.ts
@@ -18,7 +18,6 @@ import { wmtsCapabilitiesGet } from './routes/tile.wmts.js';
 import { tileXyzGet } from './routes/tile.xyz.js';
 import { versionGet } from './routes/version.js';
 import { NotFound } from './util/response.js';
-import { Validate } from './util/validate.js';
 
 export const handler = lf.http(LogConfig.get());
 

--- a/packages/lambda-tiler/src/index.ts
+++ b/packages/lambda-tiler/src/index.ts
@@ -3,6 +3,7 @@ import { LambdaHttpRequest, LambdaHttpResponse, lf } from '@linzjs/lambda';
 
 import { tileAttributionGet } from './routes/attribution.js';
 import { configImageryGet, configTileSetGet } from './routes/config.js';
+import { exportTileSetGet } from './routes/export.tileset.js';
 import { fontGet, fontList } from './routes/fonts.js';
 import { healthGet } from './routes/health.js';
 import { imageryGet } from './routes/imagery.js';
@@ -17,6 +18,7 @@ import { wmtsCapabilitiesGet } from './routes/tile.wmts.js';
 import { tileXyzGet } from './routes/tile.xyz.js';
 import { versionGet } from './routes/version.js';
 import { NotFound } from './util/response.js';
+import { Validate } from './util/validate.js';
 
 export const handler = lf.http(LogConfig.get());
 
@@ -116,3 +118,5 @@ handler.router.get('/v1/attribution/:tileSet/:tileMatrix/summary.json', tileAttr
 handler.router.get('/v1/tiles/:tileSet/:tileMatrix/WMTSCapabilities.xml', wmtsCapabilitiesGet);
 handler.router.get('/v1/tiles/:tileSet/WMTSCapabilities.xml', wmtsCapabilitiesGet);
 handler.router.get('/v1/tiles/WMTSCapabilities.xml', wmtsCapabilitiesGet);
+
+handler.router.get('/v1/export/:tileSet/:tileMatrix.:extension', exportTileSetGet);

--- a/packages/lambda-tiler/src/routes/__tests__/export.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/export.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import { ConfigProviderMemory } from '@basemaps/config';
+import { fsa, FsMemory, LogConfig, s3Config } from '@basemaps/shared';
+import assert from 'assert';
+
+import { FakeData } from '../../__tests__/config.data.js';
+import { Api, mockUrlRequest } from '../../__tests__/xyz.util.js';
+import { handler } from '../../index.js';
+import { ConfigLoader } from '../../util/config.loader.js';
+
+describe('tileset.export', () => {
+  const config = new ConfigProviderMemory();
+
+  beforeEach(() => {
+    LogConfig.get().level = 'silent';
+    fsa.register('s3://fake-memory/', new FsMemory());
+  });
+
+  afterEach(() => {
+    config.objects.clear();
+  });
+
+  it('should create presigned url', async (t) => {
+    t.mock.method(ConfigLoader, 'getDefaultConfig', () => Promise.resolve(config));
+
+    t.mock.method(s3Config, 'getSignedUrl', () => Promise.resolve('https://fake-s3-url.com/tileset.mbtiles'));
+
+    const topographic = FakeData.tileSetVector('topographic');
+    topographic.layers[0][2193] = 's3://fake-memory/fake-tiles.tar.co';
+    config.put(topographic);
+
+    await fsa.write(fsa.toUrl('s3://fake-memory/fake-tiles.mbtiles'), Buffer.from('ABC123'));
+
+    const res = await handler.router.handle(
+      mockUrlRequest('/v1/export/topographic/NZTM2000Quad.mbtiles', 'get', Api.header),
+    );
+    assert.equal(res.status, 302); // Temporary redirect
+    assert.equal(res.headers.get('location'), 'https://fake-s3-url.com/tileset.mbtiles');
+  });
+
+  it('should should fail if mbtiles do not exist', async (t) => {
+    t.mock.method(ConfigLoader, 'getDefaultConfig', () => Promise.resolve(config));
+    t.mock.method(s3Config, 'getSignedUrl', () => Promise.resolve('https://fake-s3-url.com/tileset.mbtiles'));
+
+    const topographic = FakeData.tileSetVector('topographic');
+    topographic.layers[0][2193] = 's3://fake-memory/fake-tiles.tar.co';
+    config.put(topographic);
+
+    const res = await handler.router.handle(
+      mockUrlRequest('/v1/export/topographic/NZTM2000Quad.mbtiles', 'get', Api.header),
+    );
+    assert.equal(res.status, 404);
+  });
+});

--- a/packages/lambda-tiler/src/routes/__tests__/export.test.ts
+++ b/packages/lambda-tiler/src/routes/__tests__/export.test.ts
@@ -39,7 +39,7 @@ describe('tileset.export', () => {
     assert.equal(res.headers.get('location'), 'https://fake-s3-url.com/tileset.mbtiles');
   });
 
-  it('should should fail if mbtiles do not exist', async (t) => {
+  it('should fail if mbtiles do not exist', async (t) => {
     t.mock.method(ConfigLoader, 'getDefaultConfig', () => Promise.resolve(config));
     t.mock.method(s3Config, 'getSignedUrl', () => Promise.resolve('https://fake-s3-url.com/tileset.mbtiles'));
 

--- a/packages/lambda-tiler/src/routes/export.tileset.ts
+++ b/packages/lambda-tiler/src/routes/export.tileset.ts
@@ -1,12 +1,10 @@
-import { TileSetType } from '@basemaps/config';
+import { signS3Get } from '@basemaps/shared';
 import { fsa } from '@chunkd/fs';
 import { LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambda';
 
 import { ConfigLoader } from '../util/config.loader.js';
 import { NotFound } from '../util/response.js';
 import { Validate } from '../util/validate.js';
-import { TileXyzRaster } from './tile.xyz.raster.js';
-import { tileXyzVector } from './tile.xyz.vector.js';
 
 export interface TileSetExportGet {
   Params: {
@@ -40,6 +38,7 @@ export async function exportTileSetGet(req: LambdaHttpRequest<TileSetExportGet>)
   const tileSet = await config.TileSet.get(config.TileSet.id(req.params.tileSet));
   req.timer.end('tileset:load');
   if (tileSet == null) return NotFound();
+
   // Vector tiles cannot be merged (yet!)
   if (tileSet.layers.length > 1) {
     return new LambdaHttpResponse(500, `Too many layers in vector tileset ${tileSet.layers.length}`);
@@ -56,14 +55,7 @@ export async function exportTileSetGet(req: LambdaHttpRequest<TileSetExportGet>)
   const exists = await fsa.exists(target);
   if (!exists) return NotFound();
 
-  const presignedUrl = new PresignedUrl({
-    bucket: 'linz-basemaps',
-    key: '3857/topographic-v2/a0sd8shdklhad/topographic.tar.co'.replace('.tar.co', '.mbtiles'),
-    // url: 's3://linz-basemaps/3857/topographic-v2/a0sd8shdklhad/topographic.tar.co'.replace('.tar.co', '.mbtiles'),
-  });
+  const presignedUrl = await signS3Get(target);
 
-  return new LambdaHttpResponse(302, 'Moved', {
-    location:
-      'https://nz-topography.s3.ap-southeast-2.amazonaws.com/3857/topographic-v2/a0sd8shdklhad/topographic.tar.co',
-  });
+  return new LambdaHttpResponse(302, 'Moved', { location: presignedUrl });
 }

--- a/packages/lambda-tiler/src/routes/export.tileset.ts
+++ b/packages/lambda-tiler/src/routes/export.tileset.ts
@@ -14,12 +14,12 @@ export interface TileSetExportGet {
 }
 
 /**
- * Serve a tile
+ * Export an MBTiles file
  *
- * /v1/export/:tileSet/:tileMatrixSet.:tileType
+ * /v1/export/:tileSet/:tileMatrixSet
  *
  * @example
- *  Vector Tile `/v1/tiles/topographic/WebMercatorQuad.mbtiles`
+ *  Vector Tileset `/v1/export/topographic/WebMercatorQuad.mbtiles`
  *
  */
 export async function exportTileSetGet(req: LambdaHttpRequest<TileSetExportGet>): Promise<LambdaHttpResponse> {

--- a/packages/lambda-tiler/src/routes/export.tileset.ts
+++ b/packages/lambda-tiler/src/routes/export.tileset.ts
@@ -1,0 +1,69 @@
+import { TileSetType } from '@basemaps/config';
+import { fsa } from '@chunkd/fs';
+import { LambdaHttpRequest, LambdaHttpResponse } from '@linzjs/lambda';
+
+import { ConfigLoader } from '../util/config.loader.js';
+import { NotFound } from '../util/response.js';
+import { Validate } from '../util/validate.js';
+import { TileXyzRaster } from './tile.xyz.raster.js';
+import { tileXyzVector } from './tile.xyz.vector.js';
+
+export interface TileSetExportGet {
+  Params: {
+    tileSet: string;
+    tileMatrix: string;
+  };
+}
+
+/**
+ * Serve a tile
+ *
+ * /v1/export/:tileSet/:tileMatrixSet.:tileType
+ *
+ * @example
+ *  Vector Tile `/v1/tiles/topographic/WebMercatorQuad.mbtiles`
+ *
+ */
+export async function exportTileSetGet(req: LambdaHttpRequest<TileSetExportGet>): Promise<LambdaHttpResponse> {
+  Validate.apiKey(req);
+
+  req.set('tileSet', req.params.tileSet);
+
+  const tileMatrix = Validate.getTileMatrixSet(req.params.tileMatrix);
+  if (tileMatrix == null) throw new LambdaHttpResponse(404, 'Tile Matrix not found');
+
+  req.set('tileMatrix', tileMatrix.identifier);
+  req.set('projection', tileMatrix.projection.code);
+  const config = await ConfigLoader.load(req);
+
+  req.timer.start('tileset:load');
+  const tileSet = await config.TileSet.get(config.TileSet.id(req.params.tileSet));
+  req.timer.end('tileset:load');
+  if (tileSet == null) return NotFound();
+  // Vector tiles cannot be merged (yet!)
+  if (tileSet.layers.length > 1) {
+    return new LambdaHttpResponse(500, `Too many layers in vector tileset ${tileSet.layers.length}`);
+  }
+
+  const epsgCode = tileMatrix.projection.code;
+  const layerId = tileSet.layers[0][epsgCode];
+  if (layerId == null) return new LambdaHttpResponse(404, `No data found for tile matrix: ${tileMatrix.identifier}`);
+
+  if (!layerId.startsWith('s3://')) return new LambdaHttpResponse(400, `Unable to export tilesets not inside of S3`);
+  if (!layerId.endsWith('.tar.co')) return new LambdaHttpResponse(400, `Unable to export tileset`);
+
+  const target = new URL(layerId.replace('.tar.co', '.mbtiles'));
+  const exists = await fsa.exists(target);
+  if (!exists) return NotFound();
+
+  const presignedUrl = new PresignedUrl({
+    bucket: 'linz-basemaps',
+    key: '3857/topographic-v2/a0sd8shdklhad/topographic.tar.co'.replace('.tar.co', '.mbtiles'),
+    // url: 's3://linz-basemaps/3857/topographic-v2/a0sd8shdklhad/topographic.tar.co'.replace('.tar.co', '.mbtiles'),
+  });
+
+  return new LambdaHttpResponse(302, 'Moved', {
+    location:
+      'https://nz-topography.s3.ap-southeast-2.amazonaws.com/3857/topographic-v2/a0sd8shdklhad/topographic.tar.co',
+  });
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.470.0",
-    "@aws-sdk/s3-request-presigner": "^3.470.0",
+    "@aws-sdk/s3-request-presigner": "^3.472.0",
     "@aws-sdk/client-s3": "^3.472.0",
     "@aws-sdk/util-dynamodb": "^3.470.0",
     "@basemaps/config": "^8.3.0",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.470.0",
+    "@aws-sdk/s3-request-presigner": "^3.470.0",
     "@aws-sdk/client-s3": "^3.472.0",
     "@aws-sdk/util-dynamodb": "^3.470.0",
     "@basemaps/config": "^8.3.0",

--- a/packages/shared/src/file.system.ts
+++ b/packages/shared/src/file.system.ts
@@ -15,9 +15,9 @@ import { LogConfig } from './log.js';
 
 const s3Client = new S3Client({
   /**
-   * We buckets in multiple regions we do not know ahead of time which bucket is in what region
+   * We have buckets in multiple regions. We don’t know ahead of time which region each bucket is in
    *
-   * So the S3 Client will have to follow the endpoints, this adds a bit of extra latency as requests have to be retried
+   * So, the S3 Client will have to follow the endpoints. This adds a bit of extra latency as requests have to be retried
    */
   followRegionRedirects: true,
 });

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -8,7 +8,16 @@ export { getDefaultConfig, setDefaultConfig } from './config.js';
 export { Const, Env } from './const.js';
 export { ConfigDynamoBase } from './dynamo/dynamo.config.base.js';
 export { ConfigProviderDynamo } from './dynamo/dynamo.config.js';
-export { Fsa as fsa, FsaCache, FsaChunk, FsaLog, stringToUrlFolder, urlToString } from './file.system.js';
+export {
+  Fsa as fsa,
+  FsaCache,
+  FsaChunk,
+  FsaLog,
+  s3Config,
+  signS3Get,
+  stringToUrlFolder,
+  urlToString,
+} from './file.system.js';
 export { Fqdn } from './file.system.middleware.js';
 export { getImageryCenterZoom, getPreviewQuery, getPreviewUrl, PreviewSize } from './imagery.url.js';
 export { LogConfig, LogStorage, LogType } from './log.js';


### PR DESCRIPTION
### Motivation

We have had a number of requests to gain direct access to the current mbtiles files, while sometime in the future they will be part of LINZs Open Data Registry https://github.com/linz/topography a quick option is to presign access to the current mbtiles until they are ready to be made fully public

### Modifications

Adds a  `/v1/export/:tileSet/:tileMatrix.mbtiles` route to export any dataset that has a `.mbtiles` file associated eg `topographic`

### Verification

Unit tests, will need to run in dev to validate the full redirect logic.
