### PR TITLE
feat: add aliases for tileSets

### DIFF
--- a/packages/config-loader/src/json/json.config.ts
+++ b/packages/config-loader/src/json/json.config.ts
@@ -255,7 +255,7 @@ export class ConfigJson {
       tileSet.format = ts.type === TileSetType.Vector ? 'pbf' : 'webp';
     }
 
-    tileSet.alias = ts.alias;
+    tileSet.aliases = ts.aliases;
 
     return tileSet as ConfigTileSet;
   }

--- a/packages/config-loader/src/json/json.config.ts
+++ b/packages/config-loader/src/json/json.config.ts
@@ -255,6 +255,8 @@ export class ConfigJson {
       tileSet.format = ts.type === TileSetType.Vector ? 'pbf' : 'webp';
     }
 
+    tileSet.alias = ts.alias;
+
     return tileSet as ConfigTileSet;
   }
 

--- a/packages/config-loader/src/json/parse.tile.set.ts
+++ b/packages/config-loader/src/json/parse.tile.set.ts
@@ -69,6 +69,7 @@ export const zTileSetConfig = z.object({
   maxZoom: zZoom.optional(),
   format: z.string().optional(),
   outputs: z.array(ConfigTileSetOutputParser).optional(),
+  alias: z.array(z.string()).optional(),
 });
 
 export type TileSetConfigSchemaLayer = z.infer<typeof zLayerConfig>;

