### PR TITLE
feat: swap to standard viewport settings BM-1712

### DIFF
--- a/packages/landing/static/index.html
+++ b/packages/landing/static/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <head>
-    <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
 


### PR DESCRIPTION
### Motivation

Accessibility checks have been failing basemaps.linz.govt.nz due to nonstandard viewport settings


### Modifications

Swap to the modern standard viewport settings from maplibre examples

### Verification

Looks the same on chrome 