### PR TITLE
feat(landing): new topo dropdowns BM-1376 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19457,15 +19457,6 @@
         "@basemaps/landing": "^8.10.1"
       }
     },
-    "packages/server/node_modules/@basemaps/landing": {
-      "version": "6.46.0",
-      "resolved": "https://registry.npmjs.org/@basemaps/landing/-/landing-6.46.0.tgz",
-      "integrity": "sha512-HwSi08EahMJyyMCTqgbgRU0b5i1r+8nRvr2lWSAnYygpL424vOzgAvqNCIMO72xABc9iXazLUVQUSY+BeKDXfQ==",
-      "dev": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
     "packages/shared": {
       "name": "@basemaps/shared",
       "version": "8.9.2",

--- a/packages/landing/src/components/map.label.tsx
+++ b/packages/landing/src/components/map.label.tsx
@@ -10,6 +10,7 @@ export const LabelsDisabledLayers = new Set([
   'topolite',
   'topolite-v2',
   'topo-raster',
+  'topo-raster-gridless',
 ]);
 
 export class MapLabelControl implements IControl {

--- a/packages/landing/src/config.map.ts
+++ b/packages/landing/src/config.map.ts
@@ -393,13 +393,13 @@ function addDefaultLayers(output: Map<string, LayerInfo>): void {
     },
     {
       id: 'topo-raster::topo-raster',
-      title: 'NZ Topo Maps',
+      title: 'Topo Maps',
       projections: new Set([EpsgCode.Nztm2000, EpsgCode.Google]),
       category: 'Basemaps',
     },
     {
       id: 'topo-raster::topo-raster-gridless',
-      title: 'NZ Topo Gridless Maps',
+      title: 'Topo Gridless Maps',
       projections: new Set([EpsgCode.Nztm2000, EpsgCode.Google]),
       category: 'Basemaps',
     },

--- a/packages/landing/src/config.map.ts
+++ b/packages/landing/src/config.map.ts
@@ -393,6 +393,12 @@ function addDefaultLayers(output: Map<string, LayerInfo>): void {
     },
     {
       id: 'topo-raster::topo-raster',
+      title: 'NZ Topo Maps',
+      projections: new Set([EpsgCode.Nztm2000, EpsgCode.Google]),
+      category: 'Basemaps',
+    },
+    {
+      id: 'topo-raster::topo-raster-gridless',
       title: 'NZ Topo Gridless Maps',
       projections: new Set([EpsgCode.Nztm2000, EpsgCode.Google]),
       category: 'Basemaps',


### PR DESCRIPTION
### Motivation

update drop down for gridded and gridless topo

### Modifications

<img width="428" height="627" alt="Screenshot From 2025-10-02 12-34-33" src="https://github.com/user-attachments/assets/f77b9d7e-26f3-4653-8a8a-5180dec453d7" />


<img width="428" height="511" alt="Screenshot From 2025-10-02 10-03-39" src="https://github.com/user-attachments/assets/054768fd-7cc5-4870-960f-e61d239d3aee" />



### Verification

visual