### PR TITLE
fix: include webacl id if the cloudfront is on a pay monthly plan

### DIFF
--- a/packages/_infra/src/edge/index.ts
+++ b/packages/_infra/src/edge/index.ts
@@ -107,7 +107,7 @@ export class EdgeStack extends cdk.Stack {
         cachePolicy: cf.CachePolicy.CACHING_OPTIMIZED,
       },
       additionalBehaviors,
-      webAclId: webAclId === '' ? undefined : webAclId,
+      webAclId: webAclId.startsWith('arn:') ? webAclId : undefined,
     });
 
     // Override logical ID to match deprecated CloudFrontWebDistribution logical ID to update in-place without destroying old distribution

--- a/packages/_infra/src/edge/index.ts
+++ b/packages/_infra/src/edge/index.ts
@@ -90,8 +90,7 @@ export class EdgeStack extends cdk.Stack {
     }
 
     // This value needs to be manually set after the first deployment into a business Cloudfront plan
-    const webAclIdSsm = StringParameter.valueFromLookup(this, '/linz/basemaps/cloudfront-webacl-id');
-    const webAclId = webAclIdSsm.includes('-') ? webAclIdSsm : undefined;
+    const webAclId = StringParameter.valueFromLookup(this, '/linz/basemaps/cloudfront-webacl-arn', '');
 
     this.distribution = new cf.Distribution(this, 'Distribution', {
       domainNames: config.CloudFrontDns,
@@ -108,7 +107,7 @@ export class EdgeStack extends cdk.Stack {
         cachePolicy: cf.CachePolicy.CACHING_OPTIMIZED,
       },
       additionalBehaviors,
-      webAclId,
+      webAclId: webAclId === '' ? undefined : webAclId,
     });
 
     // Override logical ID to match deprecated CloudFrontWebDistribution logical ID to update in-place without destroying old distribution

--- a/packages/_infra/src/edge/index.ts
+++ b/packages/_infra/src/edge/index.ts
@@ -3,11 +3,11 @@ import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
 import cf from 'aws-cdk-lib/aws-cloudfront';
 import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
 import s3, { Bucket, HttpMethods } from 'aws-cdk-lib/aws-s3';
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { Construct } from 'constructs';
 
 import { getConfig } from '../config.js';
 import { ParametersEdgeKeys } from '../parameters.js';
-import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 
 export interface EdgeStackProps extends cdk.StackProps {
   /** ACM certificate to use for cloudfront */

--- a/packages/_infra/src/edge/index.ts
+++ b/packages/_infra/src/edge/index.ts
@@ -105,6 +105,7 @@ export class EdgeStack extends cdk.Stack {
         allowedMethods: cf.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
         originRequestPolicy: cf.OriginRequestPolicy.CORS_S3_ORIGIN,
         cachePolicy: cf.CachePolicy.CACHING_OPTIMIZED,
+        responseHeadersPolicy: cf.ResponseHeadersPolicy.CORS_ALLOW_ALL_ORIGINS_WITH_PREFLIGHT,
       },
       additionalBehaviors,
       webAclId: webAclId.startsWith('arn:') ? webAclId : undefined,

--- a/packages/_infra/src/edge/index.ts
+++ b/packages/_infra/src/edge/index.ts
@@ -7,6 +7,7 @@ import { Construct } from 'constructs';
 
 import { getConfig } from '../config.js';
 import { ParametersEdgeKeys } from '../parameters.js';
+import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 
 export interface EdgeStackProps extends cdk.StackProps {
   /** ACM certificate to use for cloudfront */
@@ -88,6 +89,10 @@ export class EdgeStack extends cdk.Stack {
       };
     }
 
+    // This value needs to be manually set after the first deployment into a business Cloudfront plan
+    const webAclIdSsm = StringParameter.valueFromLookup(this, '/linz/basemaps/cloudfront-webacl-id');
+    const webAclId = webAclIdSsm.includes('-') ? webAclIdSsm : undefined;
+
     this.distribution = new cf.Distribution(this, 'Distribution', {
       domainNames: config.CloudFrontDns,
       certificate: acmCert,
@@ -103,6 +108,7 @@ export class EdgeStack extends cdk.Stack {
         cachePolicy: cf.CachePolicy.CACHING_OPTIMIZED,
       },
       additionalBehaviors,
+      webAclId,
     });
 
     // Override logical ID to match deprecated CloudFrontWebDistribution logical ID to update in-place without destroying old distribution


### PR DESCRIPTION
### Motivation

Redeploying dev is currently failing as it is missing the webacl id for the pay monthly cloudfront plan.

### Modifications

Force the web acl id to be set using a custom string parameter as it was created by the pay monthly plan its not currently stored anywhere in cloudfront

### Verification

Manual redeployment.
