### PR TITLE
fix: create unit tests for import config diffing

### DIFF
--- a/packages/cli-config/src/__tests__/config.diff.data.ts
+++ b/packages/cli-config/src/__tests__/config.diff.data.ts
@@ -1,0 +1,35 @@
+import { ConfigLayer, TileSetType } from '@basemaps/config';
+import { TileSetConfigSchema } from '@basemaps/config-loader/build/json/parse.tile.set.js';
+
+export const TsAerial: TileSetConfigSchema = {
+  type: 'raster' as TileSetType.Raster,
+  id: 'ts_aerial',
+  title: 'Aerial Imagery Basemap',
+  category: 'Basemaps',
+  layers: [
+    {
+      '2193': 's3://linz-basemaps/2193/grey_2025_0.075m/01JZVMA8FPS6QJGHAR4VY968FY/',
+      '3857': 's3://linz-basemaps/3857/grey_2025_0.075m/01JZVMA8FQV0MPPVBNBNZC6G3M/',
+      name: 'grey-2025-0.075m',
+      title: 'Grey 0.075m Urban Aerial Photos (2025) - Draft',
+      category: 'Urban Aerial Photos',
+      minZoom: 14,
+    },
+    {
+      '2193': 's3://linz-basemaps/2193/upper-hutt_2025_0.075m/01K0TGPNGH1R7F8G5EYWHHSGD1/',
+      '3857': 's3://linz-basemaps/3857/upper-hutt_2025_0.075m/01K0TGPNGH0C105PQTEFQG4QH6/',
+      name: 'upper-hutt-2025-0.075m',
+      title: 'Upper Hutt 0.075m Urban Aerial Photos (2025)',
+      category: 'Urban Aerial Photos',
+      minZoom: 14,
+    },
+    {
+      '2193': 's3://linz-basemaps/2193/masterton_2025_0.075m/01K0XA50T2GFPNTG1PANZJ3R8B/',
+      '3857': 's3://linz-basemaps/3857/masterton_2025_0.075m/01K0XA50T2MC43751EX6M8QDXK/',
+      name: 'masterton-2025-0.075m',
+      title: 'Masterton 0.075m Urban Aerial Photos (2025)',
+      category: 'Urban Aerial Photos',
+      minZoom: 14,
+    },
+  ] as ConfigLayer[],
+};

