### PR TITLE
fix: vector tile links need i=topographic to show style.json

### DIFF
--- a/docs/user-guide/working-with-vector-tiles/README.md
+++ b/docs/user-guide/working-with-vector-tiles/README.md
@@ -31,9 +31,9 @@ We have two sets of vector tiles, each defined by a different tile matrix: one i
 | :--------------------: | :----------------------: | :-------------------------: |
 | ![](static/labels.png) | ![](static/topolite.png) | ![](static/topographic.png) |
 
-[Labels]: https://basemaps.linz.govt.nz/?style=labels-v2&i=topographic
-[Topolite]: https://basemaps.linz.govt.nz/?style=topolite-v2&i=topographic
-[Topographic]: https://basemaps.linz.govt.nz/?style=topographic-v2&i=topographic
+[Labels]: https://basemaps.linz.govt.nz/?style=labels-v2&i=topographic-v2
+[Topolite]: https://basemaps.linz.govt.nz/?style=topolite-v2&i=topographic-v2
+[Topographic]: https://basemaps.linz.govt.nz/?style=topographic-v2&i=topographic-v2
 
 We have three guides for working with vector tiles:
 

--- a/docs/user-guide/working-with-vector-tiles/README.md
+++ b/docs/user-guide/working-with-vector-tiles/README.md
@@ -31,9 +31,9 @@ We have two sets of vector tiles, each defined by a different tile matrix: one i
 | :--------------------: | :----------------------: | :-------------------------: |
 | ![](static/labels.png) | ![](static/topolite.png) | ![](static/topographic.png) |
 
-[Labels]: https://basemaps.linz.govt.nz/?style=labels-v2
-[Topolite]: https://basemaps.linz.govt.nz/?style=topolite-v2
-[Topographic]: https://basemaps.linz.govt.nz/?style=topographic-v2
+[Labels]: https://basemaps.linz.govt.nz/?style=labels-v2&i=topographic
+[Topolite]: https://basemaps.linz.govt.nz/?style=topolite-v2&i=topographic
+[Topographic]: https://basemaps.linz.govt.nz/?style=topographic-v2&i=topographic
 
 We have three guides for working with vector tiles:
 


### PR DESCRIPTION
### Motivation

The docs pages reference https://basemaps.linz.govt.nz/?style=labels-v2 if you goto this URL the landing page currently doesnt detect that this is a vector tile URL and gives a incorrect webp XYZ link

The current logic needs `i=topographic*` to be detected as vector tiles.

TODO: this logic needs to be fixed in future


### Modifications

Update doc links to use `i=topographic-v2`

### Verification

<!-- TODO: Say how you tested your changes. -->
