### PR TITLE
fix(cli-raster): correct geotag to epsg code mappings BM-1372

### DIFF
--- a/packages/cli-raster/src/cogify/topo/extract.ts
+++ b/packages/cli-raster/src/cogify/topo/extract.ts
@@ -1,4 +1,13 @@
-import { Bounds, Epsg, ProjectionLoader, Size, TileMatrixSet, TileMatrixSets, TmsLoader } from '@basemaps/geo';
+import {
+  Bounds,
+  Epsg,
+  EpsgCode,
+  ProjectionLoader,
+  Size,
+  TileMatrixSet,
+  TileMatrixSets,
+  TmsLoader,
+} from '@basemaps/geo';
 import { LogType } from '@basemaps/shared';
 import { RasterTypeKey, Tiff, TiffTagGeo } from '@cogeotiff/core';
 import path from 'path';
@@ -52,14 +61,14 @@ export function extractBoundsFromTiff(tiff: Tiff, logger?: LogType): Bounds | nu
  */
 const GeotagToEpsgCode: Record<string, number> = {
   // global
-  'Universal Transverse Mercator Zone': 4326,
+  'Universal Transverse Mercator Zone': EpsgCode.Wgs84,
 
   // antarctic
   'McMurdo Sound Lambert Conformal 2000': 5479,
 
   // new zealand
-  'Chatham Islands Transverse Mercator 2000': 2193,
-  'New Zealand Transverse Mercator 2000': 3793,
+  'New Zealand Transverse Mercator 2000': EpsgCode.Nztm2000,
+  'Chatham Islands Transverse Mercator 2000': EpsgCode.Citm2000,
 
   // new zealand offshore islands
   'Auckland Islands Transverse Mercator': 3788,


### PR DESCRIPTION
### Motivation

In a [recent piece of work], we added the remaining _GeoTag to EPSG_ mappings necessary to process all of the Topo Raster map series collections (ANT, NZOI, PI). In the work, we mistakenly matched the following GeoTags to the wrong EPSG:

| GeoTag | EPSG |
| - | - |
| Chatham Islands Transverse Mercator 2000 | 2193 |
| New Zealand Transverse Mercator 2000 | 3793 |

[recent piece of work]: https://github.com/linz/basemaps/pull/3480

This PR corrects the mistake:

| GeoTag | EPSG |
| - | - |
| New Zealand Transverse Mercator 2000 | 2193 |
| Chatham Islands Transverse Mercator 2000 | 3793 |

### Modifications

- **packages/cli-raster**

  - `cogify/topo/extract.ts`

    - Adjusted the _GeoTag to EPSG_ mappings.

### Verification

I've run the following `topo` CLI commands to ensure the generated directories and STAC Items contain the expected map sheets:

- **New Zealand (NZ)**

  - **NZTopo250_GeoTif_Gridless**

    ```
    node packages/cli-raster/build/bin.js topo s3://linz-topographic-upload/topographic/TopoReleaseArchive/NZTopo250_GeoTif_Gridless/ --target ./tmp/target/nz-topo250/ --map-series topo250 --output ./tmp/output/nz-topo250/
    ```

  - **NZTopo50_GeoTif_Gridless**

    ```
    node packages/cli-raster/build/bin.js topo s3://linz-topographic-upload/topographic/TopoReleaseArchive/NZTopo50_GeoTif_Gridless/ --target ./tmp/target/nz-topo50/ --map-series topo50 --output ./tmp/output/nz-topo50/