### PR TITLE
fix: Check if small layers get updates

### DIFF
--- a/packages/cli-vector/src/cli/cli.extract.ts
+++ b/packages/cli-vector/src/cli/cli.extract.ts
@@ -151,6 +151,9 @@ export const ExtractCommand = command({
     await fsa.write(fsa.toUrl('/tmp/extract/hasSmallLayers'), String(smallLayers.length > 0));
     await fsa.write(fsa.toUrl('/tmp/extract/hasLargeLayers'), String(largeLayers.length > 0));
     await fsa.write(fsa.toUrl('/tmp/extract/updateRequired'), String(total > 0));
-    logger.info({ update: total > 0, hasSmall: smallLayers.length > 0, hasLarge: largeLayers.length > 0 }, 'Extract: UpdateFlags');
+    logger.info(
+      { update: total > 0, hasSmall: smallLayers.length > 0, hasLarge: largeLayers.length > 0 },
+      'Extract: UpdateFlags',
+    );
   },
 });

--- a/packages/cli-vector/src/cli/cli.extract.ts
+++ b/packages/cli-vector/src/cli/cli.extract.ts
@@ -150,5 +150,6 @@ export const ExtractCommand = command({
     await fsa.write(fsa.toUrl('/tmp/extract/largeLayers.json'), JSON.stringify(largeLayers, null, 2));
     await fsa.write(fsa.toUrl('/tmp/extract/hasSmallLayers'), String(smallLayers.length > 0));
     await fsa.write(fsa.toUrl('/tmp/extract/hasLargeLayers'), String(largeLayers.length > 0));
+    await fsa.write(fsa.toUrl('/tmp/extract/updateRequired'), String(total > 0));
   },
 });

--- a/packages/cli-vector/src/cli/cli.extract.ts
+++ b/packages/cli-vector/src/cli/cli.extract.ts
@@ -151,5 +151,6 @@ export const ExtractCommand = command({
     await fsa.write(fsa.toUrl('/tmp/extract/hasSmallLayers'), String(smallLayers.length > 0));
     await fsa.write(fsa.toUrl('/tmp/extract/hasLargeLayers'), String(largeLayers.length > 0));
     await fsa.write(fsa.toUrl('/tmp/extract/updateRequired'), String(total > 0));
+    logger.info({ update: total > 0, hasSmall: smallLayers.length > 0, hasLarge: largeLayers.length > 0 }, 'Extract: UpdateFlags');
   },
 });

--- a/packages/cli-vector/src/cli/cli.extract.ts
+++ b/packages/cli-vector/src/cli/cli.extract.ts
@@ -148,6 +148,7 @@ export const ExtractCommand = command({
     await fsa.write(fsa.toUrl('/tmp/extract/allCaches.json'), JSON.stringify(allFiles, null, 2));
     await fsa.write(fsa.toUrl('/tmp/extract/smallLayers.json'), JSON.stringify(smallLayers, null, 2));
     await fsa.write(fsa.toUrl('/tmp/extract/largeLayers.json'), JSON.stringify(largeLayers, null, 2));
+    await fsa.write(fsa.toUrl('/tmp/extract/hasSmallLayers'), String(smallLayers.length > 0));
     await fsa.write(fsa.toUrl('/tmp/extract/updateRequired'), String(total > 0));
   },
 });

--- a/packages/cli-vector/src/cli/cli.extract.ts
+++ b/packages/cli-vector/src/cli/cli.extract.ts
@@ -149,6 +149,6 @@ export const ExtractCommand = command({
     await fsa.write(fsa.toUrl('/tmp/extract/smallLayers.json'), JSON.stringify(smallLayers, null, 2));
     await fsa.write(fsa.toUrl('/tmp/extract/largeLayers.json'), JSON.stringify(largeLayers, null, 2));
     await fsa.write(fsa.toUrl('/tmp/extract/hasSmallLayers'), String(smallLayers.length > 0));
-    await fsa.write(fsa.toUrl('/tmp/extract/updateRequired'), String(total > 0));
+    await fsa.write(fsa.toUrl('/tmp/extract/hasLargeLayers'), String(largeLayers.length > 0));
   },
 });


### PR DESCRIPTION
### Motivation

ETL workflow could failure if the smallerLayers.json is empty.
https://argo.linzaccess.com/workflows/argo/cron-vector-etl-topographic-shortbread-1773766800?tab=workflow&uid=ef11f3fc-83bd-4d06-ba63-c4e4b4c210a1

### Modifications

Add hasSmallLayers and hasLargeLayers outputs from extract command to skip it when empty.

### Verification

Test run https://argo.linzaccess.com/workflows/argo/test-wentao-pr-3610-basemaps-vector-etl-shortbread-sq6j6
