### PR TITLE
chore: move release-please to use LINZ_GITHUB_AUTOMATION token BM-1862

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.LI_GITHUB_ACTION_TOKEN }}
+          token: ${{ secrets.LINZ_GITHUB_AUTOMATION }}
 
   publish-release:
     permissions:


### PR DESCRIPTION
### Motivation & Modifications

Change `release-please` token from `LI_GITHUB_ACTION_TOKEN` to `LINZ_GITHUB_AUTOMATION` to meet security requirements. 