### PR TITLE
fix(geo): ensure all supported epsg codes have a projection

### DIFF
--- a/packages/geo/src/proj/json/__tests__/proj.json.test.ts
+++ b/packages/geo/src/proj/json/__tests__/proj.json.test.ts
@@ -11,6 +11,14 @@ import { ProjJsons } from '../proj.json.js';
 import { FakeData } from './fake.data.js';
 
 describe('ProjJson', () => {
+  it('should ensure that all supported EPSG codes have an Epsg and Projection', () => {
+    for (const epsg of Epsg.Codes.values()) {
+      // ensure that an Epsg and Projection already exist
+      assert.doesNotThrow(() => Epsg.get(epsg.code));
+      assert.doesNotThrow(() => Projection.get(epsg));
+    }
+  });
+
   it('should parse each unsupported EPSG code and ProjJSON pair into a runtime Epsg and Projection', async () => {
     for (const key of Object.keys(ProjJsons)) {
       const code = Number(key);
@@ -19,13 +27,13 @@ describe('ProjJson', () => {
       if (Epsg.tryGet(code) != null) continue;
 
       // ensure that neither an Epsg or Projection already exists
-      assert.strictEqual(Epsg.tryGet(code), undefined);
-      assert.strictEqual(Projection.tryGet(code), null);
+      assert.throws(() => Epsg.get(code));
+      assert.throws(() => Projection.get(code));
 
       // ensure that both an Epsg and Projection now exist
       const epsg = await ProjectionLoader.load(code);
-      assert.notStrictEqual(Epsg.tryGet(code), undefined);
-      assert.notStrictEqual(Projection.tryGet(epsg), null);
+      assert.doesNotThrow(() => Epsg.get(code));
+      assert.doesNotThrow(() => Projection.get(epsg));
     }
   });
 

--- a/packages/geo/src/proj/projection.ts
+++ b/packages/geo/src/proj/projection.ts
@@ -283,3 +283,4 @@ export class Projection {
 Projection.define(Epsg.Nztm2000, Nztm2000Json);
 Projection.define(Epsg.Citm2000, Citm2000Json);
 Projections.set(Epsg.Google.code, { converter: Proj(Epsg.Google.toEpsgString(), Epsg.Wgs84.toEpsgString()) });
+Projections.set(Epsg.Wgs84.code, { converter: Proj(Epsg.Wgs84.toEpsgString(), Epsg.Wgs84.toEpsgString()) });


### PR DESCRIPTION
### Motivation

Attempting to process imagery with a projection code of `4326` guarantees a runtime error.

In a recent [piece of work], we modernised our processes for parsing EPSG codes and projections. With that work, we neglected to re-ensure support for the WGS84 geographic coordinate system (`EPSG:4326`). This work re-introduces that support via our new strategy.

[piece of work]: https://github.com/linz/basemaps/pull/3480

[Slack thread](https://linz.slack.com/archives/C5TCTQUJG/p1757376768654719)

### Modifications

- **packages/geo**

  - `projection.ts`

    - Added a key-value pair for WGS84 (`EPSG:4326`) to the `Projections` map.

### Verification

- **packages/geo**

  - `proj.json.test.ts`

    - Added a new test to ensure that all supported EPSG codes have an `Epsg` and `Projection` instance.
    - Updated the existing tests to use each respective class's `get` function, rather than the `tryGet` function, to allow asserting based on whether the `get` function throws an error.
