### PR TITLE
release: v8.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.9.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.9.0) (2025-09-09)
+
+
+### Bug Fixes
+
+* add required permissions for release please github action ([#3497](https://github.com/linz/basemaps/issues/3497)) ([a6155c9](https://github.com/linz/basemaps/commit/a6155c9e55beb293150031e61fe0cd46171c8c39))
+* **cli-vector:** Fix the tmp path of download layers and add try catch. BM-1352 ([#3494](https://github.com/linz/basemaps/issues/3494)) ([3769175](https://github.com/linz/basemaps/commit/376917570a2373d347d09098ccbac5e5d7515655))
+* **geo:** ensure all supported epsg codes have a projection ([#3508](https://github.com/linz/basemaps/issues/3508)) ([23a9243](https://github.com/linz/basemaps/commit/23a9243586ee3448f9c206d703ff91b7bda5978d))
+* intermittent unit tests ([#3503](https://github.com/linz/basemaps/issues/3503)) ([1e942af](https://github.com/linz/basemaps/commit/1e942af11b4018e47a05bafd8aa63e047de4cf64))
+* remove release-please from prod deploy ([#3506](https://github.com/linz/basemaps/issues/3506)) ([05b6f95](https://github.com/linz/basemaps/commit/05b6f95d9f307d56849c3068a51ab4e8971a718f))
+* stop using GITHUB_TOKEN for release-please ([#3495](https://github.com/linz/basemaps/issues/3495)) ([198cb29](https://github.com/linz/basemaps/commit/198cb29206b275b7497a8ca0d3bdaa10ae8241e3))
+
+
+### Features
+
+* **cli-raster:** Fetch chart imagery metadata from backup location.BM-1345 ([#3492](https://github.com/linz/basemaps/issues/3492)) ([2b42fa7](https://github.com/linz/basemaps/commit/2b42fa7a98730d8706506866f248cf2f43895e38))
+* **cli-raster:** New cli to standardise charts map. BM-1338 ([#3483](https://github.com/linz/basemaps/issues/3483)) ([35b7854](https://github.com/linz/basemaps/commit/35b7854c50dffd1ee5a3cbeac2289a91cc87d1b3))
+* **geo:** implement support for all raster topo map series projections BM-1160 ([#3480](https://github.com/linz/basemaps/issues/3480)) ([8652578](https://github.com/linz/basemaps/commit/8652578380c8d9fb64bce3d3724b8fb99bd1612a))
+* **geo:** support tile matrixes that are not square ([#3484](https://github.com/linz/basemaps/issues/3484)) ([7720d02](https://github.com/linz/basemaps/commit/7720d02684874b17fb744b9cadff3557676f4d42))
+* **lambda-tiler:** support one band uint16 lerc tiffs ([#3489](https://github.com/linz/basemaps/issues/3489)) ([906d016](https://github.com/linz/basemaps/commit/906d016f9d022b9113c7a1f0d09ff03ec8f6a758))
+* **landing:** quick change cycles through more basemaps BM-1293 ([#3493](https://github.com/linz/basemaps/issues/3493)) ([4bfba36](https://github.com/linz/basemaps/commit/4bfba36d8a8f7691a67a703fa78e0b1da20b9eba))
+
+
+
+
+
 # [8.8.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.8.0) (2025-09-07)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -7,5 +7,5 @@
       "conventionalCommits": true
     }
   },
-  "version": "8.8.0"
+  "version": "8.9.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19462,13 +19462,13 @@
     },
     "packages/_infra": {
       "name": "@basemaps/infra",
-      "version": "8.8.0",
+      "version": "8.9.0",
       "license": "MIT",
       "devDependencies": {
         "@aws-sdk/client-acm": "^3.470.0",
         "@aws-sdk/client-cloudformation": "^3.470.0",
-        "@basemaps/lambda-tiler": "^8.8.0",
-        "@basemaps/shared": "^8.8.0",
+        "@basemaps/lambda-tiler": "^8.9.0",
+        "@basemaps/shared": "^8.9.0",
         "@linzjs/cdk-tags": "^1.7.0",
         "aws-cdk": "2.162.x",
         "aws-cdk-lib": "2.162.x",
@@ -19480,10 +19480,10 @@
     },
     "packages/attribution": {
       "name": "@basemaps/attribution",
-      "version": "8.8.0",
+      "version": "8.9.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/geo": "^8.8.0",
+        "@basemaps/geo": "^8.9.0",
         "@linzjs/geojson": "^8.0.0"
       },
       "engines": {
@@ -19492,11 +19492,11 @@
     },
     "packages/bathymetry": {
       "name": "@basemaps/bathymetry",
-      "version": "8.8.0",
+      "version": "8.9.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/geo": "^8.8.0",
-        "@basemaps/shared": "^8.8.0",
+        "@basemaps/geo": "^8.9.0",
+        "@basemaps/shared": "^8.9.0",
         "@rushstack/ts-command-line": "^4.3.13",
         "ulid": "^2.3.0"
       },
@@ -19519,13 +19519,13 @@
     },
     "packages/cli": {
       "name": "@basemaps/cli",
-      "version": "8.8.0",
+      "version": "8.9.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/cli-config": "^8.8.0",
-        "@basemaps/cli-raster": "^8.8.0",
-        "@basemaps/cli-vector": "^8.8.0",
-        "@basemaps/shared": "^8.8.0",
+        "@basemaps/cli-config": "^8.9.0",
+        "@basemaps/cli-raster": "^8.9.0",
+        "@basemaps/cli-vector": "^8.9.0",
+        "@basemaps/shared": "^8.9.0",
         "cmd-ts": "^0.13.0"
       },
       "bin": {
@@ -19537,13 +19537,13 @@
     },
     "packages/cli-config": {
       "name": "@basemaps/cli-config",
-      "version": "8.8.0",
+      "version": "8.9.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^8.8.0",
-        "@basemaps/config-loader": "^8.8.0",
-        "@basemaps/geo": "^8.8.0",
-        "@basemaps/shared": "^8.8.0",
+        "@basemaps/config": "^8.9.0",
+        "@basemaps/config-loader": "^8.9.0",
+        "@basemaps/geo": "^8.9.0",
+        "@basemaps/shared": "^8.9.0",
         "@cotar/builder": "^6.0.1",
         "@cotar/core": "^6.0.1",
         "@cotar/tar": "^6.0.1",
@@ -19585,16 +19585,16 @@
     },
     "packages/cli-raster": {
       "name": "@basemaps/cli-raster",
-      "version": "8.8.0",
+      "version": "8.9.0",
       "license": "MIT",
       "bin": {
         "cogify": "build/bin.js"
       },
       "devDependencies": {
-        "@basemaps/config": "^8.8.0",
-        "@basemaps/config-loader": "^8.8.0",
-        "@basemaps/geo": "^8.8.0",
-        "@basemaps/shared": "^8.8.0",
+        "@basemaps/config": "^8.9.0",
+        "@basemaps/config-loader": "^8.9.0",
+        "@basemaps/geo": "^8.9.0",
+        "@basemaps/shared": "^8.9.0",
         "@linzjs/geojson": "^8.0.0",
         "@linzjs/metrics": "^8.0.0",
         "cmd-ts": "^0.12.1",
@@ -19607,12 +19607,12 @@
     },
     "packages/cli-vector": {
       "name": "@basemaps/cli-vector",
-      "version": "8.8.0",
+      "version": "8.9.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^8.8.0",
-        "@basemaps/geo": "^8.8.0",
-        "@basemaps/shared": "^8.8.0",
+        "@basemaps/config": "^8.9.0",
+        "@basemaps/geo": "^8.9.0",
+        "@basemaps/shared": "^8.9.0",
         "@cotar/builder": "^6.0.1",
         "@cotar/core": "^6.0.1",
         "@linzjs/docker-command": "^7.5.0",
@@ -19714,10 +19714,10 @@
     },
     "packages/config": {
       "name": "@basemaps/config",
-      "version": "8.8.0",
+      "version": "8.9.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/geo": "^8.8.0",
+        "@basemaps/geo": "^8.9.0",
         "base-x": "^4.0.0",
         "zod": "^3.17.3"
       },
@@ -19727,12 +19727,12 @@
     },
     "packages/config-loader": {
       "name": "@basemaps/config-loader",
-      "version": "8.8.0",
+      "version": "8.9.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^8.8.0",
-        "@basemaps/geo": "^8.8.0",
-        "@basemaps/shared": "^8.8.0"
+        "@basemaps/config": "^8.9.0",
+        "@basemaps/geo": "^8.9.0",
+        "@basemaps/shared": "^8.9.0"
       },
       "engines": {
         "node": ">=16.0.0"
@@ -19740,7 +19740,7 @@
     },
     "packages/geo": {
       "name": "@basemaps/geo",
-      "version": "8.8.0",
+      "version": "8.9.0",
       "license": "MIT",
       "dependencies": {
         "@linzjs/geojson": "^8.0.0",
@@ -19756,12 +19756,12 @@
     },
     "packages/lambda-analytic-cloudfront": {
       "name": "@basemaps/lambda-analytic-cloudfront",
-      "version": "8.8.0",
+      "version": "8.9.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^8.8.0",
-        "@basemaps/geo": "^8.8.0",
-        "@basemaps/shared": "^8.8.0",
+        "@basemaps/config": "^8.9.0",
+        "@basemaps/geo": "^8.9.0",
+        "@basemaps/shared": "^8.9.0",
         "@elastic/elasticsearch": "^8.16.2",
         "@linzjs/lambda": "^4.0.0",
         "ua-parser-js": "^1.0.39"
@@ -19775,12 +19775,12 @@
     },
     "packages/lambda-analytics": {
       "name": "@basemaps/lambda-analytics",
-      "version": "8.8.0",
+      "version": "8.9.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^8.8.0",
-        "@basemaps/geo": "^8.8.0",
-        "@basemaps/shared": "^8.8.0",
+        "@basemaps/config": "^8.9.0",
+        "@basemaps/geo": "^8.9.0",
+        "@basemaps/shared": "^8.9.0",
         "ua-parser-js": "^1.0.2"
       },
       "devDependencies": {
@@ -19792,15 +19792,15 @@
     },
     "packages/lambda-tiler": {
       "name": "@basemaps/lambda-tiler",
-      "version": "8.8.0",
+      "version": "8.9.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^8.8.0",
-        "@basemaps/config-loader": "^8.8.0",
-        "@basemaps/geo": "^8.8.0",
-        "@basemaps/shared": "^8.8.0",
-        "@basemaps/tiler": "^8.8.0",
-        "@basemaps/tiler-sharp": "^8.8.0",
+        "@basemaps/config": "^8.9.0",
+        "@basemaps/config-loader": "^8.9.0",
+        "@basemaps/geo": "^8.9.0",
+        "@basemaps/shared": "^8.9.0",
+        "@basemaps/tiler": "^8.9.0",
+        "@basemaps/tiler-sharp": "^8.9.0",
         "@linzjs/geojson": "^8.0.0",
         "@linzjs/lambda": "^4.0.0",
         "@mapbox/vector-tile": "^2.0.3",
@@ -19810,7 +19810,7 @@
         "sharp": "^0.33.0"
       },
       "devDependencies": {
-        "@basemaps/attribution": "^8.8.0",
+        "@basemaps/attribution": "^8.9.0",
         "@chunkd/fs": "^11.2.0",
         "@types/aws-lambda": "^8.10.75",
         "@types/pixelmatch": "^5.0.0",
@@ -19858,14 +19858,14 @@
     },
     "packages/landing": {
       "name": "@basemaps/landing",
-      "version": "8.8.0",
+      "version": "8.9.0",
       "license": "MIT",
       "devDependencies": {
-        "@basemaps/attribution": "^8.8.0",
-        "@basemaps/cli-config": "^8.8.0",
-        "@basemaps/config": "^8.8.0",
-        "@basemaps/geo": "^8.8.0",
-        "@basemaps/shared": "^8.8.0",
+        "@basemaps/attribution": "^8.9.0",
+        "@basemaps/cli-config": "^8.9.0",
+        "@basemaps/config": "^8.9.0",
+        "@basemaps/geo": "^8.9.0",
+        "@basemaps/shared": "^8.9.0",
         "@linzjs/geojson": "^8.0.0",
         "@linzjs/lui": "^21.46.0",
         "@servie/events": "^3.0.0",
@@ -19924,7 +19924,7 @@
     },
     "packages/server": {
       "name": "@basemaps/server",
-      "version": "8.8.0",
+      "version": "8.9.0",
       "license": "MIT",
       "dependencies": {
         "lerc": "^4.0.4",
@@ -19934,12 +19934,12 @@
         "basemaps-server": "bin/basemaps-server.cjs"
       },
       "devDependencies": {
-        "@basemaps/config": "^8.8.0",
-        "@basemaps/config-loader": "^8.8.0",
-        "@basemaps/geo": "^8.8.0",
-        "@basemaps/lambda-tiler": "^8.8.0",
+        "@basemaps/config": "^8.9.0",
+        "@basemaps/config-loader": "^8.9.0",
+        "@basemaps/geo": "^8.9.0",
+        "@basemaps/lambda-tiler": "^8.9.0",
         "@basemaps/landing": "^6.39.0",
-        "@basemaps/shared": "^8.8.0",
+        "@basemaps/shared": "^8.9.0",
         "@fastify/formbody": "^7.0.1",
         "@fastify/static": "^6.5.0",
         "cmd-ts": "^0.12.1",
@@ -19964,15 +19964,15 @@
     },
     "packages/shared": {
       "name": "@basemaps/shared",
-      "version": "8.8.0",
+      "version": "8.9.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.470.0",
         "@aws-sdk/client-s3": "^3.472.0",
         "@aws-sdk/s3-request-presigner": "^3.472.0",
         "@aws-sdk/util-dynamodb": "^3.470.0",
-        "@basemaps/config": "^8.8.0",
-        "@basemaps/geo": "^8.8.0",
+        "@basemaps/config": "^8.9.0",
+        "@basemaps/geo": "^8.9.0",
         "@chunkd/fs": "^11.2.0",
         "@chunkd/fs-aws": "^11.3.0",
         "@chunkd/middleware": "^11.1.0",
@@ -20065,10 +20065,10 @@
     },
     "packages/tiler": {
       "name": "@basemaps/tiler",
-      "version": "8.8.0",
+      "version": "8.9.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/geo": "^8.8.0",
+        "@basemaps/geo": "^8.9.0",
         "@cogeotiff/core": "^9.0.3",
         "@linzjs/metrics": "^8.0.0"
       },
@@ -20084,12 +20084,12 @@
     },
     "packages/tiler-sharp": {
       "name": "@basemaps/tiler-sharp",
-      "version": "8.8.0",
+      "version": "8.9.0",
       "license": "MIT",
       "dependencies": {
-        "@basemaps/config": "^8.8.0",
-        "@basemaps/geo": "^8.8.0",
-        "@basemaps/tiler": "^8.8.0",
+        "@basemaps/config": "^8.9.0",
+        "@basemaps/geo": "^8.9.0",
+        "@basemaps/tiler": "^8.9.0",
         "@linzjs/metrics": "^8.0.0",
         "lerc": "^4.0.4"
       },

--- a/packages/_infra/CHANGELOG.md
+++ b/packages/_infra/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.9.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.9.0) (2025-09-09)
+
+**Note:** Version bump only for package @basemaps/infra
+
+
+
+
+
 # [8.8.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.8.0) (2025-09-07)
 
 **Note:** Version bump only for package @basemaps/infra

--- a/packages/_infra/package.json
+++ b/packages/_infra/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/infra",
-  "version": "8.8.0",
+  "version": "8.9.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -26,8 +26,8 @@
   "devDependencies": {
     "@aws-sdk/client-acm": "^3.470.0",
     "@aws-sdk/client-cloudformation": "^3.470.0",
-    "@basemaps/lambda-tiler": "^8.8.0",
-    "@basemaps/shared": "^8.8.0",
+    "@basemaps/lambda-tiler": "^8.9.0",
+    "@basemaps/shared": "^8.9.0",
     "@linzjs/cdk-tags": "^1.7.0",
     "aws-cdk": "2.162.x",
     "aws-cdk-lib": "2.162.x",

--- a/packages/attribution/CHANGELOG.md
+++ b/packages/attribution/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.9.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.9.0) (2025-09-09)
+
+**Note:** Version bump only for package @basemaps/attribution
+
+
+
+
+
 # [8.8.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.8.0) (2025-09-07)
 
 **Note:** Version bump only for package @basemaps/attribution

--- a/packages/attribution/package.json
+++ b/packages/attribution/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/attribution",
-  "version": "8.8.0",
+  "version": "8.9.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -30,7 +30,7 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/geo": "^8.8.0",
+    "@basemaps/geo": "^8.9.0",
     "@linzjs/geojson": "^8.0.0"
   },
   "bundle": {

--- a/packages/bathymetry/CHANGELOG.md
+++ b/packages/bathymetry/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.9.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.9.0) (2025-09-09)
+
+**Note:** Version bump only for package @basemaps/bathymetry
+
+
+
+
+
 # [8.8.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.8.0) (2025-09-07)
 
 **Note:** Version bump only for package @basemaps/bathymetry

--- a/packages/bathymetry/package.json
+++ b/packages/bathymetry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/bathymetry",
-  "version": "8.8.0",
+  "version": "8.9.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -28,8 +28,8 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/geo": "^8.8.0",
-    "@basemaps/shared": "^8.8.0",
+    "@basemaps/geo": "^8.9.0",
+    "@basemaps/shared": "^8.9.0",
     "@rushstack/ts-command-line": "^4.3.13",
     "ulid": "^2.3.0"
   },

--- a/packages/cli-config/CHANGELOG.md
+++ b/packages/cli-config/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.9.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.9.0) (2025-09-09)
+
+**Note:** Version bump only for package @basemaps/cli-config
+
+
+
+
+
 # [8.8.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.8.0) (2025-09-07)
 
 **Note:** Version bump only for package @basemaps/cli-config

--- a/packages/cli-config/package.json
+++ b/packages/cli-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli-config",
-  "version": "8.8.0",
+  "version": "8.9.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -24,10 +24,10 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@basemaps/config": "^8.8.0",
-    "@basemaps/config-loader": "^8.8.0",
-    "@basemaps/geo": "^8.8.0",
-    "@basemaps/shared": "^8.8.0",
+    "@basemaps/config": "^8.9.0",
+    "@basemaps/config-loader": "^8.9.0",
+    "@basemaps/geo": "^8.9.0",
+    "@basemaps/shared": "^8.9.0",
     "@cotar/builder": "^6.0.1",
     "@cotar/core": "^6.0.1",
     "@cotar/tar": "^6.0.1",

--- a/packages/cli-raster/CHANGELOG.md
+++ b/packages/cli-raster/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.9.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.9.0) (2025-09-09)
+
+
+### Features
+
+* **cli-raster:** Fetch chart imagery metadata from backup location.BM-1345 ([#3492](https://github.com/linz/basemaps/issues/3492)) ([2b42fa7](https://github.com/linz/basemaps/commit/2b42fa7a98730d8706506866f248cf2f43895e38))
+* **cli-raster:** New cli to standardise charts map. BM-1338 ([#3483](https://github.com/linz/basemaps/issues/3483)) ([35b7854](https://github.com/linz/basemaps/commit/35b7854c50dffd1ee5a3cbeac2289a91cc87d1b3))
+* **geo:** implement support for all raster topo map series projections BM-1160 ([#3480](https://github.com/linz/basemaps/issues/3480)) ([8652578](https://github.com/linz/basemaps/commit/8652578380c8d9fb64bce3d3724b8fb99bd1612a))
+* **geo:** support tile matrixes that are not square ([#3484](https://github.com/linz/basemaps/issues/3484)) ([7720d02](https://github.com/linz/basemaps/commit/7720d02684874b17fb744b9cadff3557676f4d42))
+
+
+
+
+
 # [8.8.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.8.0) (2025-09-07)
 
 

--- a/packages/cli-raster/package.json
+++ b/packages/cli-raster/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli-raster",
-  "version": "8.8.0",
+  "version": "8.9.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -40,10 +40,10 @@
     "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   },
   "devDependencies": {
-    "@basemaps/config": "^8.8.0",
-    "@basemaps/config-loader": "^8.8.0",
-    "@basemaps/geo": "^8.8.0",
-    "@basemaps/shared": "^8.8.0",
+    "@basemaps/config": "^8.9.0",
+    "@basemaps/config-loader": "^8.9.0",
+    "@basemaps/geo": "^8.9.0",
+    "@basemaps/shared": "^8.9.0",
     "@linzjs/geojson": "^8.0.0",
     "@linzjs/metrics": "^8.0.0",
     "cmd-ts": "^0.12.1",

--- a/packages/cli-vector/CHANGELOG.md
+++ b/packages/cli-vector/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.9.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.9.0) (2025-09-09)
+
+
+### Bug Fixes
+
+* **cli-vector:** Fix the tmp path of download layers and add try catch. BM-1352 ([#3494](https://github.com/linz/basemaps/issues/3494)) ([3769175](https://github.com/linz/basemaps/commit/376917570a2373d347d09098ccbac5e5d7515655))
+
+
+
+
+
 # [8.8.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.8.0) (2025-09-07)
 
 

--- a/packages/cli-vector/package.json
+++ b/packages/cli-vector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli-vector",
-  "version": "8.8.0",
+  "version": "8.9.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -49,9 +49,9 @@
     "dist/"
   ],
   "dependencies": {
-    "@basemaps/config": "^8.8.0",
-    "@basemaps/geo": "^8.8.0",
-    "@basemaps/shared": "^8.8.0",
+    "@basemaps/config": "^8.9.0",
+    "@basemaps/geo": "^8.9.0",
+    "@basemaps/shared": "^8.9.0",
     "@cotar/builder": "^6.0.1",
     "@cotar/core": "^6.0.1",
     "@linzjs/docker-command": "^7.5.0",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.9.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.9.0) (2025-09-09)
+
+**Note:** Version bump only for package @basemaps/cli
+
+
+
+
+
 # [8.8.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.8.0) (2025-09-07)
 
 **Note:** Version bump only for package @basemaps/cli

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/cli",
-  "version": "8.8.0",
+  "version": "8.9.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -41,10 +41,10 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
-    "@basemaps/cli-config": "^8.8.0",
-    "@basemaps/cli-raster": "^8.8.0",
-    "@basemaps/cli-vector": "^8.8.0",
-    "@basemaps/shared": "^8.8.0",
+    "@basemaps/cli-config": "^8.9.0",
+    "@basemaps/cli-raster": "^8.9.0",
+    "@basemaps/cli-vector": "^8.9.0",
+    "@basemaps/shared": "^8.9.0",
     "cmd-ts": "^0.13.0"
   },
   "publishConfig": {

--- a/packages/config-loader/CHANGELOG.md
+++ b/packages/config-loader/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.9.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.9.0) (2025-09-09)
+
+**Note:** Version bump only for package @basemaps/config-loader
+
+
+
+
+
 # [8.8.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.8.0) (2025-09-07)
 
 **Note:** Version bump only for package @basemaps/config-loader

--- a/packages/config-loader/package.json
+++ b/packages/config-loader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/config-loader",
-  "version": "8.8.0",
+  "version": "8.9.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -28,8 +28,8 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/config": "^8.8.0",
-    "@basemaps/geo": "^8.8.0",
-    "@basemaps/shared": "^8.8.0"
+    "@basemaps/config": "^8.9.0",
+    "@basemaps/geo": "^8.9.0",
+    "@basemaps/shared": "^8.9.0"
   }
 }

--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.9.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.9.0) (2025-09-09)
+
+
+### Bug Fixes
+
+* intermittent unit tests ([#3503](https://github.com/linz/basemaps/issues/3503)) ([1e942af](https://github.com/linz/basemaps/commit/1e942af11b4018e47a05bafd8aa63e047de4cf64))
+
+
+
+
+
 # [8.8.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.8.0) (2025-09-07)
 
 

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/config",
-  "version": "8.8.0",
+  "version": "8.9.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -28,7 +28,7 @@
     "build/"
   ],
   "dependencies": {
-    "@basemaps/geo": "^8.8.0",
+    "@basemaps/geo": "^8.9.0",
     "base-x": "^4.0.0",
     "zod": "^3.17.3"
   }

--- a/packages/geo/CHANGELOG.md
+++ b/packages/geo/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.9.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.9.0) (2025-09-09)
+
+
+### Bug Fixes
+
+* **geo:** ensure all supported epsg codes have a projection ([#3508](https://github.com/linz/basemaps/issues/3508)) ([23a9243](https://github.com/linz/basemaps/commit/23a9243586ee3448f9c206d703ff91b7bda5978d))
+
+
+### Features
+
+* **geo:** implement support for all raster topo map series projections BM-1160 ([#3480](https://github.com/linz/basemaps/issues/3480)) ([8652578](https://github.com/linz/basemaps/commit/8652578380c8d9fb64bce3d3724b8fb99bd1612a))
+* **geo:** support tile matrixes that are not square ([#3484](https://github.com/linz/basemaps/issues/3484)) ([7720d02](https://github.com/linz/basemaps/commit/7720d02684874b17fb744b9cadff3557676f4d42))
+
+
+
+
+
 # [8.8.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.8.0) (2025-09-07)
 
 

--- a/packages/geo/package.json
+++ b/packages/geo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/geo",
-  "version": "8.8.0",
+  "version": "8.9.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",

--- a/packages/lambda-analytic-cloudfront/CHANGELOG.md
+++ b/packages/lambda-analytic-cloudfront/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.9.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.9.0) (2025-09-09)
+
+**Note:** Version bump only for package @basemaps/lambda-analytic-cloudfront
+
+
+
+
+
 # [8.8.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.8.0) (2025-09-07)
 
 **Note:** Version bump only for package @basemaps/lambda-analytic-cloudfront

--- a/packages/lambda-analytic-cloudfront/package.json
+++ b/packages/lambda-analytic-cloudfront/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-analytic-cloudfront",
-  "version": "8.8.0",
+  "version": "8.9.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -18,9 +18,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@basemaps/config": "^8.8.0",
-    "@basemaps/geo": "^8.8.0",
-    "@basemaps/shared": "^8.8.0",
+    "@basemaps/config": "^8.9.0",
+    "@basemaps/geo": "^8.9.0",
+    "@basemaps/shared": "^8.9.0",
     "@elastic/elasticsearch": "^8.16.2",
     "@linzjs/lambda": "^4.0.0",
     "ua-parser-js": "^1.0.39"

--- a/packages/lambda-analytics/CHANGELOG.md
+++ b/packages/lambda-analytics/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.9.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.9.0) (2025-09-09)
+
+**Note:** Version bump only for package @basemaps/lambda-analytics
+
+
+
+
+
 # [8.8.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.8.0) (2025-09-07)
 
 **Note:** Version bump only for package @basemaps/lambda-analytics

--- a/packages/lambda-analytics/package.json
+++ b/packages/lambda-analytics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-analytics",
-  "version": "8.8.0",
+  "version": "8.9.0",
   "private": true,
   "repository": {
     "type": "git",
@@ -18,9 +18,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@basemaps/config": "^8.8.0",
-    "@basemaps/geo": "^8.8.0",
-    "@basemaps/shared": "^8.8.0",
+    "@basemaps/config": "^8.9.0",
+    "@basemaps/geo": "^8.9.0",
+    "@basemaps/shared": "^8.9.0",
     "ua-parser-js": "^1.0.2"
   },
   "scripts": {

--- a/packages/lambda-tiler/CHANGELOG.md
+++ b/packages/lambda-tiler/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.9.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.9.0) (2025-09-09)
+
+**Note:** Version bump only for package @basemaps/lambda-tiler
+
+
+
+
+
 # [8.8.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.8.0) (2025-09-07)
 
 **Note:** Version bump only for package @basemaps/lambda-tiler

--- a/packages/lambda-tiler/package.json
+++ b/packages/lambda-tiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/lambda-tiler",
-  "version": "8.8.0",
+  "version": "8.9.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -22,12 +22,12 @@
   "types": "./build/index.d.ts",
   "license": "MIT",
   "dependencies": {
-    "@basemaps/config": "^8.8.0",
-    "@basemaps/config-loader": "^8.8.0",
-    "@basemaps/geo": "^8.8.0",
-    "@basemaps/shared": "^8.8.0",
-    "@basemaps/tiler": "^8.8.0",
-    "@basemaps/tiler-sharp": "^8.8.0",
+    "@basemaps/config": "^8.9.0",
+    "@basemaps/config-loader": "^8.9.0",
+    "@basemaps/geo": "^8.9.0",
+    "@basemaps/shared": "^8.9.0",
+    "@basemaps/tiler": "^8.9.0",
+    "@basemaps/tiler-sharp": "^8.9.0",
     "@linzjs/geojson": "^8.0.0",
     "@linzjs/lambda": "^4.0.0",
     "@mapbox/vector-tile": "^2.0.3",
@@ -50,7 +50,7 @@
     "bundle": "./bundle.sh"
   },
   "devDependencies": {
-    "@basemaps/attribution": "^8.8.0",
+    "@basemaps/attribution": "^8.9.0",
     "@chunkd/fs": "^11.2.0",
     "@types/aws-lambda": "^8.10.75",
     "@types/pixelmatch": "^5.0.0",

--- a/packages/landing/CHANGELOG.md
+++ b/packages/landing/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.9.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.9.0) (2025-09-09)
+
+
+### Features
+
+* **geo:** implement support for all raster topo map series projections BM-1160 ([#3480](https://github.com/linz/basemaps/issues/3480)) ([8652578](https://github.com/linz/basemaps/commit/8652578380c8d9fb64bce3d3724b8fb99bd1612a))
+* **geo:** support tile matrixes that are not square ([#3484](https://github.com/linz/basemaps/issues/3484)) ([7720d02](https://github.com/linz/basemaps/commit/7720d02684874b17fb744b9cadff3557676f4d42))
+* **landing:** quick change cycles through more basemaps BM-1293 ([#3493](https://github.com/linz/basemaps/issues/3493)) ([4bfba36](https://github.com/linz/basemaps/commit/4bfba36d8a8f7691a67a703fa78e0b1da20b9eba))
+
+
+
+
+
 # [8.8.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.8.0) (2025-09-07)
 
 

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/landing",
-  "version": "8.8.0",
+  "version": "8.9.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -28,11 +28,11 @@
     "last 2 Chrome versions"
   ],
   "devDependencies": {
-    "@basemaps/attribution": "^8.8.0",
-    "@basemaps/cli-config": "^8.8.0",
-    "@basemaps/config": "^8.8.0",
-    "@basemaps/geo": "^8.8.0",
-    "@basemaps/shared": "^8.8.0",
+    "@basemaps/attribution": "^8.9.0",
+    "@basemaps/cli-config": "^8.9.0",
+    "@basemaps/config": "^8.9.0",
+    "@basemaps/geo": "^8.9.0",
+    "@basemaps/shared": "^8.9.0",
     "@linzjs/geojson": "^8.0.0",
     "@linzjs/lui": "^21.46.0",
     "@servie/events": "^3.0.0",

--- a/packages/server/CHANGELOG.md
+++ b/packages/server/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.9.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.9.0) (2025-09-09)
+
+**Note:** Version bump only for package @basemaps/server
+
+
+
+
+
 # [8.8.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.8.0) (2025-09-07)
 
 **Note:** Version bump only for package @basemaps/server

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/server",
-  "version": "8.8.0",
+  "version": "8.9.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -52,12 +52,12 @@
     "sharp": "^0.33.0"
   },
   "devDependencies": {
-    "@basemaps/config": "^8.8.0",
-    "@basemaps/config-loader": "^8.8.0",
-    "@basemaps/geo": "^8.8.0",
-    "@basemaps/lambda-tiler": "^8.8.0",
+    "@basemaps/config": "^8.9.0",
+    "@basemaps/config-loader": "^8.9.0",
+    "@basemaps/geo": "^8.9.0",
+    "@basemaps/lambda-tiler": "^8.9.0",
     "@basemaps/landing": "^6.39.0",
-    "@basemaps/shared": "^8.8.0",
+    "@basemaps/shared": "^8.9.0",
     "@fastify/formbody": "^7.0.1",
     "@fastify/static": "^6.5.0",
     "cmd-ts": "^0.12.1",

--- a/packages/shared/CHANGELOG.md
+++ b/packages/shared/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.9.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.9.0) (2025-09-09)
+
+
+### Features
+
+* **geo:** implement support for all raster topo map series projections BM-1160 ([#3480](https://github.com/linz/basemaps/issues/3480)) ([8652578](https://github.com/linz/basemaps/commit/8652578380c8d9fb64bce3d3724b8fb99bd1612a))
+
+
+
+
+
 # [8.8.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.8.0) (2025-09-07)
 
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/shared",
-  "version": "8.8.0",
+  "version": "8.9.0",
   "private": false,
   "repository": {
     "type": "git",
@@ -27,8 +27,8 @@
     "@aws-sdk/client-s3": "^3.472.0",
     "@aws-sdk/s3-request-presigner": "^3.472.0",
     "@aws-sdk/util-dynamodb": "^3.470.0",
-    "@basemaps/config": "^8.8.0",
-    "@basemaps/geo": "^8.8.0",
+    "@basemaps/config": "^8.9.0",
+    "@basemaps/geo": "^8.9.0",
     "@chunkd/fs": "^11.2.0",
     "@chunkd/fs-aws": "^11.3.0",
     "@chunkd/middleware": "^11.1.0",

--- a/packages/tiler-sharp/CHANGELOG.md
+++ b/packages/tiler-sharp/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.9.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.9.0) (2025-09-09)
+
+
+### Features
+
+* **lambda-tiler:** support one band uint16 lerc tiffs ([#3489](https://github.com/linz/basemaps/issues/3489)) ([906d016](https://github.com/linz/basemaps/commit/906d016f9d022b9113c7a1f0d09ff03ec8f6a758))
+
+
+
+
+
 # [8.8.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.8.0) (2025-09-07)
 
 

--- a/packages/tiler-sharp/package.json
+++ b/packages/tiler-sharp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/tiler-sharp",
-  "version": "8.8.0",
+  "version": "8.9.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -22,9 +22,9 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@basemaps/config": "^8.8.0",
-    "@basemaps/geo": "^8.8.0",
-    "@basemaps/tiler": "^8.8.0",
+    "@basemaps/config": "^8.9.0",
+    "@basemaps/geo": "^8.9.0",
+    "@basemaps/tiler": "^8.9.0",
     "@linzjs/metrics": "^8.0.0",
     "lerc": "^4.0.4"
   },

--- a/packages/tiler/CHANGELOG.md
+++ b/packages/tiler/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [8.9.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.9.0) (2025-09-09)
+
+
+### Features
+
+* **geo:** support tile matrixes that are not square ([#3484](https://github.com/linz/basemaps/issues/3484)) ([7720d02](https://github.com/linz/basemaps/commit/7720d02684874b17fb744b9cadff3557676f4d42))
+
+
+
+
+
 # [8.8.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.8.0) (2025-09-07)
 
 

--- a/packages/tiler/package.json
+++ b/packages/tiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemaps/tiler",
-  "version": "8.8.0",
+  "version": "8.9.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/linz/basemaps.git",
@@ -22,7 +22,7 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@basemaps/geo": "^8.8.0",
+    "@basemaps/geo": "^8.9.0",
     "@cogeotiff/core": "^9.0.3",
     "@linzjs/metrics": "^8.0.0"
   },


### PR DESCRIPTION

# [8.9.0](https://github.com/linz/basemaps/compare/v8.7.0...v8.9.0) (2025-09-09)


### Bug Fixes

* add required permissions for release please github action ([#3497](https://github.com/linz/basemaps/issues/3497)) ([a6155c9](https://github.com/linz/basemaps/commit/a6155c9e55beb293150031e61fe0cd46171c8c39))
* **cli-vector:** Fix the tmp path of download layers and add try catch. BM-1352 ([#3494](https://github.com/linz/basemaps/issues/3494)) ([3769175](https://github.com/linz/basemaps/commit/376917570a2373d347d09098ccbac5e5d7515655))
* **geo:** ensure all supported epsg codes have a projection ([#3508](https://github.com/linz/basemaps/issues/3508)) ([23a9243](https://github.com/linz/basemaps/commit/23a9243586ee3448f9c206d703ff91b7bda5978d))
* intermittent unit tests ([#3503](https://github.com/linz/basemaps/issues/3503)) ([1e942af](https://github.com/linz/basemaps/commit/1e942af11b4018e47a05bafd8aa63e047de4cf64))
* remove release-please from prod deploy ([#3506](https://github.com/linz/basemaps/issues/3506)) ([05b6f95](https://github.com/linz/basemaps/commit/05b6f95d9f307d56849c3068a51ab4e8971a718f))
* stop using GITHUB_TOKEN for release-please ([#3495](https://github.com/linz/basemaps/issues/3495)) ([198cb29](https://github.com/linz/basemaps/commit/198cb29206b275b7497a8ca0d3bdaa10ae8241e3))


### Features

* **cli-raster:** Fetch chart imagery metadata from backup location.BM-1345 ([#3492](https://github.com/linz/basemaps/issues/3492)) ([2b42fa7](https://github.com/linz/basemaps/commit/2b42fa7a98730d8706506866f248cf2f43895e38))
* **cli-raster:** New cli to standardise charts map. BM-1338 ([#3483](https://github.com/linz/basemaps/issues/3483)) ([35b7854](https://github.com/linz/basemaps/commit/35b7854c50dffd1ee5a3cbeac2289a91cc87d1b3))
* **geo:** implement support for all raster topo map series projections BM-1160 ([#3480](https://github.com/linz/basemaps/issues/3480)) ([8652578](https://github.com/linz/basemaps/commit/8652578380c8d9fb64bce3d3724b8fb99bd1612a))
* **geo:** support tile matrixes that are not square ([#3484](https://github.com/linz/basemaps/issues/3484)) ([7720d02](https://github.com/linz/basemaps/commit/7720d02684874b17fb744b9cadff3557676f4d42))
* **lambda-tiler:** support one band uint16 lerc tiffs ([#3489](https://github.com/linz/basemaps/issues/3489)) ([906d016](https://github.com/linz/basemaps/commit/906d016f9d022b9113c7a1f0d09ff03ec8f6a758))
* **landing:** quick change cycles through more basemaps BM-1293 ([#3493](https://github.com/linz/basemaps/issues/3493)) ([4bfba36](https://github.com/linz/basemaps/commit/4bfba36d8a8f7691a67a703fa78e0b1da20b9eba))