--- a/packages/config-loader/src/json/parse.tile.set.ts
+++ b/packages/config-loader/src/json/parse.tile.set.ts
@@ -69,7 +69,7 @@ export const zTileSetConfig = z.object({
   maxZoom: zZoom.optional(),
   format: z.string().optional(),
   outputs: z.array(ConfigTileSetOutputParser).optional(),
-  alias: z.array(z.string()).optional(),
+  aliases: z.array(z.string()).optional(),
 });
 
 export type TileSetConfigSchemaLayer = z.infer<typeof zLayerConfig>;

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -62,6 +62,20 @@ For LINZ's implementation of this configuration see [linz/basemaps-config](https
 }
 ```
 
+### Tileset Aliases
+
+Tilesets can have multiple aliases, allowing them to be linked by different names:
+
+```json
+{
+  "type": "raster",
+  "id": "ts_auckland-2010-2012-0.5m",
+  "title": "Auckland 0.5m Rural Aerial Photos (2010-2012)",
+  "name": "auckland-2017-0.075m",
+  "aliases": ["auckland-urban-2017-0.075m"]
+}
+```
+
 ## Style Example
 
 [ConfigVectorStyle](./src/config/vector.style.ts)

--- a/packages/config/src/config/base.ts
+++ b/packages/config/src/config/base.ts
@@ -41,6 +41,11 @@ export const ConfigBase = z.object({
   /**
    * Was this configuration object generated from another object
    *
+   * tileset-all: All tileset contains all raster layers
+   * tileset-alias: Alias that points to another tileset
+   * imagery-name: Tileset that is identified by its imagery name
+   * imagery-id: Tileset that is identified by its imagery id
+   *
    * @default undefined
    */
   virtual: z.enum(['tileset-all', 'tileset-alias', 'imagery-name', 'imagery-id']).optional(),

--- a/packages/config/src/config/base.ts
+++ b/packages/config/src/config/base.ts
@@ -41,9 +41,9 @@ export const ConfigBase = z.object({
   /**
    * Was this configuration object generated from another object
    *
-   * @default undefined / false
+   * @default undefined
    */
-  virtual: z.boolean().optional(),
+  virtual: z.string().optional(),
 });
 
 export type ConfigBase = z.infer<typeof ConfigBase>;

--- a/packages/config/src/config/base.ts
+++ b/packages/config/src/config/base.ts
@@ -43,7 +43,7 @@ export const ConfigBase = z.object({
    *
    * @default undefined
    */
-  virtual: z.string().optional(),
+  virtual: z.enum(['tileset-all', 'tileset-alias', 'imagery-name', 'imagery-id']).optional(),
 });
 
 export type ConfigBase = z.infer<typeof ConfigBase>;

--- a/packages/config/src/config/tile.set.ts
+++ b/packages/config/src/config/tile.set.ts
@@ -62,7 +62,7 @@ export interface ConfigTileSetBase extends ConfigBase {
   maxZoom?: number;
 
   /** Array containing any tileSet aliases */
-  alias?: string[];
+  aliases?: string[];
 }
 
 export interface ConfigTileSetRaster extends ConfigTileSetBase {

--- a/packages/config/src/config/tile.set.ts
+++ b/packages/config/src/config/tile.set.ts
@@ -60,6 +60,9 @@ export interface ConfigTileSetBase extends ConfigBase {
 
   /** Maximum zoom level for this tileSet @default 30 */
   maxZoom?: number;
+
+  /** Array containing any tileSet aliases */
+  alias?: string[];
 }
 
 export interface ConfigTileSetRaster extends ConfigTileSetBase {

--- a/packages/config/src/memory/__tests__/memory.config.test.ts
+++ b/packages/config/src/memory/__tests__/memory.config.test.ts
@@ -198,6 +198,6 @@ describe('MemoryConfig', () => {
   it('virtual tileset aliases', async () => {
     config.put({ ...baseTs, aliases: ['someAlias'] } as ConfigTileSetRaster);
     const ts = await config.TileSet.get('someAlias');
-    assert.equal(ts?.id, 'someAlias');
+    assert.equal(ts?.id, tsId);
   });
 });

--- a/packages/config/src/memory/__tests__/memory.config.test.ts
+++ b/packages/config/src/memory/__tests__/memory.config.test.ts
@@ -194,4 +194,10 @@ describe('MemoryConfig', () => {
     assert.equal(target?.layers[0][2193], undefined);
     assert.equal(target?.name, 'ōtorohanga-urban-2021-0.1m');
   });
+
+  it('virtual tileset aliases', async () => {
+    config.put({ ...baseTs, aliases: ['someAlias'] } as ConfigTileSetRaster);
+    const ts = await config.TileSet.get('someAlias');
+    assert.equal(ts?.id, 'someAlias');
+  });
 });

--- a/packages/config/src/memory/__tests__/memory.config.test.ts
+++ b/packages/config/src/memory/__tests__/memory.config.test.ts
@@ -197,7 +197,8 @@ describe('MemoryConfig', () => {
 
   it('virtual tileset aliases', async () => {
     config.put({ ...baseTs, aliases: ['someAlias'] } as ConfigTileSetRaster);
-    const ts = await config.TileSet.get('someAlias');
-    assert.equal(ts?.id, tsId);
+    config.createVirtualTileSets();
+    const ts = await config.TileSet.get('ts_someAlias');
+    assert.equal(ts?.id, 'ts_someAlias');
   });
 });

--- a/packages/config/src/memory/memory.config.ts
+++ b/packages/config/src/memory/memory.config.ts
@@ -143,6 +143,16 @@ export class ConfigProviderMemory extends BasemapsConfigProvider {
         const tileSet = this.imageryToTileSetByName(obj);
         allLayers.push(tileSet.layers[0]);
       }
+
+      // add any tileset aliases
+      if (ConfigId.getPrefix(obj.id) === ConfigPrefix.TileSet) {
+        const ts = obj as ConfigTileSet;
+        if (ts.alias) {
+          for (const newId of ts.alias) {
+            this.put({ ...ts, id: ConfigId.prefix(ConfigPrefix.TileSet, newId) });
+          }
+        }
+      }
     }
     // Create an all tileset contains all raster layers
     if (allLayers.length) this.createVirtualAllTileSet(allLayers);

--- a/packages/config/src/memory/memory.config.ts
+++ b/packages/config/src/memory/memory.config.ts
@@ -145,11 +145,13 @@ export class ConfigProviderMemory extends BasemapsConfigProvider {
       }
 
       // add any tileset aliases
-      if (ConfigId.getPrefix(obj.id) === ConfigPrefix.TileSet) {
-        const ts = obj as ConfigTileSet;
-        if (ts.alias) {
-          for (const newId of ts.alias) {
-            this.put({ ...ts, id: ConfigId.prefix(ConfigPrefix.TileSet, newId) });
+      if (this.TileSet.is(obj)) {
+        if (obj.aliases) {
+          for (const alias of obj.aliases) {
+            const aliasTs = structuredClone(obj);
+            aliasTs.id = ConfigId.prefix(ConfigPrefix.TileSet, alias);
+            aliasTs.virtual = 'tileset-alias';
+            this.put(aliasTs);
           }
         }
       }
@@ -172,7 +174,7 @@ export class ConfigProviderMemory extends BasemapsConfigProvider {
 
     const allTileset: ConfigTileSet = {
       type: TileSetType.Raster,
-      virtual: true,
+      virtual: 'tileset-all',
       id: 'ts_all',
       name: 'all',
       title: 'All Imagery',
@@ -190,7 +192,7 @@ export class ConfigProviderMemory extends BasemapsConfigProvider {
     if (existing == null) {
       existing = {
         type: TileSetType.Raster,
-        virtual: true,
+        virtual: 'imagery-name',
         id: targetId,
         title: i.title,
         category: i.category,
@@ -226,7 +228,7 @@ export class ConfigProviderMemory extends BasemapsConfigProvider {
   static imageryToTileSet(i: ConfigImagery): ConfigTileSet {
     const ts: ConfigTileSetRaster = {
       type: TileSetType.Raster,
-      virtual: true,
+      virtual: 'imagery-id',
       id: ConfigId.prefix(ConfigPrefix.TileSet, ConfigId.unprefix(ConfigPrefix.Imagery, i.id)),
       name: i.name,
       title: i.title,


### PR DESCRIPTION
### Motivation

Aerial Imagery PRs with the 'Aerial Imagery Deletes' messages are breaking existing WMTS links, 'urban' or 'rural' has been removed from the layer name as it's taken out of the aerial config, which in turn, changes the URL of the individual layer WMTS

### Modifications

Add an `aliases` property so that tilesets can be linked by different names:

### Verification

added test
