### PR TITLE
docs: fix broken GDAL link in cli-raster README

### DIFF
--- a/packages/cli-raster/README.md
+++ b/packages/cli-raster/README.md
@@ -23,7 +23,7 @@ To convert imagery to optimized COG, a output tile cover is created, this covers
 cogify cover --tile-matrix WebMercatorQuad s3://linz-imagery/.../porirua_2020_0.1m --target ./output
 ```
 
-The metadata for the optimized COGS is written into the output folder where the COG creation step can use [GDAL](https://github.com/gdal/gdal) to create the output tiff.
+The metadata for the optimized COGS is written into the output folder where the COG creation step can use [GDAL](https://github.com/OSGeo/gdal) to create the output tiff.
 
 ```
 cogify create ./output/WebMercatorQuad/porirua_2020_0.1m/01GY8W69EJEMAKKXNHYMRF7DCY/14-16150-10245.json


### PR DESCRIPTION
### Motivation

The GDAL link in `packages/cli-raster/README.md` points to `https://github.com/gdal/gdal`, which does not exist (404).

GDAL's real GitHub home is the OSGeo org: `https://github.com/OSGeo/gdal`.

A reader following the doc link to learn more about GDAL hits a dead end.

### Modifications

- `packages/cli-raster/README.md`: fixed the `[GDAL]` link to point to `https://github.com/OSGeo/gdal` instead of the non-existent `https://github.com/gdal/gdal`.

### Verification

- Confirmed the old link 404s: `curl -o /dev/null -w '%{http_code}' https://github.com/gdal/gdal` → `404`.
- Confirmed the new link resolves: `curl -o /dev/null -w '%{http_code}' https://github.com/OSGeo/gdal` → `200`.
- One-line docs-only change, no code affected. `packages/cli-raster` has no separate lint/build step for its README; the repo-wide `build` CI job (typecheck/lint/test via `linz/action-typescript@v3`) covers this PR.