### PR TITLE
feat(landing): add dsm hillshade

### DIFF
--- a/packages/landing/src/config.map.ts
+++ b/packages/landing/src/config.map.ts
@@ -424,13 +424,13 @@ function addDefaultLayers(output: Map<string, LayerInfo>): void {
       id: 'hillshade',
       title: 'Hillshade Standard DEM',
       projections: new Set([EpsgCode.Nztm2000, EpsgCode.Google]),
-      category: 'Basemaps - Hillshade',
+      category: 'Elevation',
     },
     {
       id: 'hillshade-dsm',
       title: 'Hillshade Standard DSM',
       projections: new Set([EpsgCode.Nztm2000, EpsgCode.Google]),
-      category: 'Basemaps - Hillshade',
+      category: 'Elevation',
     },
     {
       id: 'elevation',

--- a/packages/landing/src/config.map.ts
+++ b/packages/landing/src/config.map.ts
@@ -410,13 +410,25 @@ function addDefaultLayers(output: Map<string, LayerInfo>): void {
     },
     {
       id: 'hillshade-igor',
-      title: 'Hillshade Igor',
+      title: 'Hillshade Igor DEM',
+      projections: new Set([EpsgCode.Nztm2000, EpsgCode.Google]),
+      category: 'Basemaps - Hillshade',
+    },
+    {
+      id: 'hillshade-igor-dsm',
+      title: 'Hillshade Igor DSM',
       projections: new Set([EpsgCode.Nztm2000, EpsgCode.Google]),
       category: 'Basemaps - Hillshade',
     },
     {
       id: 'hillshade',
-      title: 'Hillshade Standard',
+      title: 'Hillshade Standard DEM',
+      projections: new Set([EpsgCode.Nztm2000, EpsgCode.Google]),
+      category: 'Basemaps - Hillshade',
+    },
+    {
+      id: 'hillshade-dsm',
+      title: 'Hillshade Standard DSM',
       projections: new Set([EpsgCode.Nztm2000, EpsgCode.Google]),
       category: 'Basemaps - Hillshade',
     },


### PR DESCRIPTION
### Motivation

Two new national DSM hillshade layers have been published in AWS ODR. We want these layers to be published via basemaps for individual use and combined use in our various configs (Aerial, Topographic v2, NZ Topo).

### Modifications

add dsm and dsm igor

### Verification

<img width="447" height="658" alt="Screenshot from 2025-07-29 09-54-56" src="https://github.com/user-attachments/assets/47baedad-9766-43b5-be8d-69e9667c0969" />

<img width="447" height="658" alt="Screenshot from 2025-07-29 09-55-17" src="https://github.com/user-attachments/assets/55de70b8-3ca4-44d0-ba5e-3972e59fcaa7" />


