### PR TITLE
feat: improve smoke tests

### DIFF
--- a/packages/smoke/src/base.ts
+++ b/packages/smoke/src/base.ts
@@ -54,3 +54,19 @@ export function assertCacheMiss(res: Response): void {
   if (cacheHeader == null) return; // No header is a miss
   assert.equal(cacheHeader.startsWith('Miss'), true, `Should be a cache Miss ${res.headers.get('x-cache')}`);
 }
+
+/** Validate that the response was served from cache */
+export function assertCacheHit(res: Response): void {
+  const cacheHeader = res.headers.get('x-cache');
+  if (cacheHeader == null) return; // No header when testing without CloudFront
+  assert.equal(
+    cacheHeader.startsWith('Hit') || cacheHeader.startsWith('RefreshHit'),
+    true,
+    `Should be a cache Hit ${cacheHeader}`,
+  );
+}
+
+/** Validate that response has valid CORS headers */
+export function assertCors(res: Response): void {
+  assert.equal(res.headers.get('access-control-allow-origin'), '*', 'access-control-allow-origin header should be *');
+}

--- a/packages/smoke/src/cache.test.ts
+++ b/packages/smoke/src/cache.test.ts
@@ -44,14 +44,21 @@ describe('cache policies', () => {
       assertCacheMiss(res2);
     });
 
