### PR TITLE
fix(geo): handle concurrent projection loads

### DIFF
--- a/packages/geo/src/proj/__tests__/projection.loader.test.ts
+++ b/packages/geo/src/proj/__tests__/projection.loader.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert';
+import { describe, it, TestContext } from 'node:test';
+
+import { PROJJSONDefinition } from 'proj4/dist/lib/core.js';
+
+import { Aitm2000Json } from '../json/nzoi/aitm2000.js';
+import { ProjectionLoader } from '../projection.loader.js';
+
+/** Arbitrary EPSG code not in ProjJsons and not pre-registered */
+const TestCode: number = 99999;
+
+describe('ProjectionLoader', () => {
+  it('should handle concurrent loads for the same code without throwing', async (t: TestContext) => {
+    t.mock.method(
+      ProjectionLoader,
+      'fetchProjJson',
+      (): Promise<PROJJSONDefinition> =>
+        Promise.resolve({ ...Aitm2000Json, id: { authority: 'EPSG', code: TestCode } }),
+    );
+
+    const [epsgA, epsgB] = await Promise.all([ProjectionLoader.load(TestCode), ProjectionLoader.load(TestCode)]);
+
+    assert.equal(epsgA.code, TestCode);
+    assert.equal(epsgB.code, TestCode);
+    assert.equal(epsgA, epsgB);
+  });
+});

--- a/packages/geo/src/proj/projection.loader.ts
+++ b/packages/geo/src/proj/projection.loader.ts
@@ -11,6 +11,8 @@ export class ProjectionLoader {
   // Exposed for testing
   static _fetch = fetch;
 
+  private static _inflight = new Map<number, Promise<Epsg>>();
+
   /**
    * Initialises an Epsg instance for the given code and ensures that
    * a corresponding Projection instance is available.
@@ -18,9 +20,18 @@ export class ProjectionLoader {
    * @param code - The code for which to initialise an Epsg and Projection instance.
    * @returns an Epsg instance
    */
-  static async load(code: number): Promise<Epsg> {
-    if (Projection.tryGet(code) != null) return Epsg.get(code);
+  static load(code: number): Promise<Epsg> {
+    if (Projection.tryGet(code) != null) return Promise.resolve(Epsg.get(code));
 
+    let promise = this._inflight.get(code);
+    if (promise == null) {
+      promise = this._load(code).finally(() => this._inflight.delete(code));
+      this._inflight.set(code, promise);
+    }
+    return promise;
+  }
+
+  private static async _load(code: number): Promise<Epsg> {
     let projJson: PROJJSONDefinition;
 
     if (UtmZone.isUTMZoneCode(code)) {


### PR DESCRIPTION
### Motivation

concurrent calls to ProjectionLoader.load error with `Duplicate projection definition`

### Modifications

fix to check if another call completed before us

### Verification

local testing and unit test
