### PR TITLE
release: v8.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.7.0](https://github.com/linz/basemaps/compare/v8.6.0...v8.7.0) (2025-08-10)
+
+
+### Features
+
+* **cli-vector:** update the parsing logic for place_labels layer features BM-1318 ([#3470](https://github.com/linz/basemaps/issues/3470)) ([29d2593](https://github.com/linz/basemaps/commit/29d25938363255f05b91cced54397928a2a092da))
+
+
+
+
+
 # [8.6.0](https://github.com/linz/basemaps/compare/v8.5.0...v8.6.0) (2025-08-06)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
       "conventionalCommits": true
     }
   },
-  "version": "8.6.0"
+  "version": "8.7.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19516,12 +19516,12 @@
     },
     "packages/cli": {
       "name": "@basemaps/cli",
-      "version": "8.6.0",
+      "version": "8.7.0",
       "license": "MIT",
       "dependencies": {
         "@basemaps/cli-config": "^8.6.0",
         "@basemaps/cli-raster": "^8.6.0",
-        "@basemaps/cli-vector": "^8.6.0",
+        "@basemaps/cli-vector": "^8.7.0",
         "@basemaps/shared": "^8.6.0",
         "cmd-ts": "^0.13.0"
       },
@@ -19604,7 +19604,7 @@
     },
     "packages/cli-vector": {
       "name": "@basemaps/cli-vector",
-      "version": "8.6.0",
+      "version": "8.7.0",
       "license": "MIT",
       "dependencies": {
         "@basemaps/config": "^8.6.0",

--- a/packages/cli-vector/CHANGELOG.md
+++ b/packages/cli-vector/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.7.0](https://github.com/linz/basemaps/compare/v8.6.0...v8.7.0) (2025-08-10)
+
+
+### Features
+
+* **cli-vector:** update the parsing logic for place_labels layer features BM-1318 ([#3470](https://github.com/linz/basemaps/issues/3470)) ([29d2593](https://github.com/linz/basemaps/commit/29d25938363255f05b91cced54397928a2a092da))
+
+
+
+
+
 # [8.6.0](https://github.com/linz/basemaps/compare/v8.5.0...v8.6.0) (2025-08-06)
 
 **Note:** Version bump only for package @basemaps/cli-vector

--- a/packages/cli-vector/package.json
+++ b/packages/cli-vector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli-vector",
-  "version": "8.6.0",
+  "version": "8.7.0",
   "private": false,
   "repository": {
     "type": "git",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.7.0](https://github.com/linz/basemaps/compare/v8.6.0...v8.7.0) (2025-08-10)
+
+**Note:** Version bump only for package @basemaps/cli
+
+
+
+
+
 # [8.6.0](https://github.com/linz/basemaps/compare/v8.5.0...v8.6.0) (2025-08-06)
 
 **Note:** Version bump only for package @basemaps/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli",
-  "version": "8.6.0",
+  "version": "8.7.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -43,7 +43,7 @@
   "dependencies": {
     "@basemaps/cli-config": "^8.6.0",
     "@basemaps/cli-raster": "^8.6.0",
-    "@basemaps/cli-vector": "^8.6.0",
+    "@basemaps/cli-vector": "^8.7.0",
     "@basemaps/shared": "^8.6.0",
     "cmd-ts": "^0.13.0"
   },


### PR DESCRIPTION
# [8.7.0](https://github.com/linz/basemaps/compare/v8.6.0...v8.7.0) (2025-08-10)

### Features

* **cli-vector:** update the parsing logic for place_labels layer features BM-1318 ([#3470](https://github.com/linz/basemaps/issues/3470)) ([29d2593](https://github.com/linz/basemaps/commit/29d25938363255f05b91cced54397928a2a092da))