+    interface TestStyle {
+      glyphs?: string;
+      sprite?: string;
+      layers?: Array<{ id: string }>;
+      sources?: Record<string, { url?: string; tiles?: string[] }>;
+    }
+
     const configUrl = 's3://linz-basemaps/config/config-latest.json.gz';
     const v1Params = [
       {
         param: 'config',
         styleUrl: '/v1/styles/topographic.json',
         query: `config=${encodeURIComponent(configUrl)}`,
-        makeRes2Query: (id: string) => `config=${encodeURIComponent(`${configUrl}?v=${id}`)}`,
-        validate: (style: any) => {
+        makeRes2Query: (id: string): string => `config=${encodeURIComponent(`${configUrl}?v=${id}`)}`,
+        validate: (style: TestStyle): void => {
           assert.ok(style.glyphs?.includes('config='), 'glyphs should include config');
           assert.ok(style.sprite?.includes('config='), 'sprite should include config');
           assert.ok(style.sources?.['LINZ Basemaps']?.url?.includes('config='), 'source url should include config');
@@ -61,9 +68,9 @@ describe('cache policies', () => {
         param: 'exclude',
         styleUrl: '/v1/styles/topographic.json',
         query: 'exclude=background',
-        makeRes2Query: (id: string) => `exclude=${id}`,
-        validate: (style: any) => {
-          const hasBackgroundLayer = style.layers?.some((layer: any) => layer.id === 'background');
+        makeRes2Query: (id: string): string => `exclude=${id}`,
+        validate: (style: TestStyle): void => {
+          const hasBackgroundLayer = style.layers?.some((layer: { id: string }) => layer.id === 'background');
           assert.equal(hasBackgroundLayer, false, 'background layer should be excluded');
         },
       },
@@ -71,8 +78,8 @@ describe('cache policies', () => {
         param: 'pipeline',
         styleUrl: '/v1/styles/elevation.json',
         query: 'pipeline=color-ramp',
-        makeRes2Query: (_id: string) => 'pipeline=terrain-rgb',
-        validate: (style: any) => {
+        makeRes2Query: (): string => 'pipeline=terrain-rgb',
+        validate: (style: TestStyle): void => {
           const tiles = style.sources?.['basemaps-elevation-color-ramp']?.tiles;
           assert.ok(
             tiles && tiles.some((t: string) => t.includes('pipeline=color-ramp')),
@@ -89,7 +96,7 @@ describe('cache policies', () => {
         const res1 = await ctx.req(`${styleUrl}?api=${ctx.apiKey}&${query}`);
         assert.equal(res1.status, 200);
 
-        const style1 = await res1.json();
+        const style1 = (await res1.json()) as TestStyle;
         validate(style1);
 
         const res2 = await ctx.req(`${styleUrl}?api=${ctx.apiKey}&${makeRes2Query(testId)}`);
@@ -102,10 +109,7 @@ describe('cache policies', () => {
       const res = await ctx.req(`/v1/styles/elevation.json?api=${ctx.apiKey}&pipeline=color-ramp&format=webp`);
       assert.equal(res.status, 200);
 
-      const style = (await res.json()) as {
-        layers?: Array<{ id: string }>;
-        sources?: Record<string, any>;
-      };
+      const style = (await res.json()) as TestStyle;
 
       const tiles = style.sources?.['basemaps-elevation-color-ramp']?.tiles;
       assert.ok(

--- a/packages/smoke/src/cache.test.ts
+++ b/packages/smoke/src/cache.test.ts
@@ -51,59 +51,56 @@ describe('cache policies', () => {
       sources?: Record<string, { url?: string; tiles?: string[] }>;
     }
 
-    const configUrl = 's3://linz-basemaps/config/config-latest.json.gz';
-    const v1Params = [
-      {
-        param: 'config',
-        styleUrl: '/v1/styles/topographic.json',
-        query: `config=${encodeURIComponent(configUrl)}`,
-        makeRes2Query: (id: string): string => `config=${encodeURIComponent(`${configUrl}?v=${id}`)}`,
-        validate: (style: TestStyle): void => {
-          assert.ok(style.glyphs?.includes('config='), 'glyphs should include config');
-          assert.ok(style.sprite?.includes('config='), 'sprite should include config');
-          assert.ok(style.sources?.['LINZ Basemaps']?.url?.includes('config='), 'source url should include config');
-        },
-      },
-      {
-        param: 'exclude',
-        styleUrl: '/v1/styles/topographic.json',
-        query: 'exclude=background',
-        makeRes2Query: (id: string): string => `exclude=${id}`,
-        validate: (style: TestStyle): void => {
-          const hasBackgroundLayer = style.layers?.some((layer: { id: string }) => layer.id === 'background');
-          assert.equal(hasBackgroundLayer, false, 'background layer should be excluded');
-        },
-      },
-      {
-        param: 'pipeline',
-        styleUrl: '/v1/styles/elevation.json',
-        query: 'pipeline=color-ramp',
-        makeRes2Query: (): string => 'pipeline=terrain-rgb',
-        validate: (style: TestStyle): void => {
-          const tiles = style.sources?.['basemaps-elevation-color-ramp']?.tiles;
-          assert.ok(
-            tiles && tiles.some((t: string) => t.includes('pipeline=color-ramp')),
-            'tiles should include pipeline=color-ramp',
-          );
-        },
-      },
-    ];
+    it('should validate config parameter on /v1/styles/topographic.json', async () => {
+      const configUrl = 's3://linz-basemaps/config/config-latest.json.gz';
+      const testId = ulid.ulid().toLowerCase();
 
-    for (const { param, styleUrl, query, makeRes2Query, validate } of v1Params) {
-      it(`should validate ${param} parameter on ${styleUrl}`, async () => {
-        const testId = ulid.ulid().toLowerCase();
+      const res1 = await ctx.req(`/v1/styles/topographic.json?api=${ctx.apiKey}&config=${encodeURIComponent(configUrl)}`);
+      assert.equal(res1.status, 200);
 
-        const res1 = await ctx.req(`${styleUrl}?api=${ctx.apiKey}&${query}`);
-        assert.equal(res1.status, 200);
+      const style1 = (await res1.json()) as TestStyle;
+      assert.ok(style1.glyphs?.includes('config='), 'glyphs should include config');
+      assert.ok(style1.sprite?.includes('config='), 'sprite should include config');
+      assert.ok(style1.sources?.['LINZ Basemaps']?.url?.includes('config='), 'source url should include config');
 
-        const style1 = (await res1.json()) as TestStyle;
-        validate(style1);
+      const configUrl2 = `${configUrl}?v=${testId}`;
+      const res2 = await ctx.req(
+        `/v1/styles/topographic.json?api=${ctx.apiKey}&config=${encodeURIComponent(configUrl2)}`,
+      );
+      assert.equal(res2.status, 200);
+      assertCacheMiss(res2);
+    });
 
-        const res2 = await ctx.req(`${styleUrl}?api=${ctx.apiKey}&${makeRes2Query(testId)}`);
-        assert.equal(res2.status, 200);
-        assertCacheMiss(res2);
-      });
-    }
+    it('should validate exclude parameter on /v1/styles/topographic.json', async () => {
+      const testId = ulid.ulid().toLowerCase();
+
+      const res1 = await ctx.req(`/v1/styles/topographic.json?api=${ctx.apiKey}&exclude=background`);
+      assert.equal(res1.status, 200);
+
+      const style1 = (await res1.json()) as TestStyle;
+      const hasBackgroundLayer = style1.layers?.some((layer: { id: string }) => layer.id === 'background');
+      assert.equal(hasBackgroundLayer, false, 'background layer should be excluded');
+
+      const res2 = await ctx.req(`/v1/styles/topographic.json?api=${ctx.apiKey}&exclude=${testId}`);
+      assert.equal(res2.status, 200);
+      assertCacheMiss(res2);
+    });
+
+    it('should validate pipeline parameter on /v1/styles/elevation.json', async () => {
+      const res1 = await ctx.req(`/v1/styles/elevation.json?api=${ctx.apiKey}&pipeline=color-ramp`);
+      assert.equal(res1.status, 200);
+
+      const style1 = (await res1.json()) as TestStyle;
+      const tiles = style1.sources?.['basemaps-elevation-color-ramp']?.tiles;
+      assert.ok(
+        tiles && tiles.some((t: string) => t.includes('pipeline=color-ramp')),
+        'tiles should include pipeline=color-ramp',
+      );
+
+      const res2 = await ctx.req(`/v1/styles/elevation.json?api=${ctx.apiKey}&pipeline=terrain-rgb`);
+      assert.equal(res2.status, 200);
+      assertCacheMiss(res2);
+    });
 
     it('should validate format parameter and default no labels on /v1/styles/elevation.json', async () => {
       const res = await ctx.req(`/v1/styles/elevation.json?api=${ctx.apiKey}&pipeline=color-ramp&format=webp`);

--- a/packages/smoke/src/cache.test.ts
+++ b/packages/smoke/src/cache.test.ts
@@ -1,0 +1,173 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import ulid from 'ulid';
+
+import { assertCacheHit, assertCacheMiss, ctx } from './base.js';
+
+describe('cache policies', () => {
+  describe('/v1* caching (v1CachePolicy)', () => {
+    it('should hit cache on repeated request', async () => {
+      const path = `/v1/fonts.json?api=${ctx.apiKey}`;
+      const res1 = await ctx.req(path);
+      assert.equal(res1.status, 200);
+
+      const res2 = await ctx.req(path);
+      assert.equal(res2.status, 200);
+      assertCacheHit(res2);
+    });
+
+    it('should ignore query params not in v1CachePolicy allowList', async () => {
+      const testId = ulid.ulid().toLowerCase();
+      // v1CachePolicy allowList is ['config', 'exclude', 'pipeline']
+      // Unallowed query param (e.g. 'testKey') should be ignored in cache key
+      const res1 = await ctx.req(`/v1/fonts.json?api=${ctx.apiKey}&testKey=${testId}_1`);
+      assert.equal(res1.status, 200);
+
+      const res2 = await ctx.req(`/v1/fonts.json?api=${ctx.apiKey}&testKey=${testId}_2`);
+      assert.equal(res2.status, 200);
+      assertCacheHit(res2);
+    });
+
+    it('should include query params in v1CachePolicy allowList in cache key', async () => {
+      const testId1 = ulid.ulid().toLowerCase();
+      const testId2 = ulid.ulid().toLowerCase();
+      // 'config' is in v1CachePolicy allowList so varying config produces different cache keys
+      const configUrl1 = `s3://linz-basemaps/config/config-latest.json.gz?v=${testId1}`;
+      const configUrl2 = `s3://linz-basemaps/config/config-latest.json.gz?v=${testId2}`;
+
+      const res1 = await ctx.req(`/v1/fonts.json?api=${ctx.apiKey}&config=${encodeURIComponent(configUrl1)}`);
+      assert.equal(res1.status, 200);
+
+      const res2 = await ctx.req(`/v1/fonts.json?api=${ctx.apiKey}&config=${encodeURIComponent(configUrl2)}`);
+      assert.equal(res2.status, 200);
+      assertCacheMiss(res2);
+    });
+
+    const configUrl = 's3://linz-basemaps/config/config-latest.json.gz';
+    const v1Params = [
+      {
+        param: 'config',
+        styleUrl: '/v1/styles/topographic.json',
+        query: `config=${encodeURIComponent(configUrl)}`,
+        makeRes2Query: (id: string) => `config=${encodeURIComponent(`${configUrl}?v=${id}`)}`,
+        validate: (style: any) => {
+          assert.ok(style.glyphs?.includes('config='), 'glyphs should include config');
+          assert.ok(style.sprite?.includes('config='), 'sprite should include config');
+          assert.ok(style.sources?.['LINZ Basemaps']?.url?.includes('config='), 'source url should include config');
+        },
+      },
+      {
+        param: 'exclude',
+        styleUrl: '/v1/styles/topographic.json',
+        query: 'exclude=background',
+        makeRes2Query: (id: string) => `exclude=${id}`,
+        validate: (style: any) => {
+          const hasBackgroundLayer = style.layers?.some((layer: any) => layer.id === 'background');
+          assert.equal(hasBackgroundLayer, false, 'background layer should be excluded');
+        },
+      },
+      {
+        param: 'pipeline',
+        styleUrl: '/v1/styles/elevation.json',
+        query: 'pipeline=color-ramp',
+        makeRes2Query: (_id: string) => 'pipeline=terrain-rgb',
+        validate: (style: any) => {
+          const tiles = style.sources?.['basemaps-elevation-color-ramp']?.tiles;
+          assert.ok(
+            tiles && tiles.some((t: string) => t.includes('pipeline=color-ramp')),
+            'tiles should include pipeline=color-ramp',
+          );
+        },
+      },
+    ];
+
+    for (const { param, styleUrl, query, makeRes2Query, validate } of v1Params) {
+      it(`should validate ${param} parameter on ${styleUrl}`, async () => {
+        const testId = ulid.ulid().toLowerCase();
+
+        const res1 = await ctx.req(`${styleUrl}?api=${ctx.apiKey}&${query}`);
+        assert.equal(res1.status, 200);
+
+        const style1 = await res1.json();
+        validate(style1);
+
+        const res2 = await ctx.req(`${styleUrl}?api=${ctx.apiKey}&${makeRes2Query(testId)}`);
+        assert.equal(res2.status, 200);
+        assertCacheMiss(res2);
+      });
+    }
+
+    it('should validate format parameter and default no labels on /v1/styles/elevation.json', async () => {
+      const res = await ctx.req(`/v1/styles/elevation.json?api=${ctx.apiKey}&pipeline=color-ramp&format=webp`);
+      assert.equal(res.status, 200);
+
+      const style = (await res.json()) as {
+        layers?: Array<{ id: string }>;
+        sources?: Record<string, any>;
+      };
+
+      const tiles = style.sources?.['basemaps-elevation-color-ramp']?.tiles;
+      assert.ok(
+        tiles && tiles.some((t: string) => t.includes('.webp')),
+        'color-ramp tiles should be formatted as webp',
+      );
+      assert.equal(style.layers?.length, 1, 'default elevation style should have no labels');
+      assert.equal(
+        style.sources?.['LINZ Basemaps'],
+        undefined,
+        'default elevation style should not include LINZ Basemaps vector source',
+      );
+    });
+  });
+
+  describe('/@* caching (atCachePolicy)', () => {
+    it('should hit cache on repeated request', async () => {
+      const path = '/@-43.7302848,171.7870060,z10.37';
+      const res1 = await ctx.req(path);
+      assert.equal(res1.status, 200);
+
+      const res2 = await ctx.req(path);
+      assert.equal(res2.status, 200);
+      assertCacheHit(res2);
+    });
+
+    it('should ignore query params not in atCachePolicy allowList', async () => {
+      const testId = ulid.ulid().toLowerCase();
+      // atCachePolicy allowList is ['config', 'exclude', 'tileMatrix', 'style', 'pipeline', 'terrain']
+      // Unallowed query param (e.g. 'testKey') should be ignored in cache key
+      const res1 = await ctx.req(`/@-43.7302848,171.7870060,z10.37?testKey=${testId}_1`);
+      assert.equal(res1.status, 200);
+
+      const res2 = await ctx.req(`/@-43.7302848,171.7870060,z10.37?testKey=${testId}_2`);
+      assert.equal(res2.status, 200);
+      assertCacheHit(res2);
+    });
+
+    it('should include query params in atCachePolicy allowList in cache key', async () => {
+      const testId1 = ulid.ulid().toLowerCase();
+      const testId2 = ulid.ulid().toLowerCase();
+      // 'config' is in atCachePolicy allowList so varying config produces different cache keys
+      const configUrl1 = `s3://linz-basemaps/config/config-latest.json.gz?v=${testId1}`;
+      const configUrl2 = `s3://linz-basemaps/config/config-latest.json.gz?v=${testId2}`;
+
+      const res1 = await ctx.req(`/@-43.7302848,171.7870060,z10.37?config=${encodeURIComponent(configUrl1)}`);
+      assert.equal(res1.status, 200);
+
+      const res2 = await ctx.req(`/@-43.7302848,171.7870060,z10.37?config=${encodeURIComponent(configUrl2)}`);
+      assert.equal(res2.status, 200);
+      assertCacheMiss(res2);
+    });
+  });
+
+  describe('default root caching', () => {
+    it('should hit cache on repeated request for index.html', async () => {
+      const res1 = await ctx.req('/index.html');
+      assert.equal(res1.status, 200);
+
+      const res2 = await ctx.req('/index.html');
+      assert.equal(res2.status, 200);
+      assertCacheHit(res2);
+    });
+  });
+});

--- a/packages/smoke/src/cache.test.ts
+++ b/packages/smoke/src/cache.test.ts
@@ -55,7 +55,9 @@ describe('cache policies', () => {
       const configUrl = 's3://linz-basemaps/config/config-latest.json.gz';
       const testId = ulid.ulid().toLowerCase();
 
-      const res1 = await ctx.req(`/v1/styles/topographic.json?api=${ctx.apiKey}&config=${encodeURIComponent(configUrl)}`);
+      const res1 = await ctx.req(
+        `/v1/styles/topographic.json?api=${ctx.apiKey}&config=${encodeURIComponent(configUrl)}`,
+      );
       assert.equal(res1.status, 200);
 
       const style1 = (await res1.json()) as TestStyle;

--- a/packages/smoke/src/style.test.ts
+++ b/packages/smoke/src/style.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { assertCors, ctx } from './base.js';
+
+describe('styles', () => {
+  it('GET /v1/styles/topographic.json with CORS', async () => {
+    const res = await ctx.req(`/v1/styles/topographic.json?api=${ctx.apiKey}`, { headers: ctx.Cors });
+    assert.equal(res.status, 200);
+    assertCors(res);
+    const style = await res.json();
+    assert.ok(style);
+  });
+
+  it('OPTIONS /v1/styles/topographic.json with CORS', async () => {
+    const res = await ctx.req(`/v1/styles/topographic.json?api=${ctx.apiKey}`, {
+      method: 'OPTIONS',
+      headers: ctx.Cors,
+    });
+    assert.equal(res.status, 200);
+    assertCors(res);
+  });
+
+  it('GET /v1/styles/elevation.json with CORS', async () => {
+    const res = await ctx.req(`/v1/styles/elevation.json?api=${ctx.apiKey}&pipeline=color-ramp`, {
+      headers: ctx.Cors,
+    });
+    assert.equal(res.status, 200);
+    assertCors(res);
+    const style = await res.json();
+    assert.ok(style);
+  });
+
+  it('OPTIONS /v1/styles/elevation.json with CORS', async () => {
+    const res = await ctx.req(`/v1/styles/elevation.json?api=${ctx.apiKey}`, {
+      method: 'OPTIONS',
+      headers: ctx.Cors,
+    });
+    assert.equal(res.status, 200);
+    assertCors(res);
+  });
+});

--- a/packages/smoke/src/style.test.ts
+++ b/packages/smoke/src/style.test.ts
@@ -8,7 +8,7 @@ describe('styles', () => {
     const res = await ctx.req(`/v1/styles/topographic.json?api=${ctx.apiKey}`, { headers: ctx.Cors });
     assert.equal(res.status, 200);
     assertCors(res);
-    const style = await res.json();
+    const style = (await res.json()) as Record<string, unknown>;
     assert.ok(style);
   });
 
@@ -27,7 +27,7 @@ describe('styles', () => {
     });
     assert.equal(res.status, 200);
     assertCors(res);
-    const style = await res.json();
+    const style = (await res.json()) as Record<string, unknown>;
     assert.ok(style);
   });
 

--- a/packages/smoke/src/tile.test.ts
+++ b/packages/smoke/src/tile.test.ts
@@ -49,14 +49,33 @@ describe('tile', () => {
     assertCors(res);
   });
 
-  for (const ext of ['png', 'jpeg', 'avif', 'jpg']) {
-    it(`should serve a ${ext} tile`, async () => {
-      const res = await ctx.req(`/v1/tiles/aerial/WebMercatorQuad/6/62/40.${ext}?api=${ctx.apiKey}`);
-      assert.equal(res.status, 200);
-      assert.equal(res.headers.get('content-type'), `image/${ext === 'jpg' ? 'jpeg' : ext}`);
-      assertCors(res);
-    });
-  }
+  it('should serve a png tile', async () => {
+    const res = await ctx.req(`/v1/tiles/aerial/WebMercatorQuad/6/62/40.png?api=${ctx.apiKey}`);
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('content-type'), 'image/png');
+    assertCors(res);
+  });
+
+  it('should serve a jpeg tile', async () => {
+    const res = await ctx.req(`/v1/tiles/aerial/WebMercatorQuad/6/62/40.jpeg?api=${ctx.apiKey}`);
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('content-type'), 'image/jpeg');
+    assertCors(res);
+  });
+
+  it('should serve a avif tile', async () => {
+    const res = await ctx.req(`/v1/tiles/aerial/WebMercatorQuad/6/62/40.avif?api=${ctx.apiKey}`);
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('content-type'), 'image/avif');
+    assertCors(res);
+  });
+
+  it('should serve a jpg tile', async () => {
+    const res = await ctx.req(`/v1/tiles/aerial/WebMercatorQuad/6/62/40.jpg?api=${ctx.apiKey}`);
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('content-type'), 'image/jpeg');
+    assertCors(res);
+  });
 
   it('should serve a preview', async () => {
     const res = await ctx.req(`/v1/preview/aerial/WebMercatorQuad/7.25/175.4665236/-41.1619890`);

--- a/packages/smoke/src/tile.test.ts
+++ b/packages/smoke/src/tile.test.ts
@@ -1,27 +1,52 @@
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { ctx } from './base.js';
+import { assertCors, ctx } from './base.js';
 
 describe('tile', () => {
-  it('should serve a NZTM2000Quad', async () => {
-    const res = await ctx.req(`/v1/tiles/aerial/NZTM2000Quad/16/33757/30417.webp?api=${ctx.apiKey}`);
+  it('should serve a NZTM2000Quad with CORS', async () => {
+    const res = await ctx.req(`/v1/tiles/aerial/NZTM2000Quad/16/33757/30417.webp?api=${ctx.apiKey}`, {
+      headers: ctx.Cors,
+    });
     assert.equal(res.status, 200, res.statusText);
+    assertCors(res);
     const body = Buffer.from(await res.arrayBuffer());
     assert.equal(body.subarray(0, 4).toString(), 'RIFF');
+  });
+
+  it('should support OPTIONS CORS preflight on tile endpoint', async () => {
+    const res = await ctx.req(`/v1/tiles/aerial/NZTM2000Quad/16/33757/30417.webp?api=${ctx.apiKey}`, {
+      method: 'OPTIONS',
+      headers: ctx.Cors,
+    });
+    assert.equal(res.status, 200, res.statusText);
+    assertCors(res);
   });
 
   it('should serve a tile as WebMercatorQuad', async () => {
     const res = await ctx.req(`/v1/tiles/aerial/WebMercatorQuad/17/129506/80410.webp?api=${ctx.apiKey}`);
     assert.equal(res.status, 200, res.statusText);
+    assertCors(res);
 
     const body = Buffer.from(await res.arrayBuffer());
     assert.equal(body.subarray(0, 4).toString(), 'RIFF');
   });
 
-  it('should serve a vector tile', async () => {
-    const res = await ctx.req(`/v1/tiles/topographic/WebMercatorQuad/15/32267/19905.pbf?api=${ctx.apiKey}`);
+  it('should serve a vector tile with CORS', async () => {
+    const res = await ctx.req(`/v1/tiles/topographic/WebMercatorQuad/15/32267/19905.pbf?api=${ctx.apiKey}`, {
+      headers: ctx.Cors,
+    });
     assert.equal(res.status, 200, res.statusText);
+    assertCors(res);
+  });
+
+  it('should support OPTIONS CORS preflight on vector tile endpoint', async () => {
+    const res = await ctx.req(`/v1/tiles/topographic/WebMercatorQuad/15/32267/19905.pbf?api=${ctx.apiKey}`, {
+      method: 'OPTIONS',
+      headers: ctx.Cors,
+    });
+    assert.equal(res.status, 200, res.statusText);
+    assertCors(res);
   });
 
   for (const ext of ['png', 'jpeg', 'avif', 'jpg']) {
@@ -29,6 +54,7 @@ describe('tile', () => {
       const res = await ctx.req(`/v1/tiles/aerial/WebMercatorQuad/6/62/40.${ext}?api=${ctx.apiKey}`);
       assert.equal(res.status, 200);
       assert.equal(res.headers.get('content-type'), `image/${ext === 'jpg' ? 'jpeg' : ext}`);
+      assertCors(res);
     });
   }
 


### PR DESCRIPTION
### Motivation

When changing the cloudfront distrubution logic, we do not have many unit tests about how it is configured.


### Modifications

Add smoke tests for caching behaviour and Cross origin requsets

### Verification

Manually run against dev (new cloudfront) and prod (old cloudfront)