### PR TITLE
feat: allow direct access to s3 source imagery BM-1877

### DIFF
--- a/packages/_infra/src/edge/index.ts
+++ b/packages/_infra/src/edge/index.ts
@@ -18,6 +18,12 @@ export interface EdgeStackProps extends cdk.StackProps {
   lambdaUrl?: string;
 }
 
+const commonBehaviours = {
+  viewerProtocolPolicy: cf.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+  allowedMethods: cf.AllowedMethods.ALLOW_ALL,
+  originRequestPolicy: cf.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+} as const;
+
 /**
  * Edge infrastructure
  *
@@ -52,6 +58,12 @@ export class EdgeStack extends cdk.Stack {
 
     const additionalBehaviors: Record<string, cf.BehaviorOptions> = {};
 
+    const sourceBucket = s3.Bucket.fromBucketName(this, 'SourceBucket', 'linz-basemaps');
+    const sourceBucketOac = origins.S3BucketOrigin.withOriginAccessControl(sourceBucket);
+    additionalBehaviors['/2193'] = { ...commonBehaviours, origin: sourceBucketOac };
+    additionalBehaviors['/3857'] = { ...commonBehaviours, origin: sourceBucketOac };
+    additionalBehaviors['/vector'] = { ...commonBehaviours, origin: sourceBucketOac };
+
     if (props.lambdaUrl) {
       const trimmedUrl = new URL(props.lambdaUrl); // LambdaURLS include https:// and a trailing /
       const lambdaOrigin = new origins.HttpOrigin(trimmedUrl.hostname, {
@@ -75,18 +87,14 @@ export class EdgeStack extends cdk.Stack {
 
       additionalBehaviors['/v1*'] = {
         origin: lambdaOrigin,
-        viewerProtocolPolicy: cf.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-        allowedMethods: cf.AllowedMethods.ALLOW_ALL,
         cachePolicy: v1CachePolicy,
-        originRequestPolicy: cf.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+        ...commonBehaviours,
       };
 
       additionalBehaviors['/@*'] = {
         origin: lambdaOrigin,
-        viewerProtocolPolicy: cf.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-        allowedMethods: cf.AllowedMethods.ALLOW_ALL,
         cachePolicy: atCachePolicy,
-        originRequestPolicy: cf.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+        ...commonBehaviours,
       };
     }
 


### PR DESCRIPTION
### Motivation

A number of users have asked for access to the raw COGs for the basemaps imagery, since we now have a surplass of data egress, we can provide free access via cloudfront.

### Modifications

Add a undocumented feature to grant access to the imagery

### Verification

<!-- TODO: Say how you tested your changes. -->
