### PR TITLE
release: v8.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.5.0](https://github.com/linz/basemaps/compare/v8.4.0...v8.5.0) (2025-07-15)
+
+
+### Features
+
+* **cli-vector:** Add stac collection and stac catalog for the extract command. BM-1307 ([#3472](https://github.com/linz/basemaps/issues/3472)) ([b357022](https://github.com/linz/basemaps/commit/b3570226f61ab035b5c6449dd0077cac5a6320db))
+* **lambda-tiler:** add export URL for mbtiles ([#3474](https://github.com/linz/basemaps/issues/3474)) ([e15c811](https://github.com/linz/basemaps/commit/e15c8117cf19d6021a0e7a275fccf72a5449c4b2))
+
+
+
+
+
 # [8.4.0](https://github.com/linz/basemaps/compare/v8.3.0...v8.4.0) (2025-06-25)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
       "conventionalCommits": true
     }
   },
-  "version": "8.4.0"
+  "version": "8.5.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19459,13 +19459,13 @@
     },
     "packages/_infra": {
       "name": "@basemaps/infra",
-      "version": "8.3.0",
+      "version": "8.5.0",
       "license": "MIT",
       "devDependencies": {
         "@aws-sdk/client-acm": "^3.470.0",
         "@aws-sdk/client-cloudformation": "^3.470.0",
-        "@basemaps/lambda-tiler": "^8.3.0",
-        "@basemaps/shared": "^8.3.0",
+        "@basemaps/lambda-tiler": "^8.5.0",
+        "@basemaps/shared": "^8.5.0",
         "@linzjs/cdk-tags": "^1.7.0",
         "aws-cdk": "2.162.x",
         "aws-cdk-lib": "2.162.x",
@@ -19489,11 +19489,11 @@
     },
     "packages/bathymetry": {
       "name": "@basemaps/bathymetry",
-      "version": "8.3.0",
+      "version": "8.5.0",
       "license": "MIT",
       "dependencies": {
         "@basemaps/geo": "^8.3.0",
-        "@basemaps/shared": "^8.3.0",
+        "@basemaps/shared": "^8.5.0",
         "@rushstack/ts-command-line": "^4.3.13",
         "ulid": "^2.3.0"
       },
@@ -19516,13 +19516,13 @@
     },
     "packages/cli": {
       "name": "@basemaps/cli",
-      "version": "8.4.0",
+      "version": "8.5.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/cli-config": "^8.4.0",
-        "@basemaps/cli-raster": "^8.3.0",
-        "@basemaps/cli-vector": "^8.4.0",
-        "@basemaps/shared": "^8.3.0",
+        "@basemaps/cli-config": "^8.5.0",
+        "@basemaps/cli-raster": "^8.5.0",
+        "@basemaps/cli-vector": "^8.5.0",
+        "@basemaps/shared": "^8.5.0",
         "cmd-ts": "^0.13.0"
       },
       "bin": {
@@ -19534,13 +19534,13 @@
     },
     "packages/cli-config": {
       "name": "@basemaps/cli-config",
-      "version": "8.4.0",
+      "version": "8.5.0",
       "license": "MIT",
       "dependencies": {
         "@basemaps/config": "^8.3.0",
-        "@basemaps/config-loader": "^8.3.0",
+        "@basemaps/config-loader": "^8.5.0",
         "@basemaps/geo": "^8.3.0",
-        "@basemaps/shared": "^8.3.0",
+        "@basemaps/shared": "^8.5.0",
         "@cotar/builder": "^6.0.1",
         "@cotar/core": "^6.0.1",
         "@cotar/tar": "^6.0.1",
@@ -19582,16 +19582,16 @@
     },
     "packages/cli-raster": {
       "name": "@basemaps/cli-raster",
-      "version": "8.3.0",
+      "version": "8.5.0",
       "license": "MIT",
       "bin": {
         "cogify": "build/bin.js"
       },
       "devDependencies": {
         "@basemaps/config": "^8.3.0",
-        "@basemaps/config-loader": "^8.3.0",
+        "@basemaps/config-loader": "^8.5.0",
         "@basemaps/geo": "^8.3.0",
-        "@basemaps/shared": "^8.3.0",
+        "@basemaps/shared": "^8.5.0",
         "@linzjs/geojson": "^8.0.0",
         "@linzjs/metrics": "^8.0.0",
         "cmd-ts": "^0.12.1",
@@ -19604,12 +19604,12 @@
     },
     "packages/cli-vector": {
       "name": "@basemaps/cli-vector",
-      "version": "8.4.0",
+      "version": "8.5.0",
       "license": "MIT",
       "dependencies": {
         "@basemaps/config": "^8.3.0",
         "@basemaps/geo": "^8.3.0",
-        "@basemaps/shared": "^8.3.0",
+        "@basemaps/shared": "^8.5.0",
         "@cotar/builder": "^6.0.1",
         "@cotar/core": "^6.0.1",
         "@linzjs/docker-command": "^7.5.0",
@@ -19724,12 +19724,12 @@
     },
     "packages/config-loader": {
       "name": "@basemaps/config-loader",
-      "version": "8.3.0",
+      "version": "8.5.0",
       "license": "MIT",
       "dependencies": {
         "@basemaps/config": "^8.3.0",
         "@basemaps/geo": "^8.3.0",
-        "@basemaps/shared": "^8.3.0"
+        "@basemaps/shared": "^8.5.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -19761,12 +19761,12 @@
     },
     "packages/lambda-analytic-cloudfront": {
       "name": "@basemaps/lambda-analytic-cloudfront",
-      "version": "8.3.0",
+      "version": "8.5.0",
       "license": "MIT",
       "dependencies": {
         "@basemaps/config": "^8.3.0",
         "@basemaps/geo": "^8.3.0",
-        "@basemaps/shared": "^8.3.0",
+        "@basemaps/shared": "^8.5.0",
         "@elastic/elasticsearch": "^8.16.2",
         "@linzjs/lambda": "^4.0.0",
         "ua-parser-js": "^1.0.39"
@@ -19780,12 +19780,12 @@
     },
     "packages/lambda-analytics": {
       "name": "@basemaps/lambda-analytics",
-      "version": "8.3.0",
+      "version": "8.5.0",
       "license": "MIT",
       "dependencies": {
         "@basemaps/config": "^8.3.0",
         "@basemaps/geo": "^8.3.0",
-        "@basemaps/shared": "^8.3.0",
+        "@basemaps/shared": "^8.5.0",
         "ua-parser-js": "^1.0.2"
       },
       "devDependencies": {
@@ -19797,13 +19797,13 @@
     },
     "packages/lambda-tiler": {
       "name": "@basemaps/lambda-tiler",
-      "version": "8.3.0",
+      "version": "8.5.0",
       "license": "MIT",
       "dependencies": {
         "@basemaps/config": "^8.3.0",
-        "@basemaps/config-loader": "^8.3.0",
+        "@basemaps/config-loader": "^8.5.0",
         "@basemaps/geo": "^8.3.0",
-        "@basemaps/shared": "^8.3.0",
+        "@basemaps/shared": "^8.5.0",
         "@basemaps/tiler": "^8.3.0",
         "@basemaps/tiler-sharp": "^8.3.0",
         "@linzjs/geojson": "^8.0.0",
@@ -19863,15 +19863,15 @@
     },
     "packages/landing": {
       "name": "@basemaps/landing",
-      "version": "8.4.0",
+      "version": "8.5.0",
       "license": "MIT",
       "devDependencies": {
         "@basemaps/attribution": "^8.3.0",
-        "@basemaps/cli-config": "^8.4.0",
+        "@basemaps/cli-config": "^8.5.0",
         "@basemaps/config": "^8.3.0",
         "@basemaps/geo": "^8.3.0",
-        "@basemaps/infra": "^8.3.0",
-        "@basemaps/shared": "^8.3.0",
+        "@basemaps/infra": "^8.5.0",
+        "@basemaps/shared": "^8.5.0",
         "@linzjs/geojson": "^8.0.0",
         "@linzjs/lui": "^21.46.0",
         "@servie/events": "^3.0.0",
@@ -19939,7 +19939,7 @@
     },
     "packages/server": {
       "name": "@basemaps/server",
-      "version": "8.3.0",
+      "version": "8.5.0",
       "license": "MIT",
       "dependencies": {
         "lerc": "^4.0.4",
@@ -19950,11 +19950,11 @@
       },
       "devDependencies": {
         "@basemaps/config": "^8.3.0",
-        "@basemaps/config-loader": "^8.3.0",
+        "@basemaps/config-loader": "^8.5.0",
         "@basemaps/geo": "^8.3.0",
-        "@basemaps/lambda-tiler": "^8.3.0",
+        "@basemaps/lambda-tiler": "^8.5.0",
         "@basemaps/landing": "^6.39.0",
-        "@basemaps/shared": "^8.3.0",
+        "@basemaps/shared": "^8.5.0",
         "@fastify/formbody": "^7.0.1",
         "@fastify/static": "^6.5.0",
         "cmd-ts": "^0.12.1",
@@ -19979,7 +19979,7 @@
     },
     "packages/shared": {
       "name": "@basemaps/shared",
-      "version": "8.3.0",
+      "version": "8.5.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.470.0",

--- a/packages/_infra/CHANGELOG.md
+++ b/packages/_infra/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.5.0](https://github.com/linz/basemaps/compare/v8.4.0...v8.5.0) (2025-07-15)
+
+**Note:** Version bump only for package @basemaps/infra
+
+
+
+
+
 # [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
 
 

--- a/packages/_infra/package.json
+++ b/packages/_infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/infra",
-  "version": "8.3.0",
+  "version": "8.5.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -26,8 +26,8 @@
   "devDependencies": {
     "@aws-sdk/client-acm": "^3.470.0",
     "@aws-sdk/client-cloudformation": "^3.470.0",
-    "@basemaps/lambda-tiler": "^8.3.0",
-    "@basemaps/shared": "^8.3.0",
+    "@basemaps/lambda-tiler": "^8.5.0",
+    "@basemaps/shared": "^8.5.0",
     "@linzjs/cdk-tags": "^1.7.0",
     "aws-cdk": "2.162.x",
     "aws-cdk-lib": "2.162.x",

--- a/packages/bathymetry/CHANGELOG.md
+++ b/packages/bathymetry/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.5.0](https://github.com/linz/basemaps/compare/v8.4.0...v8.5.0) (2025-07-15)
+
+**Note:** Version bump only for package @basemaps/bathymetry
+
+
+
+
+
 # [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
 
 **Note:** Version bump only for package @basemaps/bathymetry

--- a/packages/bathymetry/package.json
+++ b/packages/bathymetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/bathymetry",
-  "version": "8.3.0",
+  "version": "8.5.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "@basemaps/geo": "^8.3.0",
-    "@basemaps/shared": "^8.3.0",
+    "@basemaps/shared": "^8.5.0",
     "@rushstack/ts-command-line": "^4.3.13",
     "ulid": "^2.3.0"
   },

--- a/packages/cli-config/CHANGELOG.md
+++ b/packages/cli-config/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.5.0](https://github.com/linz/basemaps/compare/v8.4.0...v8.5.0) (2025-07-15)
+
+**Note:** Version bump only for package @basemaps/cli-config
+
+
+
+
+
 # [8.4.0](https://github.com/linz/basemaps/compare/v8.3.0...v8.4.0) (2025-06-25)
 
 

--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli-config",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -25,9 +25,9 @@
   },
   "dependencies": {
     "@basemaps/config": "^8.3.0",
-    "@basemaps/config-loader": "^8.3.0",
+    "@basemaps/config-loader": "^8.5.0",
     "@basemaps/geo": "^8.3.0",
-    "@basemaps/shared": "^8.3.0",
+    "@basemaps/shared": "^8.5.0",
     "@cotar/builder": "^6.0.1",
     "@cotar/core": "^6.0.1",
     "@cotar/tar": "^6.0.1",

--- a/packages/cli-raster/CHANGELOG.md
+++ b/packages/cli-raster/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.5.0](https://github.com/linz/basemaps/compare/v8.4.0...v8.5.0) (2025-07-15)
+
+**Note:** Version bump only for package @basemaps/cli-raster
+
+
+
+
+
 # [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
 
 **Note:** Version bump only for package @basemaps/cli-raster

--- a/packages/cli-raster/package.json
+++ b/packages/cli-raster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli-raster",
-  "version": "8.3.0",
+  "version": "8.5.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -41,9 +41,9 @@
   },
   "devDependencies": {
     "@basemaps/config": "^8.3.0",
-    "@basemaps/config-loader": "^8.3.0",
+    "@basemaps/config-loader": "^8.5.0",
     "@basemaps/geo": "^8.3.0",
-    "@basemaps/shared": "^8.3.0",
+    "@basemaps/shared": "^8.5.0",
     "@linzjs/geojson": "^8.0.0",
     "@linzjs/metrics": "^8.0.0",
     "cmd-ts": "^0.12.1",

--- a/packages/cli-vector/CHANGELOG.md
+++ b/packages/cli-vector/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.5.0](https://github.com/linz/basemaps/compare/v8.4.0...v8.5.0) (2025-07-15)
+
+
+### Features
+
+* **cli-vector:** Add stac collection and stac catalog for the extract command. BM-1307 ([#3472](https://github.com/linz/basemaps/issues/3472)) ([b357022](https://github.com/linz/basemaps/commit/b3570226f61ab035b5c6449dd0077cac5a6320db))
+
+
+
+
+
 # [8.4.0](https://github.com/linz/basemaps/compare/v8.3.0...v8.4.0) (2025-06-25)
 
 

--- a/packages/cli-vector/package.json
+++ b/packages/cli-vector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli-vector",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -51,7 +51,7 @@
   "dependencies": {
     "@basemaps/config": "^8.3.0",
     "@basemaps/geo": "^8.3.0",
-    "@basemaps/shared": "^8.3.0",
+    "@basemaps/shared": "^8.5.0",
     "@cotar/builder": "^6.0.1",
     "@cotar/core": "^6.0.1",
     "@linzjs/docker-command": "^7.5.0",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.5.0](https://github.com/linz/basemaps/compare/v8.4.0...v8.5.0) (2025-07-15)
+
+**Note:** Version bump only for package @basemaps/cli
+
+
+
+
+
 # [8.4.0](https://github.com/linz/basemaps/compare/v8.3.0...v8.4.0) (2025-06-25)
 
 **Note:** Version bump only for package @basemaps/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -41,10 +41,10 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
-    "@basemaps/cli-config": "^8.4.0",
-    "@basemaps/cli-raster": "^8.3.0",
-    "@basemaps/cli-vector": "^8.4.0",
-    "@basemaps/shared": "^8.3.0",
+    "@basemaps/cli-config": "^8.5.0",
+    "@basemaps/cli-raster": "^8.5.0",
+    "@basemaps/cli-vector": "^8.5.0",
+    "@basemaps/shared": "^8.5.0",
     "cmd-ts": "^0.13.0"
   },
   "publishConfig": {

--- a/packages/config-loader/CHANGELOG.md
+++ b/packages/config-loader/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.5.0](https://github.com/linz/basemaps/compare/v8.4.0...v8.5.0) (2025-07-15)
+
+**Note:** Version bump only for package @basemaps/config-loader
+
+
+
+
+
 # [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
 
 **Note:** Version bump only for package @basemaps/config-loader

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/config-loader",
-  "version": "8.3.0",
+  "version": "8.5.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -30,6 +30,6 @@
   "dependencies": {
     "@basemaps/config": "^8.3.0",
     "@basemaps/geo": "^8.3.0",
-    "@basemaps/shared": "^8.3.0"
+    "@basemaps/shared": "^8.5.0"
   }
 }

--- a/packages/lambda-analytic-cloudfront/CHANGELOG.md
+++ b/packages/lambda-analytic-cloudfront/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.5.0](https://github.com/linz/basemaps/compare/v8.4.0...v8.5.0) (2025-07-15)
+
+**Note:** Version bump only for package @basemaps/lambda-analytic-cloudfront
+
+
+
+
+
 # [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
 
 **Note:** Version bump only for package @basemaps/lambda-analytic-cloudfront

--- a/packages/lambda-analytic-cloudfront/package.json
+++ b/packages/lambda-analytic-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-analytic-cloudfront",
-  "version": "8.3.0",
+  "version": "8.5.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -20,7 +20,7 @@
   "dependencies": {
     "@basemaps/config": "^8.3.0",
     "@basemaps/geo": "^8.3.0",
-    "@basemaps/shared": "^8.3.0",
+    "@basemaps/shared": "^8.5.0",
     "@elastic/elasticsearch": "^8.16.2",
     "@linzjs/lambda": "^4.0.0",
     "ua-parser-js": "^1.0.39"

--- a/packages/lambda-analytics/CHANGELOG.md
+++ b/packages/lambda-analytics/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.5.0](https://github.com/linz/basemaps/compare/v8.4.0...v8.5.0) (2025-07-15)
+
+**Note:** Version bump only for package @basemaps/lambda-analytics
+
+
+
+
+
 # [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
 
 **Note:** Version bump only for package @basemaps/lambda-analytics

--- a/packages/lambda-analytics/package.json
+++ b/packages/lambda-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-analytics",
-  "version": "8.3.0",
+  "version": "8.5.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -20,7 +20,7 @@
   "dependencies": {
     "@basemaps/config": "^8.3.0",
     "@basemaps/geo": "^8.3.0",
-    "@basemaps/shared": "^8.3.0",
+    "@basemaps/shared": "^8.5.0",
     "ua-parser-js": "^1.0.2"
   },
   "scripts": {

--- a/packages/lambda-tiler/CHANGELOG.md
+++ b/packages/lambda-tiler/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.5.0](https://github.com/linz/basemaps/compare/v8.4.0...v8.5.0) (2025-07-15)
+
+
+### Features
+
+* **lambda-tiler:** add export URL for mbtiles ([#3474](https://github.com/linz/basemaps/issues/3474)) ([e15c811](https://github.com/linz/basemaps/commit/e15c8117cf19d6021a0e7a275fccf72a5449c4b2))
+
+
+
+
+
 # [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
 
 **Note:** Version bump only for package @basemaps/lambda-tiler

--- a/packages/lambda-tiler/package.json
+++ b/packages/lambda-tiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-tiler",
-  "version": "8.3.0",
+  "version": "8.5.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -23,9 +23,9 @@
   "license": "MIT",
   "dependencies": {
     "@basemaps/config": "^8.3.0",
-    "@basemaps/config-loader": "^8.3.0",
+    "@basemaps/config-loader": "^8.5.0",
     "@basemaps/geo": "^8.3.0",
-    "@basemaps/shared": "^8.3.0",
+    "@basemaps/shared": "^8.5.0",
     "@basemaps/tiler": "^8.3.0",
     "@basemaps/tiler-sharp": "^8.3.0",
     "@linzjs/geojson": "^8.0.0",

--- a/packages/landing/CHANGELOG.md
+++ b/packages/landing/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.5.0](https://github.com/linz/basemaps/compare/v8.4.0...v8.5.0) (2025-07-15)
+
+**Note:** Version bump only for package @basemaps/landing
+
+
+
+
+
 # [8.4.0](https://github.com/linz/basemaps/compare/v8.3.0...v8.4.0) (2025-06-25)
 
 **Note:** Version bump only for package @basemaps/landing

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/landing",
-  "version": "8.4.0",
+  "version": "8.5.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -29,11 +29,11 @@
   ],
   "devDependencies": {
     "@basemaps/attribution": "^8.3.0",
-    "@basemaps/cli-config": "^8.4.0",
+    "@basemaps/cli-config": "^8.5.0",
     "@basemaps/config": "^8.3.0",
     "@basemaps/geo": "^8.3.0",
-    "@basemaps/infra": "^8.3.0",
-    "@basemaps/shared": "^8.3.0",
+    "@basemaps/infra": "^8.5.0",
+    "@basemaps/shared": "^8.5.0",
     "@linzjs/geojson": "^8.0.0",
     "@linzjs/lui": "^21.46.0",
     "@servie/events": "^3.0.0",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.5.0](https://github.com/linz/basemaps/compare/v8.4.0...v8.5.0) (2025-07-15)
+
+**Note:** Version bump only for package @basemaps/server
+
+
+
+
+
 # [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
 
 **Note:** Version bump only for package @basemaps/server

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/server",
-  "version": "8.3.0",
+  "version": "8.5.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -53,11 +53,11 @@
   },
   "devDependencies": {
     "@basemaps/config": "^8.3.0",
-    "@basemaps/config-loader": "^8.3.0",
+    "@basemaps/config-loader": "^8.5.0",
     "@basemaps/geo": "^8.3.0",
-    "@basemaps/lambda-tiler": "^8.3.0",
+    "@basemaps/lambda-tiler": "^8.5.0",
     "@basemaps/landing": "^6.39.0",
-    "@basemaps/shared": "^8.3.0",
+    "@basemaps/shared": "^8.5.0",
     "@fastify/formbody": "^7.0.1",
     "@fastify/static": "^6.5.0",
     "cmd-ts": "^0.12.1",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.5.0](https://github.com/linz/basemaps/compare/v8.4.0...v8.5.0) (2025-07-15)
+
+
+### Features
+
+* **lambda-tiler:** add export URL for mbtiles ([#3474](https://github.com/linz/basemaps/issues/3474)) ([e15c811](https://github.com/linz/basemaps/commit/e15c8117cf19d6021a0e7a275fccf72a5449c4b2))
+
+
+
+
+
 # [8.3.0](https://github.com/linz/basemaps/compare/v8.2.0...v8.3.0) (2025-06-17)
 
 **Note:** Version bump only for package @basemaps/shared

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/shared",
-  "version": "8.3.0",
+  "version": "8.5.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -24,8 +24,8 @@
   },
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.470.0",
-    "@aws-sdk/s3-request-presigner": "^3.472.0",
     "@aws-sdk/client-s3": "^3.472.0",
+    "@aws-sdk/s3-request-presigner": "^3.472.0",
     "@aws-sdk/util-dynamodb": "^3.470.0",
     "@basemaps/config": "^8.3.0",
     "@basemaps/geo": "^8.3.0",


### PR DESCRIPTION
# [8.5.0](https://github.com/linz/basemaps/compare/v8.4.0...v8.5.0) (2025-07-15)


### Features

* **cli-vector:** Add stac collection and stac catalog for the extract command. BM-1307 ([#3472](https://github.com/linz/basemaps/issues/3472)) ([b357022](https://github.com/linz/basemaps/commit/b3570226f61ab035b5c6449dd0077cac5a6320db))
* **lambda-tiler:** add export URL for mbtiles ([#3474](https://github.com/linz/basemaps/issues/3474)) ([e15c811](https://github.com/linz/basemaps/commit/e15c8117cf19d6021a0e7a275fccf72a5449c4b2))