### PR TITLE
build: add script for smoke test with correct glob

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -156,7 +156,7 @@ jobs:
       - name: (Dev) After Deploy Smoke Test
         run: |
           cd packages/smoke
-          node --test
+          npm run smoke
 
   deploy-prod:
     runs-on: ubuntu-latest

--- a/packages/smoke/README.md
+++ b/packages/smoke/README.md
@@ -5,7 +5,7 @@ Utility to smoke test deployments
 to run
 
 ```bash
-BASEMAPS_HOST=https://dev.basemaps.linz.govt.nz node --test
+BASEMAPS_HOST=https://dev.basemaps.linz.govt.nz npm run smoke
 ```
 
 _Requires Node >= 18_

--- a/packages/smoke/package.json
+++ b/packages/smoke/package.json
@@ -16,7 +16,9 @@
     "node": ">=18.0.0"
   },
   "license": "MIT",
-  "scripts": {},
+  "scripts": {
+    "smoke": "node --test \"build/*.test.js\""
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
### Motivation

smoke tester was broken after node24 upgrade

### Modifications

ensure the test glob is passed to "node --test"

### Verification

Tested locally.