--- a/packages/cli-config/src/__tests__/config.diff.test.ts
+++ b/packages/cli-config/src/__tests__/config.diff.test.ts
@@ -1,0 +1,157 @@
+import assert from 'node:assert';
+import { before, describe, it, TestContext } from 'node:test';
+
+import { ConfigLayer, ConfigProviderMemory, ConfigTileSetRaster, getAllImagery, sha256base58 } from '@basemaps/config';
+import { ConfigJson } from '@basemaps/config-loader';
+import { ConfigImageryTiff } from '@basemaps/config-loader/build/json/tiff.config.js';
+import { TileSetConfigSchema, TileSetConfigSchemaLayer } from '@basemaps/config-loader/src/json/parse.tile.set.js';
+import { Epsg, EpsgCode, TileMatrixSets } from '@basemaps/geo';
+import { fsa, FsMemory, LogConfig } from '@basemaps/shared';
+import pLimit from 'p-limit';
+
+import { outputChange } from '../cli/action.import.js';
+import { TsAerial } from './config.diff.data.js';
+import { configDiff, DiffNew, DiffRemoved } from './config.diff.js';
+
+describe('config.diff', () => {
+  const fsMem = new FsMemory();
+
+  before(() => {
+    // Imagery is linked from s3, overwrite s3 links to just use memory
+    fsa.register('s3://', fsMem);
+
+    fsa.register('source://', fsMem);
+    fsa.register('before://', fsMem);
+    fsa.register('after://', fsMem);
+
+    fsMem.files.clear();
+    fsa.write(fsa.toUrl('before://config/tileset/aerial.json'), JSON.stringify(TsAerial));
+  });
+
+  async function stubLoadConfig(t: TestContext, source: string): Promise<ConfigProviderMemory> {
+    t.mock.method(ConfigJson.prototype, 'initImageryFromTiffUrl', (url: URL) => {
+      // const imageryName = getImageryName(url);
+      const parts = url.pathname.split('/');
+      const projection = TileMatrixSets.get(Epsg.parseCode(parts[1]) as EpsgCode);
+      const imageryName = parts[2];
+
+      const gsd = imageryName.split('_').at(-1);
+      const imagery: ConfigImageryTiff = {
+        id: `im_${sha256base58(url.href)}`,
+        name: imageryName,
+        title: imageryName,
+        updatedAt: Date.now(),
+        projection: projection?.projection.code,
+        tileMatrix: projection?.identifier ?? 'none',
+        gsd: parseFloat(gsd ?? '100'),
+        uri: url.href,
+        url: url,
+        bounds: { x: 0, y: 0, width: 0, height: 0 },
+        files: [],
+      };
+      return Promise.resolve(imagery);
+    });
+
+    const mem = await ConfigJson.fromUrl(new URL(source), pLimit(1), LogConfig.get());
+    mem.createVirtualTileSets(false);
+    return mem;
+  }
+
+  it('should load the aerial config', async (t) => {
+    const cfg = await stubLoadConfig(t, 'before://config/');
+
+    const tsAerial = await cfg.TileSet.get('aerial');
+    assert.ok(tsAerial, 'Should have loaded the aerial tile set');
+
+    assert.equal(tsAerial.layers.length, 3);
+
+    const all3857 = await getAllImagery(cfg, tsAerial.layers, [Epsg.Google]);
+
+    assert.equal(all3857.size, 3, 'Should have 3 layers in the 3857 tile set');
+    for (const layer of all3857.values()) {
+      const tsId = `ts_${layer.name}`;
+      assert.ok(cfg.objects.has(tsId), `Should have a tile set for ${layer.name}`);
+    }
+  });
+
+  it('should not have any changes when nothing has changed', async (t) => {
+    const before = await stubLoadConfig(t, 'before://config/');
+    const after = await stubLoadConfig(t, 'before://config/');
+
+    const diff = configDiff(before, after);
+
+    assert.deepEqual(diff, { raster: [] }, 'Should not have any changes when nothing has changed');
+  });
+
+  it('should diff when a layer is removed', async (t) => {
+    const before = await stubLoadConfig(t, 'before://config/');
+
+    const tsAfter = structuredClone(TsAerial);
+    tsAfter.layers.shift(); // Remove the first layer
+    await fsa.write(fsa.toUrl('after://config/tileset/aerial.json'), JSON.stringify(tsAfter));
+    const after = await stubLoadConfig(t, 'after://config/');
+    const diff = configDiff(before, after);
+
+    assert.equal(diff.raster.length, 1, 'Should only have one diff');
+    const firstDiff = diff.raster[0] as DiffRemoved<ConfigTileSetRaster>;
+    assert.equal(firstDiff.type, 'removed');
+    assert.equal(firstDiff.before.id, 'ts_grey-2025-0.075m');
+  });
+
+  it('should diff when a layer is added', async (t) => {
+    const before = await stubLoadConfig(t, 'before://config/');
+
+    const tsAfter = structuredClone(TsAerial);
+    tsAfter.layers.push(layerConfig('test-layer', 'Test layer')); // Remove the first layer
+    await fsa.write(fsa.toUrl('after://config/tileset/aerial.json'), JSON.stringify(tsAfter));
+    const after = await stubLoadConfig(t, 'after://config/');
+    const diff = configDiff(before, after);
+
+    assert.equal(diff.raster.length, 1, 'Should only have one diff');
+    const firstDiff = diff.raster[0] as DiffNew<ConfigTileSetRaster>;
+    assert.equal(firstDiff.type, 'new');
+    assert.equal(firstDiff.after.id, 'ts_test-layer');
+  });
+
+  it('should show no layer diffs when a layer is removed then added as a seperate config', async (t) => {
+    const before = await stubLoadConfig(t, 'before://config/');
+    const tsAfter = structuredClone(TsAerial);
+
+    // Remove the first layer then store it as a seperate tile set config file
+    const removed = tsAfter.layers.shift() as TileSetConfigSchemaLayer; // Remove the first layer
+    await fsa.write(fsa.toUrl('after://config/tileset/aerial.json'), JSON.stringify(tsAfter));
+    await fsa.write(
+      fsa.toUrl(`after://config/tileset/imagery/${removed.title}.json`),
+      JSON.stringify({
+        type: 'raster',
+        id: `ts_${removed.name}`,
+        name: removed.name,
+        title: removed.title,
+        category: removed.category,
+        layers: [removed],
+        minZoom: removed.minZoom,
+      } as TileSetConfigSchema),
+    );
+    const after = await stubLoadConfig(t, 'after://config/');
+    const diff = configDiff(before, after);
+
+    assert.equal(diff.raster.length, 0, 'should have no diff');
+
+    const doc = await outputChange(after, before, 'after://config/tileset/aerial.json', []);
+    const lines = doc.split('\n');
+
+    // TODO this is the bug that needs to be fixed.
+    assert.ok(lines.find((f) => f.includes('Aerial Imagery Deletes')));
+  });
+});
+
+function layerConfig(name: string, title: string): ConfigLayer {
+  return {
+    '2193': `source://linz-basemaps/2193/${name}/${sha256base58(name + '2193')}/`,
+    '3857': `source://linz-basemaps/3857/${name}/${sha256base58(name + '3857')}/`,
+    name,
+    title,
+    category: 'Urban Aerial Photos',
+    minZoom: 14,
+  };
+}

--- a/packages/cli-config/src/__tests__/config.diff.ts
+++ b/packages/cli-config/src/__tests__/config.diff.ts
@@ -1,0 +1,55 @@
+import { ConfigProviderMemory, ConfigTileSetRaster } from '@basemaps/config';
+
+function getAllTileSets(cfg: ConfigProviderMemory): Map<string, ConfigTileSetRaster> {
+  const tileSets: Map<string, ConfigTileSetRaster> = new Map();
+
+  for (const obj of cfg.objects.values()) {
+    if (!cfg.TileSet.is(obj)) continue;
+    if (tileSets.has(obj.id)) throw new Error(`Duplicate tileSet id ${obj.id}`);
+    tileSets.set(obj.id, obj as ConfigTileSetRaster);
+  }
+
+  return tileSets;
+}
+
+function tileSetDiffRaster(
+  before?: ConfigTileSetRaster,
+  after?: ConfigTileSetRaster,
+): Diff<ConfigTileSetRaster> | null {
+  if (before == null && after == null) return null;
+  if (before == null) return { type: 'new', after: after as ConfigTileSetRaster };
+  if (after == null) return { type: 'removed', before };
+
+  return null;
+}
+
+export function configDiff(
+  before: ConfigProviderMemory,
+  after: ConfigProviderMemory,
+): { raster: Diff<ConfigTileSetRaster>[] } {
+  const tileSetBefore = getAllTileSets(before);
+  const tileSetAfter = getAllTileSets(after);
+
+  const seen = new Set<string>();
+
+  const diffs: Diff<ConfigTileSetRaster>[] = [];
+
+  for (const tsBefore of tileSetBefore.values()) {
+    const diff = tileSetDiffRaster(tsBefore, tileSetAfter.get(tsBefore.id));
+    seen.add(tsBefore.id);
+    if (diff) diffs.push(diff);
+  }
+
+  for (const tsAfter of tileSetAfter.values()) {
+    if (seen.has(tsAfter.id)) continue;
+    const diff = tileSetDiffRaster(undefined, tsAfter);
+    if (diff) diffs.push(diff);
+  }
+
+  return { raster: diffs };
+}
+
+export type DiffNew<T> = { type: 'new'; after: T };
+export type DiffRemoved<T> = { type: 'removed'; before: T };
+export type DiffChanged<T> = { type: 'changed'; before: T; after: T };
+export type Diff<T> = DiffNew<T> | DiffRemoved<T> | DiffChanged<T>;

--- a/packages/config/src/memory/memory.config.ts
+++ b/packages/config/src/memory/memory.config.ts
@@ -135,11 +135,11 @@ export class ConfigProviderMemory extends BasemapsConfigProvider {
   }
 
   /** Find all imagery inside this configuration and create a virtual tile set for it */
-  createVirtualTileSets(): void {
+  createVirtualTileSets(createById = true): void {
     const allLayers: ConfigLayer[] = [];
     for (const obj of this.objects.values()) {
       if (isConfigImagery(obj)) {
-        this.put(ConfigProviderMemory.imageryToTileSet(obj));
+        if (createById) this.put(ConfigProviderMemory.imageryToTileSet(obj));
         const tileSet = this.imageryToTileSetByName(obj);
         allLayers.push(tileSet.layers[0]);
       }


### PR DESCRIPTION
### Motivation

The config diff is missing changes and its been tough to figure out exactly where the bug is

### Modifications


Expose a few functions so they can be tested
Add unit tests to load a fake config from json then use that as a diffing source

### Verification

Unit tests.
