### PR TITLE
feat(cli-raster): Fetch chart imagery metadata from backup location.BM-1345

### DIFF
--- a/packages/cli-raster/src/cogify/cli/__test__/cli.charts.test.ts
+++ b/packages/cli-raster/src/cogify/cli/__test__/cli.charts.test.ts
@@ -1,0 +1,143 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { FeatureCollection } from 'geojson';
+
+import { geojsonToBbox } from '../cli.charts.js';
+
+describe('geojsonToBbox', () => {
+  it('should calculate bbox for a Polygon', () => {
+    const geojson: FeatureCollection = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [0, 0],
+                [0, 10],
+                [10, 10],
+                [10, 0],
+                [0, 0],
+              ],
+            ],
+          },
+        },
+      ],
+    };
+
+    const bbox = geojsonToBbox(geojson);
+    assert.deepEqual(bbox, [0, 0, 10, 10]);
+  });
+
+  it('should calculate intersection of two Polygons', () => {
+    const geojson: FeatureCollection = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [0, 0],
+                [0, 10],
+                [10, 10],
+                [10, 0],
+                [0, 0],
+              ],
+            ],
+          },
+        },
+        {
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: 'Polygon',
+            coordinates: [
+              [
+                [5, 5],
+                [5, 15],
+                [15, 15],
+                [15, 5],
+                [5, 5],
+              ],
+            ],
+          },
+        },
+      ],
+    };
+
+    const bbox = geojsonToBbox(geojson);
+    assert.deepEqual(bbox, [0, 0, 15, 15]);
+  });
+
+  it('should calculate bbox for a MultiPolygon', () => {
+    const geojson: FeatureCollection = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: 'MultiPolygon',
+            coordinates: [
+              [
+                [
+                  [5, 5],
+                  [5, 15],
+                  [15, 15],
+                  [15, 5],
+                  [5, 5],
+                ],
+              ],
+              [
+                [
+                  [0, 0],
+                  [0, 10],
+                  [10, 10],
+                  [10, 0],
+                  [0, 0],
+                ],
+              ],
+            ],
+          },
+        },
+      ],
+    };
+
+    const bbox = geojsonToBbox(geojson);
+    assert.deepEqual(bbox, [0, 0, 15, 15]);
+  });
+
+  it('should throw for unsupported geometry type', () => {
+    const geojson: FeatureCollection = {
+      type: 'FeatureCollection',
+      features: [
+        {
+          type: 'Feature',
+          properties: {},
+          geometry: {
+            type: 'Point',
+            coordinates: [0, 0],
+          },
+        },
+      ],
+    };
+
+    assert.throws(() => geojsonToBbox(geojson), /must contain Polygon or MultiPolygon/);
+  });
+
+  it('should throw if no features', () => {
+    const geojson: FeatureCollection = {
+      type: 'FeatureCollection',
+      features: [],
+    };
+
+    assert.throws(() => geojsonToBbox(geojson), /No union found in GeoJSON features/);
+  });
+});


### PR DESCRIPTION
### Motivation

Some of imagery metadata like bbox and gds tagging is not exist from the source imagery in folder `s3://linz-hydrographic-upload/charts/NChart1200/`, however, they are all exists in the `s3://linz-hydrographic-upload/charts/CChart/`.
So we can back off to fetch the meta data from `CCharts`.

### Modifications
New function to prepare and fetch all the matedata for charts imagery.

### Verification
Processed CK141-7 again, this time applying metadata from the backup imagery to replace the missing georeferencing.
<img width="1298" height="569" alt="image" src="https://github.com/user-attachments/assets/55d9c4f8-bb9a-4060-a021-96a3249cd851" />
