### PR TITLE
feat(landing): quick change cycles through more basemaps BM-1293

### DIFF
--- a/packages/landing/src/components/map.switcher.tsx
+++ b/packages/landing/src/components/map.switcher.tsx
@@ -56,7 +56,7 @@ export class MapSwitcher extends Component {
     if (Config.map.layerId === 'aerial') {
       return { layerId: 'topographic', style: 'topographic' };
     } else if (Config.map.layerId === 'topographic' && Config.map.style === 'topographic') {
-      return { layerId: 'topo-raster' };
+      return { layerId: 'topo-raster', style: 'topo-raster' };
     } else if (Config.map.layerId === 'topo-raster') {
       return { layerId: 'topographic', style: 'topolite' };
     } else if (Config.map.layerId === 'topographic' && Config.map.style === 'topolite') {

--- a/packages/landing/src/components/map.switcher.tsx
+++ b/packages/landing/src/components/map.switcher.tsx
@@ -53,8 +53,19 @@ export class MapSwitcher extends Component {
   }
 
   getStyleType(): { layerId: string; style?: string } {
-    if (Config.map.layerId !== 'aerial') return { layerId: 'aerial' };
-    return { layerId: 'topographic', style: 'topographic' };
+    if (Config.map.layerId === 'aerial') {
+      return { layerId: 'topographic', style: 'topographic' };
+    } else if (Config.map.layerId === 'topographic' && Config.map.style === 'topographic') {
+      return { layerId: 'topo-raster' };
+    } else if (Config.map.layerId === 'topo-raster') {
+      return { layerId: 'topographic', style: 'topolite' };
+    } else if (Config.map.layerId === 'topographic' && Config.map.style === 'topolite') {
+      return { layerId: 'hillshade-igor' };
+    } else if (Config.map.layerId === 'hillshade-igor') {
+      return { layerId: 'hillshade-igor-dsm' };
+    } else {
+      return { layerId: 'aerial' };
+    }
   }
 
   _updateTimer: NodeJS.Timer | null = null;


### PR DESCRIPTION
### Motivation

Change the behaviour of the quick change button on https://basemaps.linz.govt.nz/  to cycle between the following maps:

1. Aerial
2. Topographic
3. NZ Topo Gridless
4. TopoLite
5. Hillshade Igor DEM
6. Hillshade Igor DSM

### Verification

visual
