### PR TITLE
fix(cli-raster): Fix drop the dummy 4th band when gdalwrap charts.

### DIFF
--- a/packages/cli-raster/src/cogify/gdal/gdal.command.ts
+++ b/packages/cli-raster/src/cogify/gdal/gdal.command.ts
@@ -236,7 +236,8 @@ export function gdalBuildChartsCommand(target: URL, source: URL, cutline: URL, t
       '-multi',
       ['-wo', 'NUM_THREADS=ALL_CPUS'],
       ['-t_srs', tileMatrix.projection.toEpsgString()],
-      '-dstalpha',
+      ['-b', '1', '-b', '2', '-b', '3'], // Drop dummy band 4 if it exists
+      ['-dstalpha'],
       ['-cutline', urlToString(cutline)],
       ['-crop_to_cutline'],
       ['-co', 'BIGTIFF=NO'],


### PR DESCRIPTION
### Motivation
When we gdalwrap charts maps and created a dummy undefined 4th band. 
```
Band 1 Block=512x512 Type=Byte, ColorInterp=Red
  Overviews: 23110x14908, 11555x7454, 5777x3727, 2888x1863, 1444x931, 722x465, 361x232
Band 2 Block=512x512 Type=Byte, ColorInterp=Green
  Overviews: 23110x14908, 11555x7454, 5777x3727, 2888x1863, 1444x931, 722x465, 361x232
Band 3 Block=512x512 Type=Byte, ColorInterp=Blue
  Overviews: 23110x14908, 11555x7454, 5777x3727, 2888x1863, 1444x931, 722x465, 361x232
Band 4 Block=512x512 Type=Byte, ColorInterp=Undefined
  Overviews: 23110x14908, 11555x7454, 5777x3727, 2888x1863, 1444x931, 722x465, 361x232
Band 5 Block=512x512 Type=Byte, ColorInterp=Alpha
  Overviews: 23110x14908, 11555x7454, 5777x3727, 2888x1863, 1444x931, 722x465, 361x232
```

### Modifications
We could drop it just keep the first 3 bands and add alpha to it.

### Verification
After dropping:
```
Band 1 Block=512x512 Type=Byte, ColorInterp=Red
  Description = Band_1
  Overviews: 23110x14908, 11555x7454, 5777x3727, 2888x1863, 1444x931, 722x465, 361x232
  Mask Flags: PER_DATASET ALPHA 
  Overviews of mask band: 23110x14908, 11555x7454, 5777x3727, 2888x1863, 1444x931, 722x465, 361x232
  Metadata:
    BandName=Band_1
    RepresentationType=ATHEMATIC
Band 2 Block=512x512 Type=Byte, ColorInterp=Green
  Description = Band_2
  Overviews: 23110x14908, 11555x7454, 5777x3727, 2888x1863, 1444x931, 722x465, 361x232
  Mask Flags: PER_DATASET ALPHA 
  Overviews of mask band: 23110x14908, 11555x7454, 5777x3727, 2888x1863, 1444x931, 722x465, 361x232
  Metadata:
    BandName=Band_2
    RepresentationType=ATHEMATIC
Band 3 Block=512x512 Type=Byte, ColorInterp=Blue
  Description = Band_3
  Overviews: 23110x14908, 11555x7454, 5777x3727, 2888x1863, 1444x931, 722x465, 361x232
  Mask Flags: PER_DATASET ALPHA 
  Overviews of mask band: 23110x14908, 11555x7454, 5777x3727, 2888x1863, 1444x931, 722x465, 361x232
  Metadata:
    BandName=Band_3
    RepresentationType=ATHEMATIC
Band 4 Block=512x512 Type=Byte, ColorInterp=Alpha
  Description = Band_4
  Overviews: 23110x14908, 11555x7454, 5777x3727, 2888x1863, 1444x931, 722x465, 361x232
  Metadata:
    BandName=Band_4
    RepresentationType=ATHEMATIC
```

<img width="1497" height="814" alt="image" src="https://github.com/user-attachments/assets/51d19c68-a602-4255-ba0c-1bc9cdc71d30" />

Argo workflow testing import:https://argo.linzaccess.com/workflows/argo/test-basemaps-charts-import-cogify-fix-colour-sw5n7?tab=workflow&uid=25728627-e35b-4a52-b00c-4423b35bd437
