### PR TITLE
fix(landing): keep gridless default

### DIFF
--- a/packages/landing/src/components/map.label.tsx
+++ b/packages/landing/src/components/map.label.tsx
@@ -9,8 +9,8 @@ export const LabelsDisabledLayers = new Set([
   'topographic-v2',
   'topolite',
   'topolite-v2',
+  'topo-raster-gridded',
   'topo-raster',
-  'topo-raster-gridless',
 ]);
 
 export class MapLabelControl implements IControl {

--- a/packages/landing/src/config.map.ts
+++ b/packages/landing/src/config.map.ts
@@ -392,13 +392,13 @@ function addDefaultLayers(output: Map<string, LayerInfo>): void {
       category: 'Basemaps',
     },
     {
-      id: 'topo-raster::topo-raster',
+      id: 'topo-raster::topo-raster-gridded',
       title: 'Topo Maps',
       projections: new Set([EpsgCode.Nztm2000, EpsgCode.Google]),
       category: 'Basemaps',
     },
     {
-      id: 'topo-raster::topo-raster-gridless',
+      id: 'topo-raster::topo-raster',
       title: 'Topo Gridless Maps',
       projections: new Set([EpsgCode.Nztm2000, EpsgCode.Google]),
       category: 'Basemaps',


### PR DESCRIPTION
This PR assists [this PR].

[this PR]: https://github.com/linz/basemaps-config/pull/1327

---

### Motivation

In a recent [piece of work], we switched our `topo-raster` tileset to serve the 600 DPI `gridded` map sheets. This changed the imagery for our customers who were consuming our original `topo-raster` endpoint. We've decided we want to switch the original endpoint back to serving the `gridless` map sheets.

[piece of work]: https://github.com/linz/basemaps-config/pull/1319

### Modifications

<!-- TODO: Say what changes you made. -->

<!-- TODO: Attach screenshots if you changed the UI. -->

### Verification

<!-- TODO: Say how you tested your changes. -